### PR TITLE
Add outfits CRUD, My Outfits builder, and draft/flash UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.0.2 - 2026-05-03
+
+- Added full outfits support across back-end and front-end, including outfit CRUD endpoints, user-scoped authorization, and outfit-to-item associations.
+- Introduced new data models and schema updates for outfits and outfit items, including ownership validation and uniqueness constraints.
+- Added the My Outfits experience with create/edit/delete flows and outfit item grouping from closet pieces.
+- Added persistent outfit draft behavior so selected item IDs are saved per user and restored from local storage.
+- Added and refined flash/toast notifications for outfit load/save/update/delete outcomes and draft confirmations.
+- Added automated test coverage for outfit flows and validations, including integration tests and model tests for Outfit and OutfitItem.
+
 ## v1.0.1 - 2026-05-03
 
 - Refined unauthorized user flows for admin-only pages and protected routes.

--- a/back-end/app/controllers/application_controller.rb
+++ b/back-end/app/controllers/application_controller.rb
@@ -158,6 +158,25 @@ class ApplicationController < ActionController::API
     payload
   end
 
+  def outfit_payload(outfit)
+    payload = outfit.serializable_hash(
+      only: %i[
+        id
+        user_id
+        name
+        tags
+        notes
+        created_at
+        updated_at
+      ]
+    )
+    payload["item_ids"] = outfit.clothing_items.map(&:id)
+    payload["items"] = outfit.clothing_items.order(:name).map do |item|
+      clothing_item_payload(item, include_user: false)
+    end
+    payload
+  end
+
   def test_user_id
     return unless Rails.env.test?
 

--- a/back-end/app/controllers/outfits_controller.rb
+++ b/back-end/app/controllers/outfits_controller.rb
@@ -1,0 +1,68 @@
+class OutfitsController < ApplicationController
+  before_action :require_login
+  before_action :set_outfit, only: %i[ show update destroy ]
+
+  def index
+    outfits = current_user.outfits.includes(:clothing_items).order(created_at: :desc)
+    render json: outfits.map { |outfit| outfit_payload(outfit) }
+  end
+
+  def show
+    render json: outfit_payload(@outfit)
+  end
+
+  def create
+    outfit = current_user.outfits.new(outfit_attributes)
+    assign_items(outfit)
+
+    if outfit.errors.empty? && outfit.save
+      render json: outfit_payload(outfit), status: :created
+    else
+      render_validation_errors(outfit)
+    end
+  end
+
+  def update
+    @outfit.assign_attributes(outfit_attributes)
+    assign_items(@outfit)
+
+    if @outfit.errors.empty? && @outfit.save
+      render json: outfit_payload(@outfit)
+    else
+      render_validation_errors(@outfit)
+    end
+  end
+
+  def destroy
+    @outfit.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_outfit
+    @outfit = current_user.outfits.includes(:clothing_items).find(params[:id])
+  end
+
+  def outfit_params
+    params.require(:outfit).permit(:name, :notes, tags: [], item_ids: [])
+  end
+
+  def outfit_attributes
+    outfit_params.slice(:name, :notes, :tags)
+  end
+
+  def assign_items(outfit)
+    return unless outfit_params.key?(:item_ids)
+
+    item_ids = Array(outfit_params[:item_ids]).reject(&:blank?).map(&:to_i).uniq
+    items = current_user.clothing_items.where(id: item_ids)
+
+    if items.size != item_ids.size
+      outfit.errors.add(:item_ids, "contain items you do not own")
+      return
+    end
+
+    outfit.clothing_items = items
+  end
+end

--- a/back-end/app/models/clothing_item.rb
+++ b/back-end/app/models/clothing_item.rb
@@ -1,5 +1,7 @@
 class ClothingItem < ApplicationRecord
   belongs_to :user
+  has_many :outfit_items, dependent: :destroy
+  has_many :outfits, through: :outfit_items
   has_one_attached :photo
   has_one_attached :cleaned_photo
 

--- a/back-end/app/models/outfit.rb
+++ b/back-end/app/models/outfit.rb
@@ -1,0 +1,16 @@
+class Outfit < ApplicationRecord
+  belongs_to :user
+  has_many :outfit_items, dependent: :destroy
+  has_many :clothing_items, through: :outfit_items
+
+  validates :name, presence: true
+  validate :tags_must_be_an_array
+
+  private
+
+  def tags_must_be_an_array
+    return if tags.nil? || tags.is_a?(Array)
+
+    errors.add(:tags, "must be an array")
+  end
+end

--- a/back-end/app/models/outfit_item.rb
+++ b/back-end/app/models/outfit_item.rb
@@ -1,0 +1,16 @@
+class OutfitItem < ApplicationRecord
+  belongs_to :outfit
+  belongs_to :clothing_item
+
+  validates :clothing_item_id, uniqueness: { scope: :outfit_id }
+  validate :clothing_item_must_belong_to_outfit_user
+
+  private
+
+  def clothing_item_must_belong_to_outfit_user
+    return unless outfit && clothing_item
+    return if outfit.user_id == clothing_item.user_id
+
+    errors.add(:clothing_item_id, "must belong to the same user as the outfit")
+  end
+end

