### PR TITLE
Accessibility: Image full screen keyboard activation

### DIFF
--- a/front-end/src/app/components/ItemHeroPreview.tsx
+++ b/front-end/src/app/components/ItemHeroPreview.tsx
@@ -25,6 +25,7 @@ export function ItemHeroPreview({
   title,
 }: ItemHeroPreviewProps) {
   const [isImageExpanded, setIsImageExpanded] = useState(false);
+  const canExpand = Boolean(allowExpand && imageUrl);
 
   return (
     <>
@@ -32,8 +33,21 @@ export function ItemHeroPreview({
         initial={{ opacity: 0, y: 18 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.45 }}
-        onClick={() => allowExpand && imageUrl && setIsImageExpanded(true)}
-        className={`relative aspect-[4/5] overflow-hidden border border-border p-8 flex flex-col justify-between bg-gradient-to-br from-stone-100 via-neutral-50 to-stone-200 ${allowExpand && imageUrl ? "cursor-zoom-in" : ""}`}
+        onClick={() => canExpand && setIsImageExpanded(true)}
+        onKeyDown={(event) => {
+          if (!canExpand) {
+            return;
+          }
+
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            setIsImageExpanded(true);
+          }
+        }}
+        role={canExpand ? "button" : undefined}
+        tabIndex={canExpand ? 0 : undefined}
+        aria-label={canExpand ? `Expand image for ${title}` : undefined}
+        className={`relative aspect-[4/5] overflow-hidden border border-border p-8 flex flex-col justify-between bg-gradient-to-br from-stone-100 via-neutral-50 to-stone-200 ${canExpand ? "cursor-zoom-in" : ""}`}
       >
         {imageUrl && (
           <>
@@ -92,7 +106,7 @@ export function ItemHeroPreview({
         </div>
       </motion.div>
 
-      {allowExpand && imageUrl && (
+      {canExpand && (
         <Dialog open={isImageExpanded} onOpenChange={setIsImageExpanded}>
           <DialogContent className="max-w-[min(92vw,72rem)] border-none bg-black/95 p-4 shadow-2xl sm:p-6">
             <DialogTitle className="sr-only">{title}</DialogTitle>


### PR DESCRIPTION
The expandable hero image preview was mouse-only, so keyboard users could not focus it or open the full image dialog. That made the interaction inaccessible for anyone navigating without a mouse.

This change updates the hero image preview to behave like an accessible interactive control when expansion is available. The preview is now focusable, supports keyboard activation with Enter and Space, and includes an accessible label so assistive technologies can announce its purpose clearly.

Closes #61 