### PR TITLE
Feat/search and filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.3 - 2026-05-04
+
+- Reworked clothing item metadata into a relaxed tag-based schema for create, edit, seed, and API payload flows.
+- Added closet search, tag filtering, and sort controls aligned with the new tag-driven item model.
+- Polished the closet filter bar layout so the search field and dropdown controls feel cleaner and more consistent.
+
 ## v1.0.1 - 2026-05-03
 
 - Refined unauthorized user flows for admin-only pages and protected routes.

--- a/back-end/app/controllers/application_controller.rb
+++ b/back-end/app/controllers/application_controller.rb
@@ -105,6 +105,7 @@ class ApplicationController < ActionController::API
       ]
     )
     payload["size"] = clothing_item.size
+    payload["tags"] = TagListNormalizer.call(clothing_item.tags)
     payload["image_url"] = clothing_item.display_photo_attachment.attached? ? url_for(clothing_item.display_photo_attachment) : nil
     payload["original_image_url"] = clothing_item.photo.attached? ? url_for(clothing_item.photo) : nil
     payload["cleaned_image_url"] = clothing_item.cleaned_photo.attached? ? url_for(clothing_item.cleaned_photo) : nil

--- a/back-end/app/controllers/clothing_items_controller.rb
+++ b/back-end/app/controllers/clothing_items_controller.rb
@@ -71,9 +71,12 @@ class ClothingItemsController < ApplicationController
 
   def clothing_item_attributes
     base_params = params.require(:clothing_item).permit(:name, :size, :date, :user_id)
-    tag_params = params.require(:clothing_item).permit(:material, :season, :style, :brand, :color).to_h.compact_blank
+    tag_params = params.require(:clothing_item).permit(tags: [])[:tags]
 
-    base_params.merge(tags: tag_params, user_id: current_user.id)
+    base_params.merge(
+      tags: TagListNormalizer.call(tag_params.presence || params.dig(:clothing_item, :tags)),
+      user_id: current_user.id
+    )
   end
 
   def attach_photo_from_request(clothing_item, temporary_files)

--- a/back-end/app/models/clothing_item.rb
+++ b/back-end/app/models/clothing_item.rb
@@ -2,6 +2,7 @@ class ClothingItem < ApplicationRecord
   belongs_to :user
   has_one_attached :photo
   has_one_attached :cleaned_photo
+  before_validation :normalize_tags
 
   enum :size, {
     xs: 0,
@@ -44,5 +45,9 @@ class ClothingItem < ApplicationRecord
     return if photo.blob.byte_size <= 10.megabytes
 
     errors.add(:photo, "must be 10 MB or smaller")
+  end
+
+  def normalize_tags
+    self.tags = TagListNormalizer.call(tags)
   end
 end

--- a/back-end/app/services/image_clean_prompt_builder.rb
+++ b/back-end/app/services/image_clean_prompt_builder.rb
@@ -43,15 +43,17 @@ class ImageCleanPromptBuilder
   end
 
   def build_for_clothing_item(clothing_item)
-    color = clothing_item.tags["color"].presence
-    material = clothing_item.tags["material"].presence
-    style = clothing_item.tags["style"].presence
+    tags = TagListNormalizer.call(clothing_item.tags)
+    color = named_tag_value(clothing_item.tags, "color")
+    material = named_tag_value(clothing_item.tags, "material")
+    style = named_tag_value(clothing_item.tags, "style")
     name = clothing_item.name.presence
     appearance_summary = clothing_item_appearance_summary(
       name: name,
       color: color,
       material: material,
-      style: style
+      style: style,
+      tags: tags
     )
 
     {
@@ -64,7 +66,7 @@ class ImageCleanPromptBuilder
         color: color,
         name: name
       ),
-      soft_hints: build_soft_hints(material: material, style: style)
+      soft_hints: build_soft_hints(material: material, style: style, tags: tags)
     }.compact_blank
   end
 
@@ -89,7 +91,7 @@ class ImageCleanPromptBuilder
     summary.compact_blank.join(" ").presence
   end
 
-  def clothing_item_appearance_summary(name:, color:, material:, style:)
+  def clothing_item_appearance_summary(name:, color:, material:, style:, tags:)
     summary = []
     summary << "Reference item: #{name}." if name.present?
 
@@ -100,6 +102,8 @@ class ImageCleanPromptBuilder
       summary << sentence
     elsif style.present?
       summary << "The item should keep a #{style} style."
+    elsif tags.present?
+      summary << "Reference tags: #{tags.join(', ')}."
     end
 
     summary.compact_blank.join(" ").presence
@@ -123,10 +127,19 @@ class ImageCleanPromptBuilder
     constraints
   end
 
-  def build_soft_hints(material:, style:)
+  def build_soft_hints(material:, style:, tags: [])
     hints = []
     hints << "Material cues should stay consistent with #{material}." if material.present?
     hints << "The styling should still read as #{style}." if style.present?
+    if material.blank? && style.blank? && tags.present?
+      hints << "Keep the item consistent with these tags: #{tags.join(', ')}."
+    end
     hints
+  end
+
+  def named_tag_value(tags, key)
+    return unless tags.is_a?(Hash)
+
+    tags[key].presence || tags[key.to_sym].presence
   end
 end

--- a/back-end/app/services/tag_list_normalizer.rb
+++ b/back-end/app/services/tag_list_normalizer.rb
@@ -1,0 +1,50 @@
+class TagListNormalizer
+  def self.call(raw_tags)
+    new(raw_tags).call
+  end
+
+  def initialize(raw_tags)
+    @raw_tags = raw_tags
+  end
+
+  def call
+    extracted_values
+      .flat_map { |value| split_values(value) }
+      .map { |value| normalize_tag(value) }
+      .compact_blank
+      .uniq
+  end
+
+  private
+
+  attr_reader :raw_tags
+
+  def extracted_values
+    case raw_tags
+    when ActionController::Parameters
+      extracted_values_from_hash(raw_tags.to_unsafe_h)
+    when Hash
+      extracted_values_from_hash(raw_tags)
+    when Array
+      raw_tags
+    when nil
+      []
+    else
+      [ raw_tags ]
+    end
+  end
+
+  def extracted_values_from_hash(hash)
+    hash.values
+  end
+
+  def split_values(value)
+    return value if value.is_a?(Array)
+
+    value.to_s.split(/[,\n]/)
+  end
+
+  def normalize_tag(value)
+    value.to_s.strip.downcase.gsub(/\s+/, " ")
+  end
+end

--- a/back-end/db/seeds.rb
+++ b/back-end/db/seeds.rb
@@ -5,54 +5,46 @@ srand(20260425)
 ClothingItem.destroy_all
 User.destroy_all
 