--- a/back-end/app/models/user.rb
+++ b/back-end/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_secure_password
 
   has_many :clothing_items, dependent: :destroy
+  has_many :outfits, dependent: :destroy
   has_many :outfit_uploads, dependent: :destroy
 
   validates :username, presence: true, uniqueness: true

--- a/back-end/config/routes.rb
+++ b/back-end/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     resources :clothing_items, except: %i[new edit] do
       post :generate_clean_image, on: :member
     end
+    resources :outfits, except: %i[new edit]
     resources :outfit_uploads, only: %i[create show]
     resources :outfit_detections, only: [] do
       post :generate_clean_image, on: :member

--- a/back-end/db/migrate/20260504022000_create_outfits.rb
+++ b/back-end/db/migrate/20260504022000_create_outfits.rb
@@ -1,0 +1,12 @@
+class CreateOutfits < ActiveRecord::Migration[8.1]
+  def change
+    create_table :outfits do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+      t.json :tags
+      t.text :notes
+
+      t.timestamps
+    end
+  end
+end

--- a/back-end/db/migrate/20260504022100_create_outfit_items.rb
+++ b/back-end/db/migrate/20260504022100_create_outfit_items.rb
@@ -1,0 +1,12 @@
+class CreateOutfitItems < ActiveRecord::Migration[8.1]
+  def change
+    create_table :outfit_items do |t|
+      t.references :outfit, null: false, foreign_key: true
+      t.references :clothing_item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :outfit_items, %i[outfit_id clothing_item_id], unique: true
+  end
+end

--- a/back-end/db/schema.rb
+++ b/back-end/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_011000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_022100) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -93,6 +93,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_011000) do
     t.index ["outfit_upload_id"], name: "index_outfit_detections_on_outfit_upload_id"
   end
 
+  create_table "outfit_items", force: :cascade do |t|
+    t.integer "clothing_item_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "outfit_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["clothing_item_id"], name: "index_outfit_items_on_clothing_item_id"
+    t.index ["outfit_id", "clothing_item_id"], name: "index_outfit_items_on_outfit_id_and_clothing_item_id", unique: true
+    t.index ["outfit_id"], name: "index_outfit_items_on_outfit_id"
+  end
+
   create_table "outfit_uploads", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "detected_at"
@@ -104,6 +114,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_011000) do
     t.integer "user_id", null: false
     t.string "vision_model"
     t.index ["user_id"], name: "index_outfit_uploads_on_user_id"
+  end
+
+  create_table "outfits", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.text "notes"
+    t.json "tags"
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_outfits_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -125,5 +145,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_011000) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "clothing_items", "users"
   add_foreign_key "outfit_detections", "outfit_uploads"
+  add_foreign_key "outfit_items", "clothing_items"
+  add_foreign_key "outfit_items", "outfits"
   add_foreign_key "outfit_uploads", "users"
+  add_foreign_key "outfits", "users"
 end

--- a/back-end/test/fixtures/outfit_items.yml
+++ b/back-end/test/fixtures/outfit_items.yml
@@ -1,0 +1,7 @@
+one:
+  outfit: one
+  clothing_item: one
+
+two:
+  outfit: two
+  clothing_item: two

--- a/back-end/test/fixtures/outfits.yml
+++ b/back-end/test/fixtures/outfits.yml
@@ -1,0 +1,14 @@
+one:
+  user: one
+  name: Weekend Capsule
+  tags:
+    - casual
+    - spring
+  notes: Light layers for weekend errands.
+
+two:
+  user: two
+  name: Work Rotation
+  tags:
+    - office
+  notes: Smart-casual office options.

