### PR TITLE
Polish Milestone 1 auth feedback and not-found states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.8 - 2026-05-04
+
+- Added visible auth feedback for failed Google sign-in attempts and successful logout on the frontend landing flow.
+- Added a dedicated frontend 404 state for unknown SPA routes instead of falling back to the closet page.
+- Fixed outfit item tag labels to read from the current array-based tag model and removed duplicate env-loader logic from `start.sh`.
+
 ## v1.0.7 - 2026-05-04
 
 - Updated Google sign-in to reuse an existing seeded user when the Google account email already exists in the database.

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -62,6 +62,15 @@ interface OutfitsRouteState {
   kind: "outfits";
 }
 
+interface NotFoundRouteState {
+  kind: "not-found";
+}
+
+interface HomeMessageState {
+  kind: "error" | "success";
+  text: string;
+}
+
 type AppRoute =
   | RouteState
   | ClosetRouteState
@@ -69,7 +78,8 @@ type AppRoute =
   | UsersRouteState
   | UserRouteState
   | NewItemRouteState
-  | OutfitsRouteState;
+  | OutfitsRouteState
+  | NotFoundRouteState;
 
 function isClosetRoute(route: AppRoute) {
   return route.kind === "closet" || route.kind === "item" || route.kind === "new-item";
@@ -84,7 +94,20 @@ function isUsersRoute(route: AppRoute) {
 }
 
 function isProtectedRoute(route: AppRoute) {
-  return route.kind !== "home";
+  return route.kind !== "home" && route.kind !== "not-found";
+}
+
+function authErrorMessage(code: string | null) {
+  switch (code) {
+    case "auth_cancelled":
+      return "Google sign-in was cancelled before it finished.";
+    case "google_auth_failed":
+      return "Google sign-in could not be completed. Please try again.";
+    case "signin_failed":
+      return "Sign-in failed. Please try again.";
+    default:
+      return "We couldn't sign you in. Please try again.";
+  }
 }
 
 function parseCreateItemMode(value: string | null): CreateItemMode {
@@ -133,7 +156,7 @@ function getRouteFromLocation(
     return { kind: "home" };
   }
 
-  return { kind: "closet" };
+  return { kind: "not-found" };
 }
 
 function navigateTo(pathname: string) {
@@ -219,7 +242,7 @@ export default function App() {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
-  const [homeMessage, setHomeMessage] = useState("");
+  const [homeMessage, setHomeMessage] = useState<HomeMessageState | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTag, setSelectedTag] = useState("all");
   const [sortOption, setSortOption] = useState<ClosetSortOption>("name-asc");
@@ -233,7 +256,23 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    const query = new URLSearchParams(window.location.search);
+    const authError = query.get("auth_error");
+    if (!authError) {
+      return;
+    }
+
+    setHomeMessage({ kind: "error", text: authErrorMessage(authError) });
+    query.delete("auth_error");
+
+    const nextSearch = query.toString();
+    const nextUrl = `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ""}`;
+    window.history.replaceState({}, "", nextUrl);
+  }, [route.kind]);
+
+  useEffect(() => {
     if (!isProtectedRoute(route)) {
+      setIsLoading(false);
       return;
     }
 
@@ -248,12 +287,12 @@ export default function App() {
         const nextUser = await fetchClosetOwner(controller.signal);
         if (!nextUser) {
           setUser(null);
-          setHomeMessage(unauthorizedMessage);
+          setHomeMessage({ kind: "error", text: unauthorizedMessage });
           navigateTo("/");
           return;
         }
 
-        setHomeMessage("");
+        setHomeMessage((current) => (current?.kind === "error" ? null : current));
         setUser(nextUser);
       } catch (error) {
         if (!controller.signal.aborted) {
@@ -357,6 +396,7 @@ export default function App() {
         }
 
         setUser(null);
+        setHomeMessage({ kind: "success", text: "Signed out successfully." });
         navigateTo("/");
       }}
       className="inline-flex items-center justify-center gap-3 border border-border px-4 py-2.5 text-sm transition-colors hover:border-foreground"
@@ -418,12 +458,42 @@ export default function App() {
             </button>
           </div>
           {homeMessage ? (
-            <div className="mt-6 border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-              <p style={{ fontFamily: "Outfit, sans-serif" }}>{homeMessage}</p>
+            <div
+              className={`mt-6 px-4 py-3 text-sm ${
+                homeMessage.kind === "success"
+                  ? "border border-emerald-300/40 bg-emerald-50 text-emerald-900"
+                  : "border border-destructive/30 bg-destructive/10 text-destructive"
+              }`}
+            >
+              <p style={{ fontFamily: "Outfit, sans-serif" }}>{homeMessage.text}</p>
             </div>
           ) : null}
         </motion.div>
       </section>
+    );
+  } else if (route.kind === "not-found") {
+    pageContent = (
+      <div className="max-w-3xl mx-auto px-6 py-16">
+        <div className="border border-border bg-card p-8">
+          <p
+            className="uppercase tracking-[0.3em] text-xs text-muted-foreground mb-3"
+            style={{ fontFamily: "Outfit, sans-serif" }}
+          >
+            Page Not Found
+          </p>
+          <h1 className="mb-3">We couldn&apos;t find that page.</h1>
+          <p className="mb-6 text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            The link may be out of date, or the page may have been moved.
+          </p>
+          <button
+            onClick={() => navigateTo(user ? "/closet" : "/")}
+            className="inline-flex items-center justify-center border border-border px-4 py-2.5 text-sm transition-colors hover:border-foreground"
+            style={{ fontFamily: "Outfit, sans-serif" }}
+          >
+            {user ? "Back to closet" : "Back home"}
+          </button>
+        </div>
+      </div>
     );
   } else if (isUnauthorizedAdminRoute) {
     pageContent = (

--- a/front-end/src/app/components/MyOutfitsPage.tsx
+++ b/front-end/src/app/components/MyOutfitsPage.tsx
@@ -7,8 +7,8 @@ import {
   createOutfit,
   destroyOutfit,
   fetchOutfits,
+  formatTagLabel,
   Outfit,
-  titleize,
   updateOutfit,
   User,
 } from "../lib/closet";
@@ -304,7 +304,7 @@ export function MyOutfitsPage({
                     <div className="min-w-0 flex-1">
                       <p className="truncate" style={{ fontFamily: "Outfit, sans-serif" }}>{item.name}</p>
                       <p className="text-xs text-muted-foreground truncate" style={{ fontFamily: "Outfit, sans-serif" }}>
-                        {item.tags.style ? titleize(item.tags.style) : "Unstyled"}
+                        {item.tags.length > 0 ? formatTagLabel(item.tags[0]) : "Unstyled"}
                       </p>
                     </div>
 
@@ -441,7 +441,7 @@ export function MyOutfitsPage({
                           <p style={{ fontFamily: "Outfit, sans-serif" }}>{item.name}</p>
                           <p className="text-xs text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
                             <Shirt className="inline w-3 h-3 mr-1" />
-                            {item.tags.style ? titleize(item.tags.style) : "Unstyled"}
+                            {item.tags.length > 0 ? formatTagLabel(item.tags[0]) : "Unstyled"}
                           </p>
                         </div>
                       </div>

--- a/start.sh
+++ b/start.sh
@@ -6,45 +6,6 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BACKEND_DIR="$ROOT_DIR/back-end"
 FRONTEND_DIR="$ROOT_DIR/front-end"
 
-load_env_file() {
-  local env_file="$1"
-  local line=""
-  local key=""
-  local value=""
-  local line_number=0
-
-  if [[ ! -f "$env_file" ]]; then
-    return
-  fi
-
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    ((line_number += 1))
-    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
-    [[ "$line" =~ ^[[:space:]]*# ]] && continue
-
-    if [[ ! "$line" =~ ^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
-      echo "Skipping unsupported env entry in $env_file at line $line_number" >&2
-      continue
-    fi
-
-    key="${BASH_REMATCH[2]}"
-    value="${BASH_REMATCH[3]}"
-    value="${value%$'\r'}"
-
-    if [[ "$value" =~ ^\"(.*)\"$ ]]; then
-      value="${BASH_REMATCH[1]}"
-    elif [[ "$value" =~ ^\'(.*)\'$ ]]; then
-      value="${BASH_REMATCH[1]}"
-    fi
-
-    if [[ -z "${!key:-}" ]]; then
-      export "$key=$value"
-    fi
-  done < "$env_file"
-}
-
-load_env_file "$BACKEND_DIR/.env"
-
 BACKEND_HOST="${BACKEND_HOST:-127.0.0.1}"
 BACKEND_PORT="${BACKEND_PORT:-3000}"
 FRONTEND_HOST="${FRONTEND_HOST:-127.0.0.1}"


### PR DESCRIPTION
## Summary
Polishes Milestone 1 by tightening frontend auth/error UX and bringing repository documentation up to date with the current app.

## User-Facing Changes
- Added visible feedback for failed Google sign-in attempts and successful logout.
- Added a real frontend 404 state for unknown routes instead of falling back to the closet page.
- Fixed outfit item tag labels so saved outfits display current tag data correctly.

## Internal-Facing Changes
- Updated `README.md`, `wiki.md`, `PROJECT_INDEX.md`, and the backend/frontend READMEs to match the current Milestone 1 implementation.
- Added changelog entries and release tags for the Milestone 1 patch/documentation follow-up.
- Removed duplicate env-loader logic in `start.sh` to reduce script drift.


Closes #31 