-SEASON_MONTHS = {
-  spring: [ 3, 4, 5 ],
-  summer: [ 6, 7, 8 ],
-  fall: [ 9, 10, 11 ],
-  winter: [ 12, 1, 2 ],
-  all_season: (1..12).to_a
-}.freeze
-
 WARDROBE_LIBRARY = {
   smart_casual: [
-    [ "Oxford Shirt", "J.Crew", "cotton", "spring", "blue" ],
-    [ "Merino Crewneck Sweater", "Uniqlo", "merino_wool", "winter", "charcoal" ],
-    [ "Straight-Leg Jeans", "Madewell", "denim", "all_season", "indigo" ],
-    [ "Tailored Chinos", "Banana Republic", "twill", "fall", "khaki" ],
-    [ "Leather Loafers", "Sam Edelman", "leather", "all_season", "black" ],
-    [ "Single-Breasted Blazer", "Theory", "wool_blend", "fall", "navy" ]
+    [ "Oxford Shirt", [ "j.crew", "cotton", "blue", "office", "layering" ] ],
+    [ "Merino Crewneck Sweater", [ "uniqlo", "merino wool", "charcoal", "cozy", "polished" ] ],
+    [ "Straight-Leg Jeans", [ "madewell", "denim", "indigo", "everyday", "classic" ] ],
+    [ "Tailored Chinos", [ "banana republic", "twill", "khaki", "workwear", "tailored" ] ],
+    [ "Leather Loafers", [ "sam edelman", "leather", "black", "dressy", "classic" ] ],
+    [ "Single-Breasted Blazer", [ "theory", "wool blend", "navy", "office", "sharp" ] ]
   ],
   athleisure: [
-    [ "Training Joggers", "Lululemon", "recycled_polyester", "all_season", "black" ],
-    [ "Performance Tee", "Nike", "moisture_wicking_jersey", "summer", "heather_gray" ],
-    [ "Running Hoodie", "Under Armour", "performance_fleece", "winter", "gray" ],
-    [ "Quarter-Zip Pullover", "Vuori", "polyester", "fall", "navy" ],
-    [ "Hybrid Shorts", "Ten Thousand", "nylon", "summer", "stone" ],
-    [ "Trail Shell Jacket", "Patagonia", "ripstop", "spring", "olive" ]
+    [ "Training Joggers", [ "lululemon", "recycled polyester", "black", "active", "weekend" ] ],
+    [ "Performance Tee", [ "nike", "moisture wicking", "heather gray", "gym", "breathable" ] ],
+    [ "Running Hoodie", [ "under armour", "performance fleece", "gray", "cozy", "active" ] ],
+    [ "Quarter-Zip Pullover", [ "vuori", "polyester", "navy", "layering", "commute" ] ],
+    [ "Hybrid Shorts", [ "ten thousand", "nylon", "stone", "summer", "training" ] ],
+    [ "Trail Shell Jacket", [ "patagonia", "ripstop", "olive", "outdoors", "weatherproof" ] ]
   ],
   minimal: [
-    [ "Rib Tank", "Uniqlo", "cotton", "summer", "black" ],
-    [ "Relaxed Trousers", "COS", "twill", "all_season", "taupe" ],
-    [ "Linen Button-Down", "Everlane", "linen", "spring", "white" ],
-    [ "Slip Skirt", "Aritzia", "satin", "summer", "cream" ],
-    [ "Wool Coat", "Mango", "wool", "winter", "camel" ],
-    [ "Ankle Boots", "Steve Madden", "suede", "fall", "brown" ]
+    [ "Rib Tank", [ "uniqlo", "cotton", "black", "minimal", "basics" ] ],
+    [ "Relaxed Trousers", [ "cos", "twill", "taupe", "workwear", "clean lines" ] ],
+    [ "Linen Button-Down", [ "everlane", "linen", "white", "airy", "capsule" ] ],
+    [ "Slip Skirt", [ "aritzia", "satin", "cream", "soft", "date night" ] ],
+    [ "Wool Coat", [ "mango", "wool", "camel", "outerwear", "elevated" ] ],
+    [ "Ankle Boots", [ "steve madden", "suede", "brown", "fall", "classic" ] ]
   ],
   vintage: [
-    [ "Band Tee", "Levis", "cotton", "all_season", "washed_black" ],
-    [ "High-Rise Mom Jeans", "Levis", "denim", "all_season", "light_blue" ],
-    [ "Corduroy Jacket", "Free People", "corduroy", "fall", "rust" ],
-    [ "Pleated Midi Dress", "Reformation", "viscose", "summer", "sage" ],
-    [ "Western Boots", "Frye", "leather", "fall", "cognac" ],
-    [ "Wool Beret", "Anthropologie", "wool", "winter", "burgundy" ]
+    [ "Band Tee", [ "levis", "cotton", "washed black", "graphic", "casual" ] ],
+    [ "High-Rise Mom Jeans", [ "levis", "denim", "light blue", "retro", "weekend" ] ],
+    [ "Corduroy Jacket", [ "free people", "corduroy", "rust", "textured", "layering" ] ],
+    [ "Pleated Midi Dress", [ "reformation", "viscose", "sage", "dressy", "romantic" ] ],
+    [ "Western Boots", [ "frye", "leather", "cognac", "statement", "boots" ] ],
+    [ "Wool Beret", [ "anthropologie", "wool", "burgundy", "accessory", "playful" ] ]
   ],
   polished: [
-    [ "Silk Blouse", "Sezane", "silk", "spring", "ivory" ],
-    [ "Pleated Trousers", "Aritzia", "crepe", "all_season", "black" ],
-    [ "Cashmere Cardigan", "Naadam", "cashmere", "winter", "oatmeal" ],
-    [ "Pencil Skirt", "Theory", "wool_blend", "fall", "charcoal" ],
-    [ "Block Heel Pumps", "Cole Haan", "leather", "all_season", "black" ],
-    [ "Trench Coat", "Everlane", "cotton_blend", "spring", "sand" ]
+    [ "Silk Blouse", [ "sezane", "silk", "ivory", "polished", "workwear" ] ],
+    [ "Pleated Trousers", [ "aritzia", "crepe", "black", "tailored", "office" ] ],
+    [ "Cashmere Cardigan", [ "naadam", "cashmere", "oatmeal", "soft", "luxury" ] ],
+    [ "Pencil Skirt", [ "theory", "wool blend", "charcoal", "office", "classic" ] ],
+    [ "Block Heel Pumps", [ "cole haan", "leather", "black", "dressy", "heels" ] ],
+    [ "Trench Coat", [ "everlane", "cotton blend", "sand", "outerwear", "timeless" ] ]
   ]
 }.freeze
 