--- a/back-end/test/integration/outfits_flow_test.rb
+++ b/back-end/test/integration/outfits_flow_test.rb
@@ -1,0 +1,86 @@
+require "test_helper"
+
+class OutfitsFlowTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @other_user = users(:two)
+    @outfit = outfits(:one)
+    @user_item = clothing_items(:one)
+    @other_user_item = clothing_items(:two)
+  end
+
+  test "outfits index only returns current user outfits" do
+    get outfits_url, headers: auth_headers(@user), as: :json
+
+    assert_response :success
+    assert_equal [ @outfit.id ], response_json.map { |outfit| outfit["id"] }
+    assert_equal [ @user_item.id ], response_json.first["item_ids"]
+  end
+
+  test "outfit show loads for current user" do
+    get outfit_url(@outfit), headers: auth_headers(@user), as: :json
+
+    assert_response :success
+    assert_equal @outfit.name, response_json["name"]
+    assert_equal @user_item.id, response_json["items"].first["id"]
+  end
+
+  test "can create an outfit with owned items" do
+    assert_difference("Outfit.count", 1) do
+      post outfits_url, params: {
+        outfit: {
+          name: "Rainy Day Fit",
+          tags: [ "rain", "casual" ],
+          notes: "Layers and waterproof shoes.",
+          item_ids: [ @user_item.id ]
+        }
+      }, headers: auth_headers(@user), as: :json
+    end
+
+    assert_response :created
+
+    created_outfit = Outfit.order(:created_at).last
+    assert_equal @user.id, created_outfit.user_id
+    assert_equal [ @user_item.id ], created_outfit.clothing_item_ids
+    assert_equal [ "rain", "casual" ], response_json["tags"]
+  end
+
+  test "cannot create an outfit using another user's item" do
+    assert_no_difference("Outfit.count") do
+      post outfits_url, params: {
+        outfit: {
+          name: "Forbidden Fit",
+          item_ids: [ @other_user_item.id ]
+        }
+      }, headers: auth_headers(@user), as: :json
+    end
+
+    assert_response :unprocessable_content
+    assert_includes response_json["errors"], "Item ids contain items you do not own"
+  end
+
+  test "can update an outfit and replace item list" do
+    patch outfit_url(@outfit), params: {
+      outfit: {
+        name: "Weekend Capsule Updated",
+        notes: "Updated note",
+        item_ids: []
+      }
+    }, headers: auth_headers(@user), as: :json
+
+    assert_response :success
+
+    @outfit.reload
+    assert_equal "Weekend Capsule Updated", @outfit.name
+    assert_equal "Updated note", @outfit.notes
+    assert_empty @outfit.clothing_item_ids
+  end
+
+  test "can delete an outfit" do
+    assert_difference("Outfit.count", -1) do
+      delete outfit_url(@outfit), headers: auth_headers(@user), as: :json
+    end
+
+    assert_response :no_content
+  end
+end

--- a/back-end/test/models/outfit_item_test.rb
+++ b/back-end/test/models/outfit_item_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class OutfitItemTest < ActiveSupport::TestCase
+  test "fixture outfit item is valid" do
+    assert outfit_items(:one).valid?
+  end
+
+  test "clothing item is unique per outfit" do
+    duplicate = OutfitItem.new(outfit: outfits(:one), clothing_item: clothing_items(:one))
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:clothing_item_id], "has already been taken"
+  end
+
+  test "clothing item must belong to the same user as outfit" do
+    invalid = OutfitItem.new(outfit: outfits(:one), clothing_item: clothing_items(:two))
+
+    assert_not invalid.valid?
+    assert_includes invalid.errors[:clothing_item_id], "must belong to the same user as the outfit"
+  end
+end

--- a/back-end/test/models/outfit_test.rb
+++ b/back-end/test/models/outfit_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class OutfitTest < ActiveSupport::TestCase
+  test "fixture outfit is valid" do
+    assert outfits(:one).valid?
+  end
+
+  test "name is required" do
+    outfit = Outfit.new(user: users(:one), tags: [ "casual" ])
+
+    assert_not outfit.valid?
+    assert_includes outfit.errors[:name], "can't be blank"
+  end
+
+  test "tags must be an array when present" do
+    outfit = Outfit.new(user: users(:one), name: "Weekend", tags: { style: "casual" })
+
+    assert_not outfit.valid?
+    assert_includes outfit.errors[:tags], "must be an array"
+  end
+end

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -5,6 +5,7 @@ import { AddItemMenu } from "./components/AddItemMenu";
 import { ClothingCard } from "./components/ClothingCard";
 import { CreateItemPage } from "./components/CreateItemPage";
 import { ItemDetailPage } from "./components/ItemDetailPage";
