### PR TITLE
Routing bugs!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.7 - 2026-05-04
+
+- Updated Google sign-in to reuse an existing seeded user when the Google account email already exists in the database.
+- Preserved seeded admin access by attaching the real Google UID to the existing user record instead of creating a duplicate account.
+- Added regression test coverage for same-email and case-insensitive Google sign-in reuse.
+
 ## v1.0.6 - 2026-05-04
 
 - Simplified demo seed data so the database now creates the real Northwestern admin account instead of additional Google users you cannot sign into locally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.5 - 2026-05-04
+
+- Fixed the manual add-item back button so it consistently returns users to the closet page.
+- Restricted users-directory navigation to admin users by adding an admin-only `Users` header button and removing non-admin UI paths into `/users`.
+- Preserved the existing route-level authorization while making the UI navigation match the intended access rules more closely.
+
 ## v1.0.4 - 2026-05-04
 
 - Merged the tag-based closet search and relaxed item schema work with the new outfits and lookbook experience from `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.6 - 2026-05-04
+
+- Simplified demo seed data so the database now creates the real Northwestern admin account instead of additional Google users you cannot sign into locally.
+- Seeded `annabelgoldman2025@u.northwestern.edu` with admin access and a 20-item demo closet.
+- Removed extra seeded demo users so the development data better matches the team’s actual login flow.
+
 ## v1.0.5 - 2026-05-04
 
 - Fixed the manual add-item back button so it consistently returns users to the closet page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.2 - 2026-05-03
+
+- Fixed deployed routing so browser visits to `/users` and `/users/:id` render the frontend app instead of raw JSON responses.
+- Preserved JSON authorization behavior for API requests while restoring correct SPA fallback behavior for HTML requests.
+
 ## v1.0.1 - 2026-05-03
 
 - Refined unauthorized user flows for admin-only pages and protected routes.

--- a/back-end/app/controllers/fallback_controller.rb
+++ b/back-end/app/controllers/fallback_controller.rb
@@ -1,5 +1,32 @@
 class FallbackController < ActionController::Base
   def index
-    render file: Rails.root.join("public/index.html")
+    render file: resolved_index_path, layout: false
+  rescue ArgumentError
+    render html: fallback_html, layout: false
+  end
+
+  private
+
+  def resolved_index_path
+    [
+      Rails.root.join("public/index.html"),
+      Rails.root.parent.join("front-end/dist/index.html")
+    ].find { |path| path.exist? } || Rails.root.join("public/index.html")
+  end
+
+  def fallback_html
+    <<~HTML.html_safe
+      <!doctype html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width,initial-scale=1">
+          <title>Closet Organizer</title>
+        </head>
+        <body>
+          <div id="root"></div>
+        </body>
+      </html>
+    HTML
   end
 end

--- a/back-end/app/models/user.rb
+++ b/back-end/app/models/user.rb
@@ -10,10 +10,12 @@ class User < ApplicationRecord
   validates :uid, presence: true, uniqueness: { scope: :provider }
 
   def self.from_google_auth(auth_hash)
-    user = find_or_initialize_by(provider: auth_hash.provider, uid: auth_hash.uid)
+    user = find_for_google_auth(auth_hash)
     preferred_username = auth_hash.info.name.presence || auth_hash.info.email.presence || "User"
 
     user.assign_attributes(
+      provider: auth_hash.provider,
+      uid: auth_hash.uid,
       email: auth_hash.info.email,
       username: resolved_google_username(user, preferred_username),
       avatar_url: auth_hash.info.image
@@ -22,6 +24,12 @@ class User < ApplicationRecord
     user.password = SecureRandom.hex(24) if user.new_record?
     user.save!
     user
+  end
+
+  def self.find_for_google_auth(auth_hash)
+    find_by(provider: auth_hash.provider, uid: auth_hash.uid) ||
+      find_by_normalized_email(auth_hash.info.email) ||
+      new
   end
 
   def self.resolved_google_username(user, preferred_username)
@@ -38,10 +46,16 @@ class User < ApplicationRecord
     end
   end
 
+  def self.find_by_normalized_email(email)
+    return if email.blank?
+
+    where("lower(email) = ?", email.to_s.downcase).first
+  end
+
   def self.username_taken?(username, except_id: nil)
     scope = where(username: username)
     scope = scope.where.not(id: except_id) if except_id.present?
     scope.exists?
   end
-  private_class_method :resolved_google_username, :username_taken?
+  private_class_method :find_for_google_auth, :find_by_normalized_email, :resolved_google_username, :username_taken?
 end

--- a/back-end/config/routes.rb
+++ b/back-end/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
   match "/auth/:provider/callback", to: "sessions#create", via: %i[ get post ]
   get "/auth/failure", to: "sessions#failure"
 
+  get "users", to: "fallback#index", constraints: ->(req) { !req.xhr? && req.format.html? }
+  get "users/:id", to: "fallback#index", constraints: ->(req) { !req.xhr? && req.format.html? }
+
   scope defaults: { format: :json } do
     root "clothing_items#index"
     get "me", to: "sessions#me"

--- a/back-end/db/seeds.rb
+++ b/back-end/db/seeds.rb
@@ -61,60 +61,14 @@ SIZE_PROFILES = {
 
 seed_users = [
   {
-    username: "alexis_ward",
-    email: "alexis.ward@example.com",
-    provider: "google_oauth2",
-    uid: "seed-alexis-ward",
-    password: "password",
-    preferred_style: "smart_casual",
-    size_profile: :standard,
-    item_count: 20
-  },
-  {
     username: "annabel_goldman",
-    email: "annabel.goldman@example.com",
+    email: "annabelgoldman2025@u.northwestern.edu",
     provider: "google_oauth2",
     uid: "seed-annabel-goldman",
     password: "password",
     admin: true,
     preferred_style: "polished",
-    item_count: 0
-  },
-  {
-    username: "jordan_lee",
-    email: "jordan.lee@example.com",
-    provider: "google_oauth2",
-    uid: "seed-jordan-lee",
-    password: "password",
-    preferred_style: "athleisure",
-    items: [
-      { name: "Heather Gray Running Hoodie", size: :large, date: Date.new(2026, 2, 2), tags: [ "nike", "performance fleece", "gray", "active", "hoodie" ] },
-      { name: "Black Training Joggers", size: :large, date: Date.new(2026, 1, 24), tags: [ "lululemon", "recycled polyester", "black", "active", "joggers" ] },
-      { name: "Forest Performance Tee", size: :medium, date: Date.new(2026, 3, 22), tags: [ "under armour", "moisture wicking", "green", "gym", "tee" ] },
-      { name: "Navy Quarter-Zip Pullover", size: :large, date: Date.new(2025, 11, 3), tags: [ "vuori", "polyester", "navy", "layering", "athleisure" ] },
-      { name: "Stone Utility Shorts", size: :medium, date: Date.new(2025, 8, 19), tags: [ "ten thousand", "nylon", "stone", "summer", "training" ] },
-      { name: "Trail Running Vest", size: :medium, date: Date.new(2025, 10, 7), tags: [ "patagonia", "ripstop", "black", "outdoors", "running" ] },
-      { name: "White Court Sneakers", size: :large, date: Date.new(2025, 7, 14), tags: [ "adidas", "leather", "white", "sport", "sneakers" ] },
-      { name: "Slate Rain Shell Jacket", size: :large, date: Date.new(2026, 4, 12), tags: [ "arcteryx", "nylon", "slate", "outerwear", "rainy day" ] }
-    ]
-  },
-  {
-    username: "maya_patel",
-    email: "maya.patel@example.com",
-    provider: "google_oauth2",
-    uid: "seed-maya-patel",
-    password: "password",
-    preferred_style: "minimal",
-    items: [
-      { name: "Oat Linen Blazer", size: :small, date: Date.new(2026, 3, 18), tags: [ "mango", "linen", "oat", "blazer", "capsule" ] },
-      { name: "Black Rib Tank", size: :xs, date: Date.new(2026, 4, 4), tags: [ "uniqlo", "cotton", "black", "minimal", "tank" ] },
-      { name: "Cream Slip Skirt", size: :small, date: Date.new(2025, 6, 9), tags: [ "zara", "satin", "cream", "dressy", "soft" ] },
-      { name: "Charcoal Merino Sweater", size: :small, date: Date.new(2025, 12, 11), tags: [ "cos", "merino wool", "charcoal", "cozy", "sweater" ] },
-      { name: "Brown Ankle Boots", size: :small, date: Date.new(2025, 10, 1), tags: [ "steve madden", "suede", "brown", "boots", "classic" ] },
-      { name: "Light Wash Denim Jacket", size: :medium, date: Date.new(2025, 9, 21), tags: [ "levis", "denim", "light blue", "layering", "weekend" ] },
-      { name: "Soft White T-Shirt", size: :small, date: Date.new(2026, 2, 27), tags: [ "everlane", "cotton", "white", "basics", "everyday" ] },
-      { name: "Sand Pleated Trousers", size: :small, date: Date.new(2025, 11, 29), tags: [ "aritzia", "twill", "sand", "tailored", "office" ] }
-    ]
+    item_count: 20
   }
 ]
 

--- a/back-end/test/integration/users_flow_test.rb
+++ b/back-end/test/integration/users_flow_test.rb
@@ -13,6 +13,13 @@ class UsersFlowTest < ActionDispatch::IntegrationTest
     assert_equal [ @user.username, @admin.username ].sort, response_json.map { |user| user["username"] }
   end
 
+  test "browser html request for users index falls back to the frontend app" do
+    get "/users"
+
+    assert_response :success
+    assert_includes response.body, "<div id=\"root\"></div>"
+  end
+
   test "non-admin cannot load users index" do
     get users_url, headers: auth_headers(@user), as: :json
 
@@ -25,6 +32,13 @@ class UsersFlowTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal @user.username, response_json["username"]
+  end
+
+  test "browser html request for user show falls back to the frontend app" do
+    get "/users/#{@user.id}"
+
+    assert_response :success
+    assert_includes response.body, "<div id=\"root\"></div>"
   end
 
   test "non-admin cannot load user show" do

--- a/back-end/test/models/user_test.rb
+++ b/back-end/test/models/user_test.rb
@@ -59,4 +59,58 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "alex", user.username
     assert_equal "updated-alex@example.com", user.email
   end
+
+  test "google auth reuses an existing user with the same email" do
+    seeded_user = User.create!(
+      username: "annabel_goldman",
+      email: "annabelgoldman2025@u.northwestern.edu",
+      provider: "google_oauth2",
+      uid: "seed-annabel-goldman",
+      admin: true,
+      password: "password123"
+    )
+
+    auth_hash = OpenStruct.new(
+      provider: "google_oauth2",
+      uid: "real-google-uid-123",
+      info: OpenStruct.new(
+        email: "annabelgoldman2025@u.northwestern.edu",
+        name: "Annabel Goldman",
+        image: "https://example.com/annabel.png"
+      )
+    )
+
+    user = User.from_google_auth(auth_hash)
+
+    assert_equal seeded_user.id, user.id
+    assert_equal "annabel_goldman", user.username
+    assert_equal "real-google-uid-123", user.uid
+    assert user.admin?
+  end
+
+  test "google auth reuses an existing user with the same email regardless of case" do
+    seeded_user = User.create!(
+      username: "annabel_goldman_case",
+      email: "annabelgoldman2025@u.northwestern.edu",
+      provider: "google_oauth2",
+      uid: "seed-annabel-goldman-case",
+      admin: true,
+      password: "password123"
+    )
+
+    auth_hash = OpenStruct.new(
+      provider: "google_oauth2",
+      uid: "real-google-uid-456",
+      info: OpenStruct.new(
+        email: "ANNABELGOLDMAN2025@u.northwestern.edu",
+        name: "Annabel Goldman",
+        image: "https://example.com/annabel.png"
+      )
+    )
+
+    user = User.from_google_auth(auth_hash)
+
+    assert_equal seeded_user.id, user.id
+    assert_equal "real-google-uid-456", user.uid
+  end
 end

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -79,6 +79,10 @@ function isOutfitRoute(route: AppRoute) {
   return route.kind === "outfits";
 }
 
+function isUsersRoute(route: AppRoute) {
+  return route.kind === "users" || route.kind === "user";
+}
+
 function isProtectedRoute(route: AppRoute) {
   return route.kind !== "home";
 }
@@ -477,19 +481,7 @@ export default function App() {
         userId={targetUserId}
         initialMode={route.mode}
         initialUser={targetUser}
-        onBack={() => {
-          if (route.mode === "image") {
-            navigateTo("/closet");
-            return;
-          }
-
-          if (route.userId) {
-            navigateTo(`/users/${route.userId}`);
-            return;
-          }
-
-          navigateTo("/closet");
-        }}
+        onBack={() => navigateTo("/closet")}
         onItemsCreated={(nextItems) => {
           setUser((current) => {
             if (!current || current.id !== targetUserId || nextItems.length === 0) {
@@ -756,6 +748,19 @@ export default function App() {
                 >
                   My Outfits
                 </button>
+                {user.admin ? (
+                  <button
+                    onClick={() => navigateTo("/users")}
+                    className={`inline-flex items-center justify-center border px-4 py-2.5 text-sm transition-colors ${
+                      isUsersRoute(route)
+                        ? "border-foreground bg-foreground text-background"
+                        : "border-border text-foreground hover:border-foreground"
+                    }`}
+                    style={{ fontFamily: "Outfit, sans-serif" }}
+                  >
+                    Users
+                  </button>
+                ) : null}
               </nav>
             ) : null}
             {globalAction}


### PR DESCRIPTION
## Summary

This PR fixes the deployed `/users` routing issue and also polishes the related admin-only navigation and demo seed data so the users area behaves more consistently across environments.

### User-facing changes
- fixes deployed behavior for direct browser visits to `/users` and `/users/:id`
- restores the expected frontend unauthorized UI instead of showing raw JSON like `{"error":"You're not authorized to view this page."}`
- keeps local and deployed 403/route-fallback behavior consistent
- updates admin-only navigation so only admin users see a `Users` button in the header
- removes non-admin UI paths into the users directory
- fixes the manual add-item back button so it returns to the closet page
- simplifies demo seed data so the primary seeded account is `annabelgoldman2025@u.northwestern.edu` with admin access and a seeded closet

### Internal changes
- adds explicit HTML fallback routing for `/users` and `/users/:id`
- preserves JSON authorization behavior for API requests
- makes the fallback controller more resilient when the built SPA file is not present in local/test contexts
- adds integration coverage for browser HTML requests to users routes
- updates changelog/tag bookkeeping for the patch releases on this branch
- trims seed data to remove extra demo users that are not useful for the team’s real sign-in flow

## Testing
- `bundle exec rails test`
- `bundle exec rails test test/integration/users_flow_test.rb`
- `npm run build`
- `ruby -c back-end/db/seeds.rb`

Closes #33