@@ -86,7 +78,6 @@ seed_users = [
     password: "password",
     admin: true,
     preferred_style: "polished",
-    size_profile: :standard,
     item_count: 0
   },
   {
@@ -97,14 +88,14 @@ seed_users = [
     password: "password",
     preferred_style: "athleisure",
     items: [
-      { name: "Heather Gray Running Hoodie", size: :large, date: Date.new(2026, 2, 2), material: "performance_fleece", season: "winter", style: "athleisure", brand: "Nike", color: "gray" },
-      { name: "Black Training Joggers", size: :large, date: Date.new(2026, 1, 24), material: "recycled_polyester", season: "winter", style: "athleisure", brand: "Lululemon", color: "black" },
-      { name: "Forest Performance Tee", size: :medium, date: Date.new(2026, 3, 22), material: "moisture_wicking_jersey", season: "spring", style: "sport", brand: "Under Armour", color: "green" },
-      { name: "Navy Quarter-Zip Pullover", size: :large, date: Date.new(2025, 11, 3), material: "polyester", season: "fall", style: "athleisure", brand: "Vuori", color: "navy" },
-      { name: "Stone Utility Shorts", size: :medium, date: Date.new(2025, 8, 19), material: "nylon", season: "summer", style: "casual", brand: "Ten Thousand", color: "stone" },
-      { name: "Trail Running Vest", size: :medium, date: Date.new(2025, 10, 7), material: "ripstop", season: "fall", style: "outdoor", brand: "Patagonia", color: "black" },
-      { name: "White Court Sneakers", size: :large, date: Date.new(2025, 7, 14), material: "leather", season: "summer", style: "sport", brand: "Adidas", color: "white" },
-      { name: "Slate Rain Shell Jacket", size: :large, date: Date.new(2026, 4, 12), material: "nylon", season: "spring", style: "outdoor", brand: "Arcteryx", color: "slate" }
+      { name: "Heather Gray Running Hoodie", size: :large, date: Date.new(2026, 2, 2), tags: [ "nike", "performance fleece", "gray", "active", "hoodie" ] },
+      { name: "Black Training Joggers", size: :large, date: Date.new(2026, 1, 24), tags: [ "lululemon", "recycled polyester", "black", "active", "joggers" ] },
+      { name: "Forest Performance Tee", size: :medium, date: Date.new(2026, 3, 22), tags: [ "under armour", "moisture wicking", "green", "gym", "tee" ] },
+      { name: "Navy Quarter-Zip Pullover", size: :large, date: Date.new(2025, 11, 3), tags: [ "vuori", "polyester", "navy", "layering", "athleisure" ] },
+      { name: "Stone Utility Shorts", size: :medium, date: Date.new(2025, 8, 19), tags: [ "ten thousand", "nylon", "stone", "summer", "training" ] },
+      { name: "Trail Running Vest", size: :medium, date: Date.new(2025, 10, 7), tags: [ "patagonia", "ripstop", "black", "outdoors", "running" ] },
+      { name: "White Court Sneakers", size: :large, date: Date.new(2025, 7, 14), tags: [ "adidas", "leather", "white", "sport", "sneakers" ] },
+      { name: "Slate Rain Shell Jacket", size: :large, date: Date.new(2026, 4, 12), tags: [ "arcteryx", "nylon", "slate", "outerwear", "rainy day" ] }
     ]
   },
   {
@@ -115,24 +106,20 @@ seed_users = [
     password: "password",
     preferred_style: "minimal",
     items: [
-      { name: "Oat Linen Blazer", size: :small, date: Date.new(2026, 3, 18), material: "linen", season: "spring", style: "minimal", brand: "Mango", color: "oat" },
-      { name: "Black Rib Tank", size: :xs, date: Date.new(2026, 4, 4), material: "cotton", season: "spring", style: "minimal", brand: "Uniqlo", color: "black" },
-      { name: "Cream Slip Skirt", size: :small, date: Date.new(2025, 6, 9), material: "satin", season: "summer", style: "dressy", brand: "Zara", color: "cream" },
-      { name: "Charcoal Merino Sweater", size: :small, date: Date.new(2025, 12, 11), material: "merino_wool", season: "winter", style: "minimal", brand: "COS", color: "charcoal" },
-      { name: "Brown Ankle Boots", size: :small, date: Date.new(2025, 10, 1), material: "suede", season: "fall", style: "classic", brand: "Steve Madden", color: "brown" },
-      { name: "Light Wash Denim Jacket", size: :medium, date: Date.new(2025, 9, 21), material: "denim", season: "fall", style: "casual", brand: "Levis", color: "light_blue" },
-      { name: "Soft White T-Shirt", size: :small, date: Date.new(2026, 2, 27), material: "cotton", season: "all_season", style: "minimal", brand: "Everlane", color: "white" },
-      { name: "Sand Pleated Trousers", size: :small, date: Date.new(2025, 11, 29), material: "twill", season: "winter", style: "workwear", brand: "Aritzia", color: "sand" }
+      { name: "Oat Linen Blazer", size: :small, date: Date.new(2026, 3, 18), tags: [ "mango", "linen", "oat", "blazer", "capsule" ] },
+      { name: "Black Rib Tank", size: :xs, date: Date.new(2026, 4, 4), tags: [ "uniqlo", "cotton", "black", "minimal", "tank" ] },
+      { name: "Cream Slip Skirt", size: :small, date: Date.new(2025, 6, 9), tags: [ "zara", "satin", "cream", "dressy", "soft" ] },
+      { name: "Charcoal Merino Sweater", size: :small, date: Date.new(2025, 12, 11), tags: [ "cos", "merino wool", "charcoal", "cozy", "sweater" ] },
+      { name: "Brown Ankle Boots", size: :small, date: Date.new(2025, 10, 1), tags: [ "steve madden", "suede", "brown", "boots", "classic" ] },
+      { name: "Light Wash Denim Jacket", size: :medium, date: Date.new(2025, 9, 21), tags: [ "levis", "denim", "light blue", "layering", "weekend" ] },
+      { name: "Soft White T-Shirt", size: :small, date: Date.new(2026, 2, 27), tags: [ "everlane", "cotton", "white", "basics", "everyday" ] },
+      { name: "Sand Pleated Trousers", size: :small, date: Date.new(2025, 11, 29), tags: [ "aritzia", "twill", "sand", "tailored", "office" ] }
     ]
   }
 ]
 
-def random_purchase_date(season_name)
-  season_key = season_name.to_sym
-  month = SEASON_MONTHS.fetch(season_key).sample
-  year = month > Date.today.month ? Date.today.year - 1 : Date.today.year
-  day = rand(1..27)
-  Date.new(year, month, day)
+def random_purchase_date
+  Date.today - rand(20..540)
 end
 
 def build_item_name(base_name)
@@ -159,7 +146,7 @@ seed_users.each do |user_data|
         size: item_data[:size],
         date: item_data[:date],
         user: user,
-        tags: item_data.slice(:material, :season, :style, :brand, :color)
+        tags: item_data[:tags]
       )
       created_items_count += 1
     end
@@ -170,20 +157,14 @@ seed_users.each do |user_data|
   size_pool = SIZE_PROFILES.fetch(user_data.fetch(:size_profile, :standard))
 
   user_data.fetch(:item_count, 0).times do
