### PR TITLE
feat: persist full outfit drafts across closet and outfits flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.10 - 2026-05-04
+
+- Persisted full outfit draft state per user so name, notes, tags, and selected item IDs survive navigation between Closet and My Outfits.
+- Synced My Outfits create-form fields directly with stored draft data to prevent losing in-progress outfit details while adding items.
+- Kept draft item IDs filtered to available closet items when loading persisted drafts, preventing stale references after item deletes.
+
 ## v1.0.9 - 2026-05-04
 
 - Refreshed the root `README.md`, `wiki.md`, and `PROJECT_INDEX.md` so the repository-level documentation matches the Milestone 1 app state.

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -20,12 +20,14 @@ import {
   beginGoogleSignIn,
   ClothingItem,
   CreateItemMode,
+  emptyOutfitDraft,
   fetchClosetOwner,
   formatPossessive,
   formatPreferredStyle,
-  loadOutfitDraftItemIds,
+  loadOutfitDraft,
   logoutSession,
-  saveOutfitDraftItemIds,
+  OutfitDraft,
+  saveOutfitDraft,
   titleize,
   User,
 } from "./lib/closet";
@@ -246,7 +248,7 @@ export default function App() {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTag, setSelectedTag] = useState("all");
   const [sortOption, setSortOption] = useState<ClosetSortOption>("name-asc");