+import { MyOutfitsPage } from "./components/MyOutfitsPage";
 import { UserDetailPage } from "./components/UserDetailPage";
 import { UsersDirectoryPage } from "./components/UsersDirectoryPage";
 import {
@@ -14,7 +15,9 @@ import {
   fetchClosetOwner,
   formatPossessive,
   formatPreferredStyle,
+  loadOutfitDraftItemIds,
   logoutSession,
+  saveOutfitDraftItemIds,
   titleize,
   User,
 } from "./lib/closet";
@@ -47,16 +50,25 @@ interface NewItemRouteState {
   mode: CreateItemMode;
 }
 
+interface OutfitsRouteState {
+  kind: "outfits";
+}
+
 type AppRoute =
   | RouteState
   | ClosetRouteState
   | ItemRouteState
   | UsersRouteState
   | UserRouteState
-  | NewItemRouteState;
+  | NewItemRouteState
+  | OutfitsRouteState;
 
 function isClosetRoute(route: AppRoute) {
   return route.kind === "closet" || route.kind === "item" || route.kind === "new-item";
+}
+
+function isOutfitRoute(route: AppRoute) {
+  return route.kind === "outfits";
 }
 
 function isProtectedRoute(route: AppRoute) {
@@ -93,6 +105,10 @@ function getRouteFromLocation(
     return { kind: "users" };
   }
 
+  if (normalizedPath === "/outfits") {
+    return { kind: "outfits" };
+  }
+
   if (userMatch) {
     return { kind: "user", userId: Number(userMatch[1]) };
   }
@@ -109,11 +125,12 @@ function getRouteFromLocation(
 }
 
 function navigateTo(pathname: string) {
-  if (window.location.pathname === pathname) {
+  const nextUrl = new URL(pathname, window.location.origin);
+  if (window.location.pathname === nextUrl.pathname && window.location.search === nextUrl.search) {
     return;
   }
 
-  window.history.pushState({}, "", pathname);
+  window.history.pushState({}, "", `${nextUrl.pathname}${nextUrl.search}`);
   window.dispatchEvent(new PopStateEvent("popstate"));
 }
 
@@ -147,6 +164,8 @@ export default function App() {
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
   const [homeMessage, setHomeMessage] = useState("");
+  const [outfitDraftItemIds, setOutfitDraftItemIds] = useState<number[]>([]);
+  const [outfitDraftNotice, setOutfitDraftNotice] = useState("");
 
   useEffect(() => {
     const handlePopState = () => setRoute(getRouteFromLocation());
@@ -196,6 +215,37 @@ export default function App() {
     return () => controller.abort();
   }, [route.kind]);
 
+  useEffect(() => {
+    if (!user) {
+      setOutfitDraftItemIds([]);
+      return;
+    }
+
+    const availableItemIds = new Set(user.clothing_items.map((item) => item.id));
+    const persisted = loadOutfitDraftItemIds(user.id).filter((itemId) => availableItemIds.has(itemId));
+    setOutfitDraftItemIds(persisted);
+  }, [user?.id, user?.clothing_items]);
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+
+    saveOutfitDraftItemIds(user.id, outfitDraftItemIds);
+  }, [outfitDraftItemIds, user]);
+
+  useEffect(() => {
+    if (!outfitDraftNotice) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setOutfitDraftNotice("");
+    }, 2400);
+
+    return () => window.clearTimeout(timeout);
+  }, [outfitDraftNotice]);
+
   const clothingItems = user?.clothing_items ?? [];
   const isLoggedOutProtectedRoute = isProtectedRoute(route) && !user;
 
@@ -205,6 +255,18 @@ export default function App() {
     route.kind === "item"
       ? clothingItems.find((item) => item.id === route.itemId) ?? null
       : null;
+
+  function addItemToOutfitDraft(itemId: number) {
+    setOutfitDraftItemIds((current) => {
+      if (current.includes(itemId)) {
+        setOutfitDraftNotice("Already in your outfit draft.");
+        return current;
+      }
+
+      setOutfitDraftNotice("Added to outfit draft.");
+      return [itemId, ...current];
+    });
+  }
 
   const isAdminRoute = route.kind === "users" || route.kind === "user";
   const isUnauthorizedAdminRoute = Boolean(user && !user.admin && isAdminRoute);
@@ -389,10 +451,21 @@ export default function App() {
         onItemSaved={(nextItem) => setUser((current) => updateUserItem(current, nextItem))}
         onItemDeleted={(itemId) => {
           setUser((current) => removeUserItem(current, itemId));
+          setOutfitDraftItemIds((current) => current.filter((id) => id !== itemId));
           navigateTo("/closet");
         }}
       />
     );
+  } else if (route.kind === "outfits") {
+    pageContent = user ? (
+      <MyOutfitsPage
+        user={user}
+        draftItemIds={outfitDraftItemIds}
+        onDraftChange={setOutfitDraftItemIds}
+        onBrowseCloset={() => navigateTo("/closet")}
+        onOpenItem={(itemId) => navigateTo(`/items/${itemId}`)}
+      />
+    ) : null;
   } else {
     pageContent = (
       <div className="max-w-7xl mx-auto px-6 py-12">
@@ -491,6 +564,7 @@ export default function App() {
                     {...item}
                     index={index}
                     onSelect={(itemId) => navigateTo(`/items/${itemId}`)}
+                    onAddToOutfit={addItemToOutfitDraft}
                   />
                 ))}
               </div>
@@ -542,6 +616,17 @@ export default function App() {
                 >
                   Closet
                 </button>
+                <button
+                  onClick={() => navigateTo("/outfits")}
+                  className={`inline-flex items-center justify-center border px-4 py-2.5 text-sm transition-colors ${
+                    isOutfitRoute(route)
+                      ? "border-foreground bg-foreground text-background"
+                      : "border-border text-foreground hover:border-foreground"
+                  }`}
+                  style={{ fontFamily: "Outfit, sans-serif" }}
+                >
+                  My Outfits
+                </button>
               </nav>
             ) : null}
             {globalAction}