-    base_name, brand, material, season, color = style_pool.sample
+    base_name, base_tags = style_pool.sample
 
     ClothingItem.create!(
       name: build_item_name(base_name),
       size: size_pool.sample,
-      date: random_purchase_date(season),
+      date: random_purchase_date,
       user: user,
-      tags: {
-        material: material,
-        season: season,
-        style: user.preferred_style,
-        brand: brand,
-        color: color
-      }
+      tags: base_tags + [ user.preferred_style.to_s.tr("_", " ") ]
     )
     created_items_count += 1
   end

--- a/back-end/test/fixtures/clothing_items.yml
+++ b/back-end/test/fixtures/clothing_items.yml
@@ -4,11 +4,10 @@ one:
   name: Ivory Blouse
   size: medium
   tags:
-    material: silk
-    season: spring
-    style: elegant
-    brand: Maison
-    color: ivory
+    - silk
+    - elegant
+    - maison
+    - ivory
   date: 2026-04-19 17:45:04
   user: one
 
@@ -16,10 +15,9 @@ two:
   name: Denim Jacket
   size: large
   tags:
-    material: denim
-    season: fall
-    style: casual
-    brand: Heritage
-    color: blue
+    - denim
+    - casual
+    - heritage
+    - blue
   date: 2026-04-18 15:30:00
   user: two

--- a/back-end/test/integration/clothing_items_flow_test.rb
+++ b/back-end/test/integration/clothing_items_flow_test.rb
@@ -28,11 +28,7 @@ class ClothingItemsFlowTest < ActionDispatch::IntegrationTest
           user_id: @user.id,
           size: "large",
           date: "2026-04-20",
-          material: "wool",
-          season: "winter",
-          style: "tailored",
-          brand: "Studio North",
-          color: "camel"
+          tags: [ "wool", "camel", "tailored", "studio north" ]
         }
       }, headers: auth_headers(@user), as: :json
     end
@@ -40,6 +36,7 @@ class ClothingItemsFlowTest < ActionDispatch::IntegrationTest
     assert_response :created
     assert_equal "Camel Coat", response_json["name"]
     assert_equal "large", response_json["size"]
+    assert_equal [ "wool", "camel", "tailored", "studio north" ], response_json["tags"]
   end
 
   test "can create a clothing item with a photo" do
@@ -49,7 +46,7 @@ class ClothingItemsFlowTest < ActionDispatch::IntegrationTest
           name: "Photo Tee",
           user_id: @user.id,
           size: "medium",
-          color: "white",
+          tags: [ "white", "tee", "casual" ],
           photo: item_photo_upload
         }
       }, headers: auth_headers(@user)
@@ -67,7 +64,7 @@ class ClothingItemsFlowTest < ActionDispatch::IntegrationTest
           name: "Cropped Shirt",
           user_id: @user.id,
           size: "medium",
-          color: "white",
+          tags: [ "white", "shirt", "cropped" ],
           photo: item_photo_upload_png,
           crop_x: "0.1",
           crop_y: "0.1",
@@ -117,7 +114,7 @@ class ClothingItemsFlowTest < ActionDispatch::IntegrationTest
           name: "Verified Shirt",
           user_id: @user.id,
           size: "medium",
-          color: "white",
+          tags: [ "white", "shirt", "verified" ],
           source_outfit_detection_id: detection.id
         }
       }, headers: auth_headers(@user)
@@ -164,7 +161,7 @@ class ClothingItemsFlowTest < ActionDispatch::IntegrationTest
           name: "Verified Shirt",
           user_id: @user.id,
           size: "medium",
-          color: "white",
+          tags: [ "white", "shirt", "verified" ],
           source_outfit_detection_id: detection.id
         }
       }, headers: auth_headers(@user)
@@ -184,11 +181,7 @@ class ClothingItemsFlowTest < ActionDispatch::IntegrationTest
         user_id: @user.id,
         size: "small",
         date: "2026-04-18",
-        material: "silk",
-        season: "spring",
-        style: "dressy",
-        brand: "Maison",
-        color: "ivory"
+        tags: [ "silk", "ivory", "dressy", "maison" ]
       }
     }, headers: auth_headers(@user), as: :json
 
@@ -197,8 +190,8 @@ class ClothingItemsFlowTest < ActionDispatch::IntegrationTest
     @clothing_item.reload
     assert_equal "Ivory Silk Blouse", @clothing_item.name
     assert_equal "small", @clothing_item.size
-    assert_equal "dressy", @clothing_item.tags["style"]
-    assert_equal "dressy", response_json["tags"]["style"]
+    assert_equal [ "silk", "ivory", "dressy", "maison" ], @clothing_item.tags
+    assert_equal [ "silk", "ivory", "dressy", "maison" ], response_json["tags"]
   end
 
   test "can remove a clothing item photo" do
@@ -210,11 +203,7 @@ class ClothingItemsFlowTest < ActionDispatch::IntegrationTest
         user_id: @user.id,
         size: @clothing_item.size,
         date: @clothing_item.date&.to_date&.iso8601,
-        material: @clothing_item.tags["material"],
-        season: @clothing_item.tags["season"],
-        style: @clothing_item.tags["style"],
-        brand: @clothing_item.tags["brand"],
-        color: @clothing_item.tags["color"],
+        tags: @clothing_item.tags,
         remove_photo: "true"
       }
     }, headers: auth_headers(@user)

--- a/back-end/test/models/clothing_item_test.rb
+++ b/back-end/test/models/clothing_item_test.rb
@@ -15,4 +15,21 @@ class ClothingItemTest < ActiveSupport::TestCase
   test "belongs to a user" do
     assert_equal users(:one), clothing_items(:one).user
   end
+
+  test "normalizes tags into a clean list" do
+    item = ClothingItem.new(
+      user: users(:one),
+      name: "Weekend Blazer",
+      size: :medium,
+      tags: {
+        brand: "  COS ",
+        vibe: "Workwear",
+        duplicate: "cos"
+      }
+    )
+
+    item.valid?
+
+    assert_equal [ "cos", "workwear" ], item.tags
+  end
 end

--- a/back-end/test/services/image_clean_prompt_builder_test.rb
+++ b/back-end/test/services/image_clean_prompt_builder_test.rb
@@ -60,20 +60,15 @@ class ImageCleanPromptBuilderTest < ActiveSupport::TestCase
       name: "Ivory Silk Blouse",
       user: users(:one),
       size: :small,
-      tags: {
-        "color" => "ivory",
-        "material" => "silk",
-        "style" => "dressy"
-      }
+      tags: [ "ivory", "silk", "dressy", "date night" ]
     )
 
     context = ImageCleanPromptBuilder.for_clothing_item(item)
 
     assert_equal "Ivory Silk Blouse", context[:name]
-    assert_equal "ivory", context[:color]
-    assert_equal "silk", context[:material]
-    assert_equal "dressy", context[:style]
     assert_includes context[:appearance_summary], "Reference item: Ivory Silk Blouse."
+    assert_includes context[:appearance_summary], "Reference tags: ivory, silk, dressy, date night."
     assert_includes context[:hard_constraints].join(" "), "Preserve the same item identity"