-  const [outfitDraftItemIds, setOutfitDraftItemIds] = useState<number[]>([]);
+  const [outfitDraft, setOutfitDraft] = useState<OutfitDraft>(emptyOutfitDraft());
   const [outfitDraftNotice, setOutfitDraftNotice] = useState("");
 
   useEffect(() => {
@@ -315,13 +317,16 @@ export default function App() {
 
   useEffect(() => {
     if (!user) {
-      setOutfitDraftItemIds([]);
+      setOutfitDraft(emptyOutfitDraft());
       return;
     }
 
     const availableItemIds = new Set(user.clothing_items.map((item) => item.id));
-    const persisted = loadOutfitDraftItemIds(user.id).filter((itemId) => availableItemIds.has(itemId));
-    setOutfitDraftItemIds(persisted);
+    const persisted = loadOutfitDraft(user.id);
+    setOutfitDraft({
+      ...persisted,
+      itemIds: persisted.itemIds.filter((itemId) => availableItemIds.has(itemId)),
+    });
   }, [user?.id, user?.clothing_items]);
 
   useEffect(() => {
@@ -329,8 +334,8 @@ export default function App() {
       return;
     }
 
-    saveOutfitDraftItemIds(user.id, outfitDraftItemIds);
-  }, [outfitDraftItemIds, user]);
+    saveOutfitDraft(user.id, outfitDraft);
+  }, [outfitDraft, user]);
 
   useEffect(() => {
     if (!outfitDraftNotice) {
@@ -356,14 +361,17 @@ export default function App() {
       : null;
 
   function addItemToOutfitDraft(itemId: number) {
-    setOutfitDraftItemIds((current) => {
-      if (current.includes(itemId)) {
+    setOutfitDraft((current) => {
+      if (current.itemIds.includes(itemId)) {
         setOutfitDraftNotice("Already in your outfit draft.");
         return current;
       }
 
       setOutfitDraftNotice("Added to outfit draft.");
-      return [itemId, ...current];
+      return {
+        ...current,
+        itemIds: [itemId, ...current.itemIds],
+      };
     });
   }
 
@@ -584,7 +592,10 @@ export default function App() {
         onItemSaved={(nextItem) => setUser((current) => updateUserItem(current, nextItem))}
         onItemDeleted={(itemId) => {
           setUser((current) => removeUserItem(current, itemId));
-          setOutfitDraftItemIds((current) => current.filter((id) => id !== itemId));
+          setOutfitDraft((current) => ({
+            ...current,
+            itemIds: current.itemIds.filter((id) => id !== itemId),
+          }));
           navigateTo("/closet");
         }}
       />
@@ -593,8 +604,8 @@ export default function App() {
     pageContent = user ? (
       <MyOutfitsPage
         user={user}
-        draftItemIds={outfitDraftItemIds}
-        onDraftChange={setOutfitDraftItemIds}
+        draft={outfitDraft}
+        onDraftChange={setOutfitDraft}
         onBrowseCloset={() => navigateTo("/closet")}
         onOpenItem={(itemId) => navigateTo(`/items/${itemId}`)}
       />
@@ -847,7 +858,7 @@ export default function App() {
           className="fixed bottom-6 right-6 z-50 max-w-sm border border-foreground/20 bg-background/95 px-4 py-3 text-sm shadow-lg backdrop-blur"
           style={{ fontFamily: "Outfit, sans-serif" }}
         >
-          {outfitDraftNotice} Draft has {outfitDraftItemIds.length} {outfitDraftItemIds.length === 1 ? "item" : "items"}.
+          {outfitDraftNotice} Draft has {outfitDraft.itemIds.length} {outfitDraft.itemIds.length === 1 ? "item" : "items"}.
         </motion.div>
       ) : null}
 

--- a/front-end/src/app/components/MyOutfitsPage.tsx
+++ b/front-end/src/app/components/MyOutfitsPage.tsx
@@ -6,8 +6,10 @@ import {
   ClothingItem,
   createOutfit,
   destroyOutfit,
+  emptyOutfitDraft,
   fetchOutfits,
   formatTagLabel,
+  OutfitDraft,
   Outfit,
   updateOutfit,
   User,
@@ -15,8 +17,8 @@ import {
 
 interface MyOutfitsPageProps {
   user: User;
-  draftItemIds: number[];
-  onDraftChange: (itemIds: number[]) => void;
+  draft: OutfitDraft;
+  onDraftChange: (draft: OutfitDraft) => void;
   onBrowseCloset: () => void;
   onOpenItem: (itemId: number) => void;
 }
@@ -28,7 +30,7 @@ interface FlashState {
 
 export function MyOutfitsPage({
   user,
-  draftItemIds,
+  draft,
   onDraftChange,
   onBrowseCloset,
   onOpenItem,
@@ -38,10 +40,10 @@ export function MyOutfitsPage({
   const [flash, setFlash] = useState<FlashState | null>(null);
   const [editingOutfitId, setEditingOutfitId] = useState<number | null>(null);
 
-  const [name, setName] = useState("");
-  const [notes, setNotes] = useState("");
-  const [tagInput, setTagInput] = useState("");
-  const [selectedItemIds, setSelectedItemIds] = useState<number[]>([]);
+  const [name, setName] = useState(draft.name);
+  const [notes, setNotes] = useState(draft.notes);
+  const [tagInput, setTagInput] = useState(draft.tagInput);
+  const [selectedItemIds, setSelectedItemIds] = useState<number[]>(draft.itemIds);
   const [isSaving, setIsSaving] = useState(false);
   const formSectionRef = useRef<HTMLElement | null>(null);
 
@@ -60,13 +62,24 @@ export function MyOutfitsPage({
     setFlash({ kind, message });
   }
 
+  function updateCreateDraft(nextDraft: OutfitDraft) {
+    setName(nextDraft.name);
+    setNotes(nextDraft.notes);
+    setTagInput(nextDraft.tagInput);
+    setSelectedItemIds(nextDraft.itemIds);
+    onDraftChange(nextDraft);
+  }
+
   useEffect(() => {
     if (editingOutfitId) {
       return;
     }
 
-    setSelectedItemIds(draftItemIds);
-  }, [draftItemIds, editingOutfitId]);
+    setName(draft.name);
+    setNotes(draft.notes);
+    setTagInput(draft.tagInput);
+    setSelectedItemIds(draft.itemIds);
+  }, [draft, editingOutfitId]);
 
   useEffect(() => {
     if (!flash) {
@@ -150,7 +163,7 @@ export function MyOutfitsPage({
         });
 
         setOutfits((current) => [createdOutfit, ...current]);
-        onDraftChange([]);
+        updateCreateDraft(emptyOutfitDraft());
         showFlash("success", "Outfit saved.");
       }
 
@@ -178,7 +191,12 @@ export function MyOutfitsPage({
       return;
     }
 
-    onDraftChange(selectedItemIds.filter((id) => id !== itemId));
+    updateCreateDraft({
+      name,
+      notes,
+      tagInput,
+      itemIds: selectedItemIds.filter((id) => id !== itemId),
+    });
   }
 
   function removeEditingItem(itemId: number) {
@@ -197,10 +215,10 @@ export function MyOutfitsPage({
 
   function resetForm() {
     setEditingOutfitId(null);
-    setName("");
-    setNotes("");
-    setTagInput("");
-    setSelectedItemIds(draftItemIds);
+    setName(draft.name);
+    setNotes(draft.notes);
+    setTagInput(draft.tagInput);
+    setSelectedItemIds(draft.itemIds);
   }
 
   return (
@@ -237,7 +255,20 @@ export function MyOutfitsPage({
               </span>
               <input
                 value={name}
-                onChange={(event) => setName(event.target.value)}
+                onChange={(event) => {
+                  const nextValue = event.target.value;
+                  if (editingOutfitId) {
+                    setName(nextValue);
+                    return;
+                  }
+
+                  updateCreateDraft({
+                    name: nextValue,
+                    notes,
+                    tagInput,
+                    itemIds: selectedItemIds,
+                  });
+                }}
                 placeholder="Weekend Brunch"
                 className="w-full border border-border bg-background px-3 py-2"
               />
@@ -249,7 +280,20 @@ export function MyOutfitsPage({
               </span>
               <input
                 value={tagInput}
-                onChange={(event) => setTagInput(event.target.value)}
+                onChange={(event) => {
+                  const nextValue = event.target.value;
+                  if (editingOutfitId) {
+                    setTagInput(nextValue);
+                    return;
+                  }
+
+                  updateCreateDraft({
+                    name,
+                    notes,
+                    tagInput: nextValue,
+                    itemIds: selectedItemIds,
+                  });
+                }}
                 placeholder="casual, spring"
                 className="w-full border border-border bg-background px-3 py-2"
               />
@@ -262,7 +306,20 @@ export function MyOutfitsPage({
             </span>
             <textarea
               value={notes}
-              onChange={(event) => setNotes(event.target.value)}
+              onChange={(event) => {
+                const nextValue = event.target.value;
+                if (editingOutfitId) {
+                  setNotes(nextValue);
+                  return;
+                }
+
+                updateCreateDraft({
+                  name,
+                  notes: nextValue,
+                  tagInput,
+                  itemIds: selectedItemIds,
+                });
+              }}
               placeholder="When and where to wear this look"
               className="w-full border border-border bg-background px-3 py-2 min-h-24"
             />

--- a/front-end/src/app/lib/closet.ts
+++ b/front-end/src/app/lib/closet.ts
@@ -148,49 +148,93 @@ export interface TemporaryCleanImageResult {
   filename: string;
 }
 
-function outfitDraftStorageKey(userId: number) {
-  return `outfit-draft-item-ids:${userId}`;
+export interface OutfitDraft {
+  name: string;
+  notes: string;
+  tagInput: string;
+  itemIds: number[];
 }
 
-export function loadOutfitDraftItemIds(userId: number) {
+export function emptyOutfitDraft(): OutfitDraft {
+  return {
+    name: "",
+    notes: "",
+    tagInput: "",
+    itemIds: [],
+  };
+}
+
+function outfitDraftStorageKey(userId: number) {
+  return `outfit-draft:${userId}`;
+}
+
+function normalizeOutfitDraft(raw: Partial<OutfitDraft> | null | undefined): OutfitDraft {
+  const itemIds = Array.isArray(raw?.itemIds)
+    ? raw.itemIds
+        .map((value) => Number(value))
+        .filter((value, index, array) => Number.isInteger(value) && value > 0 && array.indexOf(value) === index)
+    : [];
+
+  return {
+    name: typeof raw?.name === "string" ? raw.name : "",
+    notes: typeof raw?.notes === "string" ? raw.notes : "",
+    tagInput: typeof raw?.tagInput === "string" ? raw.tagInput : "",
+    itemIds,
+  };
+}
+
+export function loadOutfitDraft(userId: number): OutfitDraft {
   if (typeof window === "undefined") {
-    return [] as number[];
+    return emptyOutfitDraft();
   }
 
   const raw = window.localStorage.getItem(outfitDraftStorageKey(userId));
   if (!raw) {
-    return [] as number[];
+    return emptyOutfitDraft();
   }
 
   try {
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) {
-      return [] as number[];
+    if (!parsed || typeof parsed !== "object") {
+      return emptyOutfitDraft();
     }
 
-    return parsed
-      .map((value) => Number(value))
-      .filter((value) => Number.isInteger(value) && value > 0);
+    return normalizeOutfitDraft(parsed as Partial<OutfitDraft>);
   } catch {
-    return [] as number[];
+    return emptyOutfitDraft();
   }
 }
 
-export function saveOutfitDraftItemIds(userId: number, itemIds: number[]) {
+export function saveOutfitDraft(userId: number, draft: OutfitDraft) {
   if (typeof window === "undefined") {
     return;
   }
 
-  const normalized = itemIds.filter((value, index, array) =>
-    Number.isInteger(value) && value > 0 && array.indexOf(value) === index,
-  );
+  const normalized = normalizeOutfitDraft(draft);
+  const isEmpty =
+    normalized.name.trim().length === 0 &&
+    normalized.notes.trim().length === 0 &&
+    normalized.tagInput.trim().length === 0 &&
+    normalized.itemIds.length === 0;
 
-  if (normalized.length === 0) {
+  if (isEmpty) {
     window.localStorage.removeItem(outfitDraftStorageKey(userId));
     return;
   }
 
   window.localStorage.setItem(outfitDraftStorageKey(userId), JSON.stringify(normalized));
+}
+
+export function loadOutfitDraftItemIds(userId: number) {
+  return loadOutfitDraft(userId).itemIds;
+}
+
+export function saveOutfitDraftItemIds(userId: number, itemIds: number[]) {
+  const existing = loadOutfitDraft(userId);
+  saveOutfitDraft(userId, {
+    ...existing,
+    itemIds,
+  });
 }
 
 export function emptyClothingItemFormValues(): ClothingItemFormValues {


### PR DESCRIPTION
#45 
## Summary
- Persist full outfit draft state per user: name, notes, tags, and selected item IDs.
- Keep draft state when navigating between Closet and My Outfits.
- Sync My Outfits create form with persisted draft data.
- Filter persisted item IDs against currently available closet items to avoid stale references.
- Documented change in CHANGELOG v1.0.10.

## Files Changed
- front-end/src/app/App.tsx
- front-end/src/app/components/MyOutfitsPage.tsx
- front-end/src/app/lib/closet.ts
- CHANGELOG.md

## Validation
- npm run build
- bundle exec rails test