@@ -550,6 +635,17 @@ export default function App() {
       </header>
 
       <main className={`flex-1 ${route.kind === "home" ? "flex" : ""}`}>{pageContent}</main>
+
+      {outfitDraftNotice ? (
+        <motion.div
+          initial={{ opacity: 0, y: 14 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="fixed bottom-6 right-6 z-50 max-w-sm border border-foreground/20 bg-background/95 px-4 py-3 text-sm shadow-lg backdrop-blur"
+          style={{ fontFamily: "Outfit, sans-serif" }}
+        >
+          {outfitDraftNotice} Draft has {outfitDraftItemIds.length} {outfitDraftItemIds.length === 1 ? "item" : "items"}.
+        </motion.div>
+      ) : null}
 
       <footer className="border-t border-border">
         <div className="mx-auto flex max-w-7xl flex-col gap-2 px-6 py-5 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">

--- a/front-end/src/app/components/ClothingCard.tsx
+++ b/front-end/src/app/components/ClothingCard.tsx
@@ -19,6 +19,7 @@ interface ClothingCardProps {
   image_url?: string | null;
   index: number;
   onSelect?: (id: number) => void;
+  onAddToOutfit?: (id: number) => void;
 }
 
 export function ClothingCard({
@@ -29,6 +30,7 @@ export function ClothingCard({
   image_url,
   index,
   onSelect,
+  onAddToOutfit,
 }: ClothingCardProps) {
   const [isHovered, setIsHovered] = useState(false);
   const itemMetadata = [tags.material, tags.season, tags.style].filter(Boolean).join(" · ");
@@ -127,6 +129,7 @@ export function ClothingCard({
           <button
             onClick={(event) => {
               event.stopPropagation();
+              onAddToOutfit?.(id);
             }}
             className="w-full bg-white/90 backdrop-blur-sm px-4 py-2 hover:bg-white transition-colors flex items-center justify-center gap-2"
           >

--- a/front-end/src/app/components/MyOutfitsPage.tsx
+++ b/front-end/src/app/components/MyOutfitsPage.tsx
@@ -1,0 +1,473 @@
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { motion } from "motion/react";
+import { Pencil, Plus, Shirt, Trash2, X } from "lucide-react";
+import {
+  buildPlaceholderLabel,
+  ClothingItem,
+  createOutfit,
+  destroyOutfit,
+  fetchOutfits,
+  Outfit,
+  titleize,
+  updateOutfit,
+  User,
+} from "../lib/closet";
+
+interface MyOutfitsPageProps {
+  user: User;
+  draftItemIds: number[];
+  onDraftChange: (itemIds: number[]) => void;
+  onBrowseCloset: () => void;
+  onOpenItem: (itemId: number) => void;
+}
+
+interface FlashState {
+  kind: "success" | "error";
+  message: string;
+}
+
+export function MyOutfitsPage({
+  user,
+  draftItemIds,
+  onDraftChange,
+  onBrowseCloset,
+  onOpenItem,
+}: MyOutfitsPageProps) {
+  const [outfits, setOutfits] = useState<Outfit[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [flash, setFlash] = useState<FlashState | null>(null);
+  const [editingOutfitId, setEditingOutfitId] = useState<number | null>(null);
+
+  const [name, setName] = useState("");
+  const [notes, setNotes] = useState("");
+  const [tagInput, setTagInput] = useState("");
+  const [selectedItemIds, setSelectedItemIds] = useState<number[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const formSectionRef = useRef<HTMLElement | null>(null);
+
+  const sortedItems = useMemo(
+    () => [...user.clothing_items].sort((left, right) => left.name.localeCompare(right.name)),
+    [user.clothing_items],
+  );
+  const selectedItems = useMemo(() => {
+    const itemById = new Map(sortedItems.map((item) => [item.id, item]));
+    return selectedItemIds
+      .map((id) => itemById.get(id))
+      .filter((item): item is ClothingItem => Boolean(item));
+  }, [selectedItemIds, sortedItems]);
+
+  function showFlash(kind: FlashState["kind"], message: string) {
+    setFlash({ kind, message });
+  }
+
+  useEffect(() => {
+    if (editingOutfitId) {
+      return;
+    }
+
+    setSelectedItemIds(draftItemIds);
+  }, [draftItemIds, editingOutfitId]);
+
+  useEffect(() => {
+    if (!flash) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setFlash(null);
+    }, 2800);
+
+    return () => window.clearTimeout(timeout);
+  }, [flash]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function loadOutfits() {
+      setIsLoading(true);
+
+      try {
+        const nextOutfits = await fetchOutfits(controller.signal);
+        setOutfits(nextOutfits);
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          showFlash("error", error instanceof Error ? error.message : "Unable to load outfits.");
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadOutfits();
+
+    return () => controller.abort();
+  }, []);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      showFlash("error", "Please add an outfit name.");
+      return;
+    }
+
+    if (selectedItemIds.length === 0) {
+      showFlash("error", "Add at least one item to build an outfit.");
+      return;
+    }
+
+    const tags = tagInput
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+
+    setIsSaving(true);
+
+    try {
+      if (editingOutfitId) {
+        const updatedOutfit = await updateOutfit({
+          id: editingOutfitId,
+          name: trimmedName,
+          itemIds: selectedItemIds,
+          notes: notes.trim() || undefined,
+          tags: tags.length > 0 ? tags : undefined,
+        });
+
+        setOutfits((current) =>
+          current.map((outfit) => (outfit.id === updatedOutfit.id ? updatedOutfit : outfit)),
+        );
+        showFlash("success", "Outfit updated.");
+      } else {
+        const createdOutfit = await createOutfit({
+          userId: user.id,
+          name: trimmedName,
+          itemIds: selectedItemIds,
+          notes: notes.trim() || undefined,
+          tags: tags.length > 0 ? tags : undefined,
+        });
+
+        setOutfits((current) => [createdOutfit, ...current]);
+        onDraftChange([]);
+        showFlash("success", "Outfit saved.");
+      }
+
+      resetForm();
+    } catch (error) {
+      showFlash("error", error instanceof Error ? error.message : "Unable to save outfit.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleDelete(outfitId: number) {
+    try {
+      await destroyOutfit(outfitId);
+      setOutfits((current) => current.filter((outfit) => outfit.id !== outfitId));
+      showFlash("success", "Outfit deleted.");
+    } catch (error) {
+      showFlash("error", error instanceof Error ? error.message : "Unable to delete outfit.");
+    }
+  }
+
+  function removeDraftItem(itemId: number) {
+    if (editingOutfitId) {
+      setSelectedItemIds((current) => current.filter((id) => id !== itemId));
+      return;
+    }
+
+    onDraftChange(selectedItemIds.filter((id) => id !== itemId));
+  }
+
+  function removeEditingItem(itemId: number) {
+    setSelectedItemIds((current) => current.filter((id) => id !== itemId));
+  }
+
+  function startEditing(outfit: Outfit) {
+    setEditingOutfitId(outfit.id);
+    setName(outfit.name);
+    setNotes(outfit.notes ?? "");
+    setTagInput(outfit.tags?.join(", ") ?? "");
+    setSelectedItemIds(outfit.item_ids ?? outfit.items.map((item) => item.id));
+    setFlash(null);
+    formSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  function resetForm() {
+    setEditingOutfitId(null);
+    setName("");
+    setNotes("");
+    setTagInput("");
+    setSelectedItemIds(draftItemIds);
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-6 py-12 space-y-10">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p
+            className="uppercase tracking-[0.3em] text-xs text-muted-foreground mb-3"
+            style={{ fontFamily: "Outfit, sans-serif" }}
+          >
+            My Outfits
+          </p>
+          <h1 className="mb-2">Lookbook Builder</h1>
+          <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            Group your closet pieces into reusable outfit combos.
+          </p>
+        </div>
+        <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+          {outfits.length} {outfits.length === 1 ? "outfit" : "outfits"} saved
+        </p>
+      </div>
+
+      <section ref={formSectionRef} className="border border-border bg-card p-6">
+        <div className="flex items-center gap-3 mb-5">
+          <Plus className="w-4 h-4" />
+          <h2>{editingOutfitId ? "Edit Outfit" : "Create Outfit"}</h2>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="space-y-2">
+              <span className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                Name
+              </span>
+              <input
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Weekend Brunch"
+                className="w-full border border-border bg-background px-3 py-2"
+              />
+            </label>
+
+            <label className="space-y-2">
+              <span className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                Tags (comma separated)
+              </span>
+              <input
+                value={tagInput}
+                onChange={(event) => setTagInput(event.target.value)}
+                placeholder="casual, spring"
+                className="w-full border border-border bg-background px-3 py-2"
+              />
+            </label>
+          </div>
+
+          <label className="space-y-2 block">
+            <span className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+              Notes
+            </span>
+            <textarea
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              placeholder="When and where to wear this look"
+              className="w-full border border-border bg-background px-3 py-2 min-h-24"
+            />
+          </label>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                Items in this outfit
+              </p>
+              <button
+                type="button"
+                onClick={onBrowseCloset}
+                className="inline-flex items-center justify-center border border-border px-3 py-1.5 text-xs transition-colors hover:border-foreground"
+                style={{ fontFamily: "Outfit, sans-serif" }}
+              >
+                Add from closet
+              </button>
+            </div>
+
+            {selectedItems.length === 0 ? (
+              <div className="border border-dashed border-border p-4 text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                Use “Add to Outfit” on any closet item, then come back here to save.
+              </div>
+            ) : (
+              <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                {selectedItems.map((item) => (
+                  <div key={item.id} className="border border-border p-2 flex items-center gap-3">
+                    <div className="h-12 w-12 shrink-0 border border-border bg-muted overflow-hidden">
+                      {item.image_url ? (
+                        <img src={item.image_url} alt={item.name} className="h-full w-full object-cover" />
+                      ) : (
+                        <div className="h-full w-full flex items-center justify-center text-xs" style={{ fontFamily: "Outfit, sans-serif" }}>
+                          {buildPlaceholderLabel(item.name)}
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate" style={{ fontFamily: "Outfit, sans-serif" }}>{item.name}</p>
+                      <p className="text-xs text-muted-foreground truncate" style={{ fontFamily: "Outfit, sans-serif" }}>
+                        {item.tags.style ? titleize(item.tags.style) : "Unstyled"}
+                      </p>
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (editingOutfitId) {
+                          removeEditingItem(item.id);
+                          return;
+                        }
+
+                        removeDraftItem(item.id);
+                      }}
+                      className="inline-flex items-center justify-center border border-border p-1.5 hover:border-foreground transition-colors"
+                      aria-label={`Remove ${item.name}`}
+                    >
+                      <X className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              type="submit"
+              disabled={isSaving}
+              className="inline-flex items-center justify-center gap-2 border border-border px-4 py-2.5 text-sm transition-colors hover:border-foreground disabled:opacity-50"
+              style={{ fontFamily: "Outfit, sans-serif" }}
+            >
+              {editingOutfitId ? "Save Changes" : "Save Outfit"}
+            </button>
+
+            {editingOutfitId ? (
+              <button
+                type="button"
+                onClick={resetForm}
+                className="inline-flex items-center justify-center gap-2 border border-border px-4 py-2.5 text-sm transition-colors hover:border-foreground"
+                style={{ fontFamily: "Outfit, sans-serif" }}
+              >
+                Cancel Edit
+              </button>
+            ) : null}
+          </div>
+        </form>
+      </section>
+
+      <section className="space-y-4">
+        {isLoading ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            {Array.from({ length: 2 }).map((_, index) => (
+              <div key={index} className="animate-pulse border border-border p-6 space-y-4">
+                <div className="h-8 bg-muted w-1/2" />
+                <div className="h-4 bg-muted w-full" />
+                <div className="h-24 bg-muted" />
+              </div>
+            ))}
+          </div>
+        ) : outfits.length === 0 ? (
+          <div className="border border-dashed border-border p-8 text-center">
+            <p className="text-2xl mb-2" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+              No outfits yet
+            </p>
+            <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+              Build your first look above and it will appear here.
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            {outfits.map((outfit, index) => (
+              <motion.article
+                key={outfit.id}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.25, delay: index * 0.03 }}
+                className="border border-border bg-card p-5 space-y-4"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3>{outfit.name}</h3>
+                    {outfit.tags && outfit.tags.length > 0 ? (
+                      <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                        {outfit.tags.join(" · ")}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => startEditing(outfit)}
+                      className="inline-flex items-center justify-center border border-border p-2 hover:border-foreground transition-colors"
+                      aria-label="Edit outfit"
+                    >
+                      <Pencil className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={() => handleDelete(outfit.id)}
+                      className="inline-flex items-center justify-center border border-border p-2 hover:border-destructive transition-colors"
+                      aria-label="Delete outfit"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                </div>
+
+                {outfit.notes ? (
+                  <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                    {outfit.notes}
+                  </p>
+                ) : null}
+
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {outfit.items.map((item: ClothingItem) => (
+                    <button
+                      key={item.id}
+                      onClick={() => onOpenItem(item.id)}
+                      className="w-full text-left border border-border px-3 py-2 hover:border-foreground transition-colors"
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="h-9 w-9 shrink-0 border border-border rounded-full flex items-center justify-center bg-muted">
+                          {item.image_url ? (
+                            <img
+                              src={item.image_url}
+                              alt={item.name}
+                              className="h-full w-full rounded-full object-cover"
+                            />
+                          ) : (
+                            <span className="text-xs" style={{ fontFamily: "Outfit, sans-serif" }}>
+                              {buildPlaceholderLabel(item.name)}
+                            </span>
+                          )}
+                        </div>
+                        <div>
+                          <p style={{ fontFamily: "Outfit, sans-serif" }}>{item.name}</p>
+                          <p className="text-xs text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                            <Shirt className="inline w-3 h-3 mr-1" />
+                            {item.tags.style ? titleize(item.tags.style) : "Unstyled"}
+                          </p>
+                        </div>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </motion.article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {flash ? (
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          className={`fixed bottom-6 right-6 z-50 max-w-sm border px-4 py-3 text-sm shadow-lg backdrop-blur ${
+            flash.kind === "success"
+              ? "border-foreground/20 bg-background/95 text-foreground"
+              : "border-destructive/25 bg-destructive/10 text-destructive"
+          }`}
+          style={{ fontFamily: "Outfit, sans-serif" }}
+        >
+          {flash.message}
+        </motion.div>
+      ) : null}
+    </div>
+  );
+}

--- a/front-end/src/app/lib/closet.ts
+++ b/front-end/src/app/lib/closet.ts
@@ -118,6 +118,18 @@ export interface OutfitUpload {
   updated_at?: string;
 }
 
+export interface Outfit {
+  id: number;
+  user_id: number;
+  name: string;
+  tags?: string[] | null;
+  notes?: string | null;
+  item_ids: number[];
+  items: ClothingItem[];
+  created_at?: string;
+  updated_at?: string;
+}
+
 export type CreateItemMode = "manual" | "image";
 
 export interface ClothingItemFormValues {
@@ -146,6 +158,51 @@ export interface TemporaryCleanImageResult {
   content_type: string;
   data_url: string;
   filename: string;
+}
+
+function outfitDraftStorageKey(userId: number) {
+  return `outfit-draft-item-ids:${userId}`;
+}
+
+export function loadOutfitDraftItemIds(userId: number) {
+  if (typeof window === "undefined") {
+    return [] as number[];
+  }
+
+  const raw = window.localStorage.getItem(outfitDraftStorageKey(userId));
+  if (!raw) {
+    return [] as number[];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [] as number[];
+    }
+
+    return parsed
+      .map((value) => Number(value))
+      .filter((value) => Number.isInteger(value) && value > 0);
+  } catch {
+    return [] as number[];
+  }
+}
+
+export function saveOutfitDraftItemIds(userId: number, itemIds: number[]) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const normalized = itemIds.filter((value, index, array) =>
+    Number.isInteger(value) && value > 0 && array.indexOf(value) === index,
+  );
+
+  if (normalized.length === 0) {
+    window.localStorage.removeItem(outfitDraftStorageKey(userId));
+    return;
+  }
+
+  window.localStorage.setItem(outfitDraftStorageKey(userId), JSON.stringify(normalized));
 }
 
 export function emptyClothingItemFormValues(): ClothingItemFormValues {
@@ -382,6 +439,103 @@ export async function fetchOutfitUpload(id: number, signal?: AbortSignal) {
   }
 
   return (await response.json()) as OutfitUpload;
+}
+
+export async function fetchOutfits(signal?: AbortSignal) {
+  const response = await fetch(`${API_BASE_URL}/outfits`, {
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+    },
+    signal,
+  });
+
+  if (!response.ok) {
+    throw await buildApiError(response);
+  }
+
+  return (await response.json()) as Outfit[];
+}
+
+interface CreateOutfitInput {
+  userId: number;
+  name: string;
+  itemIds: number[];
+  notes?: string;
+  tags?: string[];
+}
+
+export async function createOutfit(input: CreateOutfitInput) {
+  const response = await fetch(`${API_BASE_URL}/outfits`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      outfit: {
+        user_id: input.userId,
+        name: input.name,
+        item_ids: input.itemIds,
+        notes: input.notes,
+        tags: input.tags,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw await buildApiError(response);
+  }
+
+  return (await response.json()) as Outfit;
+}
+
+interface UpdateOutfitInput {
+  id: number;
+  name: string;
+  itemIds: number[];
+  notes?: string;
+  tags?: string[];
+}
+
+export async function updateOutfit(input: UpdateOutfitInput) {
+  const response = await fetch(`${API_BASE_URL}/outfits/${input.id}`, {
+    method: "PATCH",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      outfit: {
+        name: input.name,
+        item_ids: input.itemIds,
+        notes: input.notes,
+        tags: input.tags,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw await buildApiError(response);
+  }
+
+  return (await response.json()) as Outfit;
+}
+
+export async function destroyOutfit(id: number) {
+  const response = await fetch(`${API_BASE_URL}/outfits/${id}`, {
+    method: "DELETE",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw await buildApiError(response);
+  }
 }
 
 export async function destroyClothingItem(id: number) {


### PR DESCRIPTION

## Summary
- Added full outfits backend support with user-scoped CRUD.
- Added outfit data model and join model for outfit-item relationships.
- Added ownership and uniqueness validations for outfit item assignments.
- Added My Outfits frontend page for creating, editing, and deleting outfits.
- Added add-to-outfit flow from closet cards.
- Added per-user outfit draft persistence using local storage.
- Added flash/toast notifications for outfit load/save/update/delete and draft feedback.
- Updated changelog for v1.0.2.

## Backend Changes
- Added outfits controller and routes.
- Added outfit and outfit-item models plus associations.
- Added migrations for outfits and outfit_items.
- Added outfit payload serialization and item embedding.

## Frontend Changes
- Added My Outfits page and route integration.
- Added outfit API client methods and draft storage helpers.
- Updated clothing cards to support add-to-outfit action.
- Added success/error toast notifications for outfit flows.

## Testing
- Ran backend tests:
  - model tests for outfit and outfit_item
  - outfit integration flow tests
- Ran frontend build successfully.

Closes #28 
Closes #35