+    assert_includes context[:soft_hints].join(" "), "date night"
   end
 end

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -549,61 +549,44 @@ export default function App() {
               transition={{ duration: 0.6, delay: 0.3 }}
               className="mb-8 space-y-5"
             >
-              <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-                <div>
-                  <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
-                    Showing {filteredClothingItems.length} of {clothingItems.length}{" "}
-                    {clothingItems.length === 1 ? "item" : "items"}
-                  </p>
+              <div className="grid gap-3 lg:grid-cols-[minmax(0,1.9fr)_minmax(14rem,1fr)_12rem] lg:items-start">
+                <div className="relative min-w-0 self-start">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    value={searchQuery}
+                    onChange={(event) => setSearchQuery(event.target.value)}
+                    placeholder="Search by name or describe an item with tags"
+                    className="h-14 pl-10"
+                  />
                 </div>
 
-                <div className="flex flex-col gap-3 lg:min-w-[46rem] lg:flex-row">
-                  <div className="relative flex-1">
-                    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                    <Input
-                      value={searchQuery}
-                      onChange={(event) => setSearchQuery(event.target.value)}
-                      placeholder="Search by name or describe an item with tags"
-                      className="pl-9"
-                    />
-                  </div>
-
-                  <div className="w-full lg:w-[14rem]">
-                    <Select value={selectedTag} onValueChange={setSelectedTag}>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="All tags" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="all">All tags</SelectItem>
-                        {tagOptions.map((tag) => (
-                          <SelectItem key={tag} value={tag}>
-                            {titleize(tag)}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    {tagOptions.length > 0 ? (
-                      <p
-                        className="mt-2 text-xs leading-5 text-muted-foreground"
-                        style={{ fontFamily: "Outfit, sans-serif" }}
-                      >
-                        Available tags: {tagOptions.map(titleize).join(", ")}
-                      </p>
-                    ) : null}
-                  </div>
-
-                  <Select value={sortOption} onValueChange={(value) => setSortOption(value as ClosetSortOption)}>
-                    <SelectTrigger className="w-full lg:w-[12rem]">
-                      <SelectValue placeholder="Sort items" />
+                <div className="min-w-0">
+                  <Select value={selectedTag} onValueChange={setSelectedTag}>
+                    <SelectTrigger className="h-14 w-full bg-stone-200 hover:bg-stone-200">
+                      <SelectValue placeholder="All tags" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="name-asc">Name A-Z</SelectItem>
-                      <SelectItem value="newest-added">Newest added</SelectItem>
-                      <SelectItem value="oldest-added">Oldest added</SelectItem>
-                      <SelectItem value="recent-purchase">Most recent purchase</SelectItem>
+                      <SelectItem value="all">All tags</SelectItem>
+                      {tagOptions.map((tag) => (
+                        <SelectItem key={tag} value={tag}>
+                          {titleize(tag)}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </div>
+
+                <Select value={sortOption} onValueChange={(value) => setSortOption(value as ClosetSortOption)}>
+                  <SelectTrigger className="h-14 w-full bg-stone-200 hover:bg-stone-200">
+                    <SelectValue placeholder="Sort items" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="name-asc">Name A-Z</SelectItem>
+                    <SelectItem value="newest-added">Newest added</SelectItem>
+                    <SelectItem value="oldest-added">Oldest added</SelectItem>
+                    <SelectItem value="recent-purchase">Most recent purchase</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
 
               {hasActiveClosetControls ? (

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -1,12 +1,20 @@
-import { useEffect, useState } from "react";
+import { useDeferredValue, useEffect, useState } from "react";
 import { motion } from "motion/react";
-import { ArrowLeft, ArrowRight, Users } from "lucide-react";
+import { ArrowLeft, ArrowRight, Search, Users } from "lucide-react";
 import { AddItemMenu } from "./components/AddItemMenu";
 import { ClothingCard } from "./components/ClothingCard";
 import { CreateItemPage } from "./components/CreateItemPage";
 import { ItemDetailPage } from "./components/ItemDetailPage";
 import { UserDetailPage } from "./components/UserDetailPage";
 import { UsersDirectoryPage } from "./components/UsersDirectoryPage";
+import { Input } from "./components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./components/ui/select";
 import {
   beginGoogleSignIn,
   ClothingItem,
@@ -141,12 +149,59 @@ function removeUserItem(user: User | null, itemId: number) {
   };
 }
 
+type ClosetSortOption = "name-asc" | "newest-added" | "oldest-added" | "recent-purchase";
+
+function matchesSearchQuery(item: ClothingItem, query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  const haystack = [
+    item.name,
+    item.size,
+    ...item.tags,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return normalizedQuery
+    .split(/\s+/)
+    .every((term) => haystack.includes(term));
+}
+
+function sortClothingItems(items: ClothingItem[], sortOption: ClosetSortOption) {
+  const sorted = [...items];
+
+  sorted.sort((left, right) => {
+    if (sortOption === "name-asc") {
+      return left.name.localeCompare(right.name);
+    }
+
+    if (sortOption === "oldest-added") {
+      return (new Date(left.created_at ?? 0).getTime()) - (new Date(right.created_at ?? 0).getTime());
+    }
+
+    if (sortOption === "recent-purchase") {
+      return (new Date(right.date ?? 0).getTime()) - (new Date(left.date ?? 0).getTime());
+    }
+
+    return (new Date(right.created_at ?? 0).getTime()) - (new Date(left.created_at ?? 0).getTime());
+  });
+
+  return sorted;
+}
+
 export default function App() {
   const [route, setRoute] = useState<AppRoute>(() => getRouteFromLocation());
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
   const [homeMessage, setHomeMessage] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedTag, setSelectedTag] = useState("all");
+  const [sortOption, setSortOption] = useState<ClosetSortOption>("name-asc");
 
   useEffect(() => {
     const handlePopState = () => setRoute(getRouteFromLocation());
@@ -197,6 +252,7 @@ export default function App() {
   }, [route.kind]);
 
   const clothingItems = user?.clothing_items ?? [];
+  const deferredSearchQuery = useDeferredValue(searchQuery);
   const isLoggedOutProtectedRoute = isProtectedRoute(route) && !user;
 
   const closetTitle = user ? formatPossessive(titleize(user.username)) : "Your Closet";
@@ -208,6 +264,21 @@ export default function App() {
 
   const isAdminRoute = route.kind === "users" || route.kind === "user";
   const isUnauthorizedAdminRoute = Boolean(user && !user.admin && isAdminRoute);
+  const tagOptions = Array.from(new Set(clothingItems.flatMap((item) => item.tags))).sort((left, right) =>
+    left.localeCompare(right),
+  );
+  const filteredClothingItems = sortClothingItems(
+    clothingItems.filter((item) => {
+      if (selectedTag !== "all" && !item.tags.includes(selectedTag)) {
+        return false;
+      }
+
+      return matchesSearchQuery(item, deferredSearchQuery);
+    }),
+    sortOption,
+  );
+  const hasActiveClosetControls =
+    searchQuery.trim().length > 0 || selectedTag !== "all" || sortOption !== "name-asc";
 
   const globalAction = user ? (
     <button
@@ -476,16 +547,89 @@ export default function App() {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ duration: 0.6, delay: 0.3 }}
-              className="mb-8 flex items-center justify-between"
+              className="mb-8 space-y-5"
             >
-              <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
-                Showing {clothingItems.length} {clothingItems.length === 1 ? "item" : "items"}
-              </p>
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                <div>
+                  <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                    Showing {filteredClothingItems.length} of {clothingItems.length}{" "}
+                    {clothingItems.length === 1 ? "item" : "items"}
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-3 lg:min-w-[46rem] lg:flex-row">
+                  <div className="relative flex-1">
+                    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                      value={searchQuery}
+                      onChange={(event) => setSearchQuery(event.target.value)}
+                      placeholder="Search by name or describe an item with tags"
+                      className="pl-9"
+                    />
+                  </div>
+
+                  <div className="w-full lg:w-[14rem]">
+                    <Select value={selectedTag} onValueChange={setSelectedTag}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="All tags" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All tags</SelectItem>
+                        {tagOptions.map((tag) => (
+                          <SelectItem key={tag} value={tag}>
+                            {titleize(tag)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {tagOptions.length > 0 ? (
+                      <p
+                        className="mt-2 text-xs leading-5 text-muted-foreground"
+                        style={{ fontFamily: "Outfit, sans-serif" }}
+                      >
+                        Available tags: {tagOptions.map(titleize).join(", ")}
+                      </p>
+                    ) : null}
+                  </div>
+
+                  <Select value={sortOption} onValueChange={(value) => setSortOption(value as ClosetSortOption)}>
+                    <SelectTrigger className="w-full lg:w-[12rem]">
+                      <SelectValue placeholder="Sort items" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="name-asc">Name A-Z</SelectItem>
+                      <SelectItem value="newest-added">Newest added</SelectItem>
+                      <SelectItem value="oldest-added">Oldest added</SelectItem>
+                      <SelectItem value="recent-purchase">Most recent purchase</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              {hasActiveClosetControls ? (
+                <div className="flex items-center justify-between gap-4 border border-border bg-card px-4 py-3">
+                  <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                    Refine your closet with free-text search, tag filters, and sorting.
+                  </p>
+                  <button
+                    onClick={() => {
+                      setSearchQuery("");
+                      setSelectedTag("all");
+                      setSortOption("name-asc");
+                    }}
+                    className="inline-flex items-center justify-center border border-border px-3 py-2 text-sm transition-colors hover:border-foreground"
+                    style={{ fontFamily: "Outfit, sans-serif" }}
+                  >
+                    Clear filters
+                  </button>
+                </div>
+              ) : null}
+
             </motion.div>
 
-            {user && clothingItems.length > 0 ? (
+            {user && filteredClothingItems.length > 0 ? (
               <div className="grid grid-cols-1 gap-x-6 gap-y-12 sm:grid-cols-2 lg:grid-cols-4">
-                {clothingItems.map((item, index) => (
+                {filteredClothingItems.map((item, index) => (
                   <ClothingCard
                     key={item.id}
                     {...item}
@@ -497,11 +641,13 @@ export default function App() {
             ) : (
               <div className="border border-dashed border-border p-10 text-center">
                 <p className="mb-3 text-2xl" style={{ fontFamily: "Cormorant Garamond, serif" }}>
-                  {user ? "No matching items yet" : "No closet data found"}
+                  {user ? "No matching items found" : "No closet data found"}
                 </p>
                 <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
                   {user
-                    ? "Add a new item to start building out this closet."
+                    ? hasActiveClosetControls
+                      ? "Try a different tag, search phrase, or sort."
+                      : "Add a new item to start building out this closet."
                     : "Sign in with Google to load your closet."}
                 </p>
               </div>

--- a/front-end/src/app/components/ClothingCard.tsx
+++ b/front-end/src/app/components/ClothingCard.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import { Plus } from "lucide-react";
 import { useState } from "react";
 import {
+  formatTagLabel,
   formatDisplaySize,
 } from "../lib/closet";
 
@@ -9,13 +10,7 @@ interface ClothingCardProps {
   id: number;
   name: string;
   size: string;
-  tags: {
-    material?: string;
-    season?: string;
-    style?: string;
-    brand?: string;
-    color?: string;
-  };
+  tags: string[];
   image_url?: string | null;
   index: number;
   onSelect?: (id: number) => void;
@@ -31,7 +26,8 @@ export function ClothingCard({
   onSelect,
 }: ClothingCardProps) {
   const [isHovered, setIsHovered] = useState(false);
-  const itemMetadata = [tags.material, tags.season, tags.style].filter(Boolean).join(" · ");
+  const visibleTags = tags.slice(0, 3);
+  const itemMetadata = visibleTags.map(formatTagLabel).join(" · ");
   const handleSelect = () => onSelect?.(id);
 
   return (
@@ -70,12 +66,12 @@ export function ClothingCard({
             }}
           >
             <div className="space-y-2">
-              {tags.color && (
+              {tags[0] && (
                 <p
                   className="uppercase tracking-[0.25em] text-xs"
                   style={{ fontFamily: "Outfit, sans-serif" }}
                 >
-                  {tags.color}
+                  {formatTagLabel(tags[0])}
                 </p>
               )}
               {itemMetadata && (
@@ -139,16 +135,16 @@ export function ClothingCard({
       <div className="mt-3 space-y-1">
         <div className="flex items-center gap-2 text-muted-foreground" style={{ fontFamily: 'Outfit, sans-serif' }}>
           <span className="uppercase tracking-wider">{formatDisplaySize(size)}</span>
-          {tags.color && (
+          {tags[0] && (
             <>
               <span>·</span>
-              <span className="capitalize">{tags.color}</span>
+              <span>{formatTagLabel(tags[0])}</span>
             </>
           )}
         </div>
-        {tags.brand && (
+        {tags[1] && (
           <p className="italic opacity-60" style={{ fontFamily: 'Outfit, sans-serif' }}>
-            {tags.brand}
+            {visibleTags.slice(1).map(formatTagLabel).join(" · ")}
           </p>
         )}
       </div>

--- a/front-end/src/app/components/ItemDetailPage.tsx
+++ b/front-end/src/app/components/ItemDetailPage.tsx
@@ -6,10 +6,11 @@ import {
   ClothingItem,
   destroyClothingItem,
   fetchClothingItem,
+  formatTagLabel,
   formatDisplaySize,
   generateClothingItemCleanImage,
+  parseTagInput,
   saveClothingItem,
-  titleize,
   toClothingItemFormValues,
 } from "../lib/closet";
 import { AiCleanImageButton } from "./AiCleanImageButton";
@@ -95,6 +96,7 @@ export function ItemDetailPage({
   }, [formValues, item, photoState.removeExisting, photoState.selectedFile]);
 
   const previewName = formValues?.name.trim() || item?.name?.trim() || "Untitled Item";
+  const previewTags = formValues ? parseTagInput(formValues.tags).slice(0, 2) : [];
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -229,7 +231,7 @@ export function ItemDetailPage({
           imageUrl={photoState.imageUrl}
           label="Clothing Item"
           primaryDetail={formatDisplaySize(formValues.size)}
-          secondaryDetail={formValues.style ? `${titleize(formValues.style)} style` : null}
+          secondaryDetail={previewTags.length > 0 ? previewTags.map(formatTagLabel).join(" · ") : null}
           title={previewName}
         />
 

--- a/front-end/src/app/components/ItemMetadataFields.tsx
+++ b/front-end/src/app/components/ItemMetadataFields.tsx
@@ -1,7 +1,6 @@
 import {
   ClothingItemFormValues,
   formatDisplaySize,
-  titleize,
 } from "../lib/closet";
 
 interface ItemMetadataFieldsProps {
@@ -10,10 +9,6 @@ interface ItemMetadataFieldsProps {
 }
 
 const sizeOptions = ["xs", "small", "medium", "large", "xl"];
-const tagFields: Array<keyof Pick<
-  ClothingItemFormValues,
-  "brand" | "color" | "material" | "season" | "style"
->> = ["brand", "color", "material", "season", "style"];
 
 export function ItemMetadataFields({ onChange, values }: ItemMetadataFieldsProps) {
   function updateField<K extends keyof ClothingItemFormValues>(
@@ -54,7 +49,7 @@ export function ItemMetadataFields({ onChange, values }: ItemMetadataFieldsProps
       </label>
 
       <label className="space-y-2">
-        <span>Date</span>
+        <span>Purchase Date</span>
         <input
           type="date"
           value={values.date}
@@ -63,16 +58,18 @@ export function ItemMetadataFields({ onChange, values }: ItemMetadataFieldsProps
         />
       </label>
 
-      {tagFields.map((fieldName) => (
-        <label key={fieldName} className="space-y-2">
-          <span>{titleize(fieldName)}</span>
-          <input
-            value={values[fieldName]}
-            onChange={(event) => updateField(fieldName, event.target.value)}
-            className="w-full border border-border bg-card px-4 py-3"
-          />
-        </label>
-      ))}
+      <label className="space-y-2 sm:col-span-2">
+        <span>Tags</span>
+        <textarea
+          value={values.tags}
+          onChange={(event) => updateField("tags", event.target.value)}
+          className="min-h-28 w-full border border-border bg-card px-4 py-3"
+          placeholder="Try tags like cotton, blue, weekend, office"
+        />
+        <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+          Add comma-separated tags so people can search and filter this item naturally.
+        </p>
+      </label>
     </>
   );
 }

--- a/front-end/src/app/components/UserDetailPage.tsx
+++ b/front-end/src/app/components/UserDetailPage.tsx
@@ -6,6 +6,7 @@ import {
   formatDisplaySize,
   formatPossessive,
   formatPreferredStyle,
+  formatTagLabel,
   titleize,
   User,
 } from "../lib/closet";
@@ -209,43 +210,47 @@ export function UserDetailPage({
                   </p>
                 </div>
               ) : (
-                user.clothing_items.map((item, index) => (
-                  <motion.button
-                    key={item.id}
-                    initial={{ opacity: 0, y: 12 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.35, delay: index * 0.03 }}
-                    onClick={() => onOpenItem(item.id)}
-                    className="w-full text-left border border-border bg-card p-5 hover:border-foreground transition-colors"
-                  >
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="flex items-start gap-4">
-                        <div className="h-12 w-12 shrink-0 border border-border rounded-full flex items-center justify-center bg-muted">
-                          <Shirt className="w-5 h-5" />
+                user.clothing_items.map((item, index) => {
+                  const visibleTags = item.tags.slice(0, 3);
+
+                  return (
+                    <motion.button
+                      key={item.id}
+                      initial={{ opacity: 0, y: 12 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ duration: 0.35, delay: index * 0.03 }}
+                      onClick={() => onOpenItem(item.id)}
+                      className="w-full text-left border border-border bg-card p-5 hover:border-foreground transition-colors"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex items-start gap-4">
+                          <div className="h-12 w-12 shrink-0 border border-border rounded-full flex items-center justify-center bg-muted">
+                            <Shirt className="w-5 h-5" />
+                          </div>
+                          <div>
+                            <h3 className="mb-1">{item.name}</h3>
+                            <p
+                              className="text-muted-foreground"
+                              style={{ fontFamily: "Outfit, sans-serif" }}
+                            >
+                              {formatDisplaySize(item.size)}
+                              {visibleTags[0] ? ` · ${formatTagLabel(visibleTags[0])}` : ""}
+                            </p>
+                            <p
+                              className="mt-2 text-sm text-muted-foreground"
+                              style={{ fontFamily: "Outfit, sans-serif" }}
+                            >
+                              {visibleTags.length > 0
+                                ? visibleTags.map(formatTagLabel).join(" · ")
+                                : "No tags added yet"}
+                            </p>
+                          </div>
                         </div>
-                        <div>
-                          <h3 className="mb-1">{item.name}</h3>
-                          <p
-                            className="text-muted-foreground"
-                            style={{ fontFamily: "Outfit, sans-serif" }}
-                          >
-                            {formatDisplaySize(item.size)}
-                            {item.tags.color ? ` · ${titleize(item.tags.color)}` : ""}
-                            {item.tags.brand ? ` · ${item.tags.brand}` : ""}
-                          </p>
-                          <p
-                            className="text-sm text-muted-foreground mt-2"
-                            style={{ fontFamily: "Outfit, sans-serif" }}
-                          >
-                            {item.tags.season ? titleize(item.tags.season) : "No season tagged"}
-                            {item.tags.style ? ` · ${titleize(item.tags.style)}` : ""}
-                          </p>
-                        </div>
+                        <ChevronRight className="mt-1 h-4 w-4 shrink-0" />
                       </div>
-                      <ChevronRight className="w-4 h-4 mt-1 shrink-0" />
-                    </div>
-                  </motion.button>
-                ))
+                    </motion.button>
+                  );
+                })
               )}
             </div>
           </motion.div>

--- a/front-end/src/app/lib/closet.ts
+++ b/front-end/src/app/lib/closet.ts
@@ -25,14 +25,6 @@ function defaultBackendBaseUrl() {
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? defaultApiBaseUrl();
 const BACKEND_BASE_URL = import.meta.env.VITE_BACKEND_BASE_URL ?? defaultBackendBaseUrl();
 
-export interface ClothingItemTags {
-  material?: string;
-  season?: string;
-  style?: string;
-  brand?: string;
-  color?: string;
-}
-
 export interface UserSummary {
   id: number;
   username: string;
@@ -48,7 +40,7 @@ export interface ClothingItem {
   user_id: number;
   created_at?: string;
   updated_at?: string;
-  tags: ClothingItemTags;
+  tags: string[];
   image_url?: string | null;
   original_image_url?: string | null;
   cleaned_image_url?: string | null;
@@ -124,11 +116,7 @@ export interface ClothingItemFormValues {
   name: string;
   size: string;
   date: string;
-  material: string;
-  season: string;
-  style: string;
-  brand: string;
-  color: string;
+  tags: string;
 }
 
 export interface ClothingItemPhotoOptions {
@@ -153,11 +141,7 @@ export function emptyClothingItemFormValues(): ClothingItemFormValues {
     name: "",
     size: "medium",
     date: "",
-    material: "",
-    season: "",
-    style: "",
-    brand: "",
-    color: "",
+    tags: "",
   };
 }
 
@@ -179,6 +163,25 @@ export function formatPossessive(name: string) {
 
 export function formatPreferredStyle(style?: string | null) {
   return style ? titleize(style) : null;
+}
+
+export function parseTagInput(value: string) {
+  return Array.from(
+    new Set(
+      value
+        .split(/[,\n]/)
+        .map((tag) => tag.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  );
+}
+
+export function formatTagInput(tags: string[]) {
+  return tags.join(", ");
+}
+
+export function formatTagLabel(tag: string) {
+  return titleize(tag);
 }
 
 export function formatDisplaySize(size: string) {
@@ -208,11 +211,7 @@ export function toClothingItemFormValues(item: ClothingItem): ClothingItemFormVa
     name: item.name,
     size: item.size,
     date: toDateInputValue(item.date),
-    material: item.tags.material ?? "",
-    season: item.tags.season ?? "",
-    style: item.tags.style ?? "",
-    brand: item.tags.brand ?? "",
-    color: item.tags.color ?? "",
+    tags: formatTagInput(item.tags),
   };
 }
 
@@ -223,11 +222,11 @@ export function toClothingItemFormValuesFromDetection(
     name: detection.suggested_name?.trim() || titleize(detection.category),
     size: "medium",
     date: "",
-    material: detection.details.material_guess?.trim() ?? "",
-    season: "",
-    style: detection.details.style_guess?.trim() ?? "",
-    brand: "",
-    color: detection.details.dominant_color?.trim() ?? "",
+    tags: formatTagInput([
+      detection.details.dominant_color?.trim() ?? "",
+      detection.details.material_guess?.trim() ?? "",
+      detection.details.style_guess?.trim() ?? "",
+    ]),
   };
 }
 
@@ -253,7 +252,7 @@ export async function fetchCurrentUser(signal?: AbortSignal) {
     throw new Error(`Request failed with status ${response.status}`);
   }
 
-  return (await response.json()) as User;
+  return normalizeUserPayload((await response.json()) as User);
 }
 
 export function beginGoogleSignIn() {
@@ -278,7 +277,7 @@ export async function fetchUsers(signal?: AbortSignal) {
     throw await buildApiError(response);
   }
 
-  return (await response.json()) as User[];
+  return ((await response.json()) as User[]).map(normalizeUserPayload);
 }
 
 export async function fetchUser(id: number, signal?: AbortSignal) {
@@ -288,7 +287,7 @@ export async function fetchUser(id: number, signal?: AbortSignal) {
     throw await buildApiError(response);
   }
 
-  return (await response.json()) as User;
+  return normalizeUserPayload((await response.json()) as User);
 }
 
 export async function fetchClothingItem(id: number, signal?: AbortSignal) {
@@ -298,7 +297,7 @@ export async function fetchClothingItem(id: number, signal?: AbortSignal) {
     throw new Error(`Request failed with status ${response.status}`);
   }
 
-  return (await response.json()) as ClothingItem;
+  return normalizeClothingItemPayload((await response.json()) as ClothingItem);
 }
 
 export async function saveClothingItem(
@@ -320,7 +319,7 @@ export async function saveClothingItem(
     throw await buildApiError(response);
   }
 
-  return (await response.json()) as ClothingItem;
+  return normalizeClothingItemPayload((await response.json()) as ClothingItem);
 }
 
 export async function createClothingItem(
@@ -341,7 +340,7 @@ export async function createClothingItem(
     throw await buildApiError(response);
   }
 
-  return (await response.json()) as ClothingItem;
+  return normalizeClothingItemPayload((await response.json()) as ClothingItem);
 }
 
 export async function createOutfitUpload(
@@ -471,6 +470,36 @@ async function buildApiError(response: Response) {
   }
 }
 
+function normalizeTagList(rawTags: unknown): string[] {
+  if (Array.isArray(rawTags)) {
+    return parseTagInput(rawTags.join(","));
+  }
+
+  if (rawTags && typeof rawTags === "object") {
+    return parseTagInput(Object.values(rawTags as Record<string, unknown>).join(","));
+  }
+
+  if (typeof rawTags === "string") {
+    return parseTagInput(rawTags);
+  }
+
+  return [];
+}
+
+function normalizeClothingItemPayload(item: ClothingItem): ClothingItem {
+  return {
+    ...item,
+    tags: normalizeTagList((item as ClothingItem & { tags?: unknown }).tags),
+  };
+}
+
+function normalizeUserPayload(user: User): User {
+  return {
+    ...user,
+    clothing_items: (user.clothing_items ?? []).map(normalizeClothingItemPayload),
+  };
+}
+
 function buildClothingItemFormData(
   userId: number,
   values: ClothingItemFormValues,
@@ -482,11 +511,9 @@ function buildClothingItemFormData(
   formData.append("clothing_item[user_id]", String(userId));
   formData.append("clothing_item[size]", values.size);
   formData.append("clothing_item[date]", values.date);
-  formData.append("clothing_item[material]", values.material);
-  formData.append("clothing_item[season]", values.season);
-  formData.append("clothing_item[style]", values.style);
-  formData.append("clothing_item[brand]", values.brand);
-  formData.append("clothing_item[color]", values.color);
+  parseTagInput(values.tags).forEach((tag) => {
+    formData.append("clothing_item[tags][]", tag);
+  });
 
   if (photoOptions.photo) {
     formData.append("clothing_item[photo]", photoOptions.photo);


### PR DESCRIPTION
## Summary

This PR adds Milestone 1 closet search/filter/sort functionality and updates clothing items to use a more flexible tag-based metadata model.

### User-facing changes
- adds closet search by item name and descriptive tags
- adds tag filtering and sorting on the main closet page
- updates the add/edit item flow to use flexible tags instead of the older fixed metadata fields
- polishes the closet filter bar layout and control styling

### Internal changes
- converts clothing item tags to a normalized tag-list format across the frontend and backend
- updates seeds, API payload handling, and tests to match the relaxed schema
- adds a `v1.0.3` changelog entry and annotated release tag

## Testing
- `npm run build`
- `bundle exec rails test`
- `RUBOCOP_CACHE_ROOT=tmp/rubocop bundle exec rubocop --no-server ...`


Closes #27 
Closes #9 
