### PR TITLE
Enhancement/consistent UI primatives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Frontend UI Architecture
+
+When building or refactoring frontend UI in this repo, prefer the shared primitives in `front-end/src/app/components/primitives/` before introducing custom button or dropdown markup.
+
+Use these first:
+
+- `front-end/src/app/components/primitives/PrimitiveButton.tsx`
+- `front-end/src/app/components/primitives/PrimitiveSelect.tsx`
+- `front-end/src/app/components/primitives/PrimitiveDropdownMenu.tsx`
+- `front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx`
+
+## Default Rule
+
+- Reuse an existing primitive when it already fits the interaction.
+- If a new visual variation is needed, extend the primitive instead of duplicating styles in page-level or feature-level components.
+- Keep app-specific composition outside the primitives layer, but keep shared interaction patterns, sizing, spacing, and focus treatment inside the primitives layer.
+- Do not hand-roll new button, select trigger, or dropdown trigger styles in feature files unless there is a strong reason the existing primitives cannot support the use case.
+
+## Goal
+
+This project should use a consistent control system for buttons, selects, and dropdowns so new UI work stays visually aligned and easier to maintain.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,14 +10,15 @@ Use these first:
 - `front-end/src/app/components/primitives/PrimitiveSelect.tsx`
 - `front-end/src/app/components/primitives/PrimitiveDropdownMenu.tsx`
 - `front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx`
+- `front-end/src/app/components/primitives/PrimitiveText.tsx`
 
 ## Default Rule
 
 - Reuse an existing primitive when it already fits the interaction.
 - If a new visual variation is needed, extend the primitive instead of duplicating styles in page-level or feature-level components.
 - Keep app-specific composition outside the primitives layer, but keep shared interaction patterns, sizing, spacing, and focus treatment inside the primitives layer.
-- Do not hand-roll new button, select trigger, or dropdown trigger styles in feature files unless there is a strong reason the existing primitives cannot support the use case.
+- Do not hand-roll new button, select trigger, dropdown trigger, or recurring typography styles in feature files unless there is a strong reason the existing primitives cannot support the use case.
 
 ## Goal
 
-This project should use a consistent control system for buttons, selects, and dropdowns so new UI work stays visually aligned and easier to maintain.
+This project should use a consistent control and typography system so new UI work stays visually aligned and easier to maintain.

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useDeferredValue, useEffect, useState } from "react";
 import { motion } from "motion/react";
 import { ArrowLeft, ArrowRight, Search, Users } from "lucide-react";
 import { AddItemMenu } from "./components/AddItemMenu";
@@ -8,15 +8,24 @@ import { ItemDetailPage } from "./components/ItemDetailPage";
 import { MyOutfitsPage } from "./components/MyOutfitsPage";
 import { UserDetailPage } from "./components/UserDetailPage";
 import { UsersDirectoryPage } from "./components/UsersDirectoryPage";
+import {
+  PrimitiveDropdownMenu,
+  PrimitiveDropdownMenuCheckboxItem,
+  PrimitiveDropdownMenuContent,
+  PrimitiveDropdownMenuLabel,
+  PrimitiveDropdownMenuSeparator,
+  PrimitiveDropdownMenuTrigger,
+} from "./components/primitives/PrimitiveDropdownMenu";
+import { PrimitiveDropdownTriggerButton } from "./components/primitives/PrimitiveDropdownTriggerButton";
+import {
+  PrimitiveSelect,
+  PrimitiveSelectContent,
+  PrimitiveSelectItem,
+  PrimitiveSelectTrigger,
+  PrimitiveSelectValue,
+} from "./components/primitives/PrimitiveSelect";
 import { AccessRestrictedState } from "./components/shared/AccessRestrictedState";
 import { Input } from "./components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "./components/ui/select";
 import {
   beginGoogleSignIn,
   ClothingItem,
@@ -29,7 +38,7 @@ import {
   User,
 } from "./lib/closet";
 import {
-  buildTagOptions,
+  buildGroupedTagOptions,
   ClosetSortOption,
   filterClothingItems,
   hasActiveClosetControls,
@@ -49,6 +58,13 @@ import { useOutfitDraftState } from "./lib/useOutfitDraftState";
 interface HomeMessageState {
   kind: "error" | "success";
   text: string;
+}
+
+interface ClosetFilterMenuProps {
+  label: string;
+  options: string[];
+  selectedValues: string[];
+  onToggleValue: (value: string) => void;
 }
 
 function updateUserItem(user: User | null, nextItem: ClothingItem) {
@@ -75,6 +91,55 @@ function removeUserItem(user: User | null, itemId: number) {
   };
 }
 
+function formatFilterMenuTrigger(label: string, selectedValues: string[]) {
+  if (selectedValues.length === 0) {
+    return label;
+  }
+
+  const formattedValues = selectedValues.map(titleize);
+  if (formattedValues.length === 1) {
+    return formattedValues[0];
+  }
+
+  return `${formattedValues[0]} +${formattedValues.length - 1}`;
+}
+
+function ClosetFilterMenu({
+  label,
+  options,
+  selectedValues,
+  onToggleValue,
+}: ClosetFilterMenuProps) {
+  const triggerLabel = formatFilterMenuTrigger(label, selectedValues);
+
+  return (
+    <PrimitiveDropdownMenu>
+      <PrimitiveDropdownMenuTrigger asChild>
+        <PrimitiveDropdownTriggerButton
+          disabled={options.length === 0}
+          style={{ fontFamily: "Outfit, sans-serif" }}
+        >
+          {triggerLabel}
+        </PrimitiveDropdownTriggerButton>
+      </PrimitiveDropdownMenuTrigger>
+      <PrimitiveDropdownMenuContent align="start" className="max-h-80 w-64 overflow-y-auto">
+        <PrimitiveDropdownMenuLabel>{label}</PrimitiveDropdownMenuLabel>
+        <PrimitiveDropdownMenuSeparator />
+        {options.map((option) => (
+          <PrimitiveDropdownMenuCheckboxItem
+            key={option}
+            checked={selectedValues.includes(option)}
+            onCheckedChange={() => onToggleValue(option)}
+            onSelect={(event) => event.preventDefault()}
+          >
+            {titleize(option)}
+          </PrimitiveDropdownMenuCheckboxItem>
+        ))}
+      </PrimitiveDropdownMenuContent>
+    </PrimitiveDropdownMenu>
+  );
+}
+
 export default function App() {
   const [route, setRoute] = useState<AppRoute>(() => getRouteFromLocation());
   const [user, setUser] = useState<User | null>(null);
@@ -82,7 +147,9 @@ export default function App() {
   const [errorMessage, setErrorMessage] = useState("");
   const [homeMessage, setHomeMessage] = useState<HomeMessageState | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedTag, setSelectedTag] = useState("all");
+  const [selectedBrands, setSelectedBrands] = useState<string[]>([]);
+  const [selectedColors, setSelectedColors] = useState<string[]>([]);
+  const [selectedOtherTags, setSelectedOtherTags] = useState<string[]>([]);
   const [sortOption, setSortOption] = useState<ClosetSortOption>("name-asc");
   const [outfitDraftNotice, setOutfitDraftNotice] = useState("");
   const [outfitDraft, setOutfitDraft] = useOutfitDraftState(user);
@@ -172,14 +239,26 @@ export default function App() {
       : null;
   const isAdminRoute = route.kind === "users" || route.kind === "user";
   const isUnauthorizedAdminRoute = Boolean(user && !user.admin && isAdminRoute);
-  const tagOptions = buildTagOptions(clothingItems);
+  const groupedTagOptions = buildGroupedTagOptions(clothingItems);
+  const selectedFilterTags = [...selectedBrands, ...selectedColors, ...selectedOtherTags];
   const filteredClothingItems = filterClothingItems(
     clothingItems,
     deferredSearchQuery,
-    selectedTag,
+    selectedFilterTags,
     sortOption,
   );
-  const hasActiveFilters = hasActiveClosetControls(searchQuery, selectedTag, sortOption);
+  const hasActiveFilters = hasActiveClosetControls(searchQuery, selectedFilterTags, sortOption);
+
+  function toggleSelectedValue(
+    value: string,
+    setSelectedValues: Dispatch<SetStateAction<string[]>>,
+  ) {
+    setSelectedValues((current) =>
+      current.includes(value)
+        ? current.filter((entry) => entry !== value)
+        : [...current, value].sort((left, right) => left.localeCompare(right)),
+    );
+  }
 
   function addItemToOutfitDraft(itemId: number) {
     setOutfitDraft((current) => {
@@ -480,7 +559,7 @@ export default function App() {
               transition={{ duration: 0.6, delay: 0.3 }}
               className="mb-8 space-y-5"
             >
-              <div className="grid gap-3 lg:grid-cols-[minmax(0,1.9fr)_minmax(14rem,1fr)_12rem] lg:items-start">
+              <div className="grid gap-3 min-[660px]:grid-cols-[minmax(0,3.2fr)_repeat(3,minmax(0,0.8fr))_minmax(0,1fr)] min-[660px]:items-start">
                 <div className="relative min-w-0 self-start">
                   <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
@@ -492,52 +571,47 @@ export default function App() {
                 </div>
 
                 <div className="min-w-0">
-                  <Select value={selectedTag} onValueChange={setSelectedTag}>
-                    <SelectTrigger className="h-14 w-full bg-stone-200 hover:bg-stone-200">
-                      <SelectValue placeholder="All tags" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">All tags</SelectItem>
-                      {tagOptions.map((tag) => (
-                        <SelectItem key={tag} value={tag}>
-                          {titleize(tag)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <ClosetFilterMenu
+                    label="Tags"
+                    options={groupedTagOptions.other}
+                    selectedValues={selectedOtherTags}
+                    onToggleValue={(value) => toggleSelectedValue(value, setSelectedOtherTags)}
+                  />
                 </div>
 
-                <Select value={sortOption} onValueChange={(value) => setSortOption(value as ClosetSortOption)}>
-                  <SelectTrigger className="h-14 w-full bg-stone-200 hover:bg-stone-200">
-                    <SelectValue placeholder="Sort items" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="name-asc">Name A-Z</SelectItem>
-                    <SelectItem value="newest-added">Newest added</SelectItem>
-                    <SelectItem value="oldest-added">Oldest added</SelectItem>
-                    <SelectItem value="recent-purchase">Most recent purchase</SelectItem>
-                  </SelectContent>
-                </Select>
+                <div className="min-w-0">
+                  <ClosetFilterMenu
+                    label="Colors"
+                    options={groupedTagOptions.colors}
+                    selectedValues={selectedColors}
+                    onToggleValue={(value) => toggleSelectedValue(value, setSelectedColors)}
+                  />
+                </div>
+
+                <div className="min-w-0">
+                  <ClosetFilterMenu
+                    label="Brands"
+                    options={groupedTagOptions.brands}
+                    selectedValues={selectedBrands}
+                    onToggleValue={(value) => toggleSelectedValue(value, setSelectedBrands)}
+                  />
+                </div>
+
+                <div className="min-w-0">
+                  <PrimitiveSelect value={sortOption} onValueChange={(value) => setSortOption(value as ClosetSortOption)}>
+                    <PrimitiveSelectTrigger className="h-14 w-full bg-stone-200 hover:bg-stone-200">
+                      <PrimitiveSelectValue placeholder="Sort items" />
+                    </PrimitiveSelectTrigger>
+                    <PrimitiveSelectContent>
+                      <PrimitiveSelectItem value="name-asc">Name A-Z</PrimitiveSelectItem>
+                      <PrimitiveSelectItem value="newest-added">Newest added</PrimitiveSelectItem>
+                      <PrimitiveSelectItem value="oldest-added">Oldest added</PrimitiveSelectItem>
+                      <PrimitiveSelectItem value="recent-purchase">Most recent purchase</PrimitiveSelectItem>
+                    </PrimitiveSelectContent>
+                  </PrimitiveSelect>
+                </div>
               </div>
 
-              {hasActiveFilters ? (
-                <div className="flex items-center justify-between gap-4 border border-border bg-card px-4 py-3">
-                  <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
-                    Refine your closet with free-text search, tag filters, and sorting.
-                  </p>
-                  <button
-                    onClick={() => {
-                      setSearchQuery("");
-                      setSelectedTag("all");
-                      setSortOption("name-asc");
-                    }}
-                    className="inline-flex items-center justify-center border border-border px-3 py-2 text-sm transition-colors hover:border-foreground"
-                    style={{ fontFamily: "Outfit, sans-serif" }}
-                  >
-                    Clear filters
-                  </button>
-                </div>
-              ) : null}
             </motion.div>
 
             {user && filteredClothingItems.length > 0 ? (
@@ -581,27 +655,20 @@ export default function App() {
       <header className="border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85">
         <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-6 py-5">
           <button
-            onClick={() => navigateTo("/")}
-            className="inline-flex items-center justify-center border border-border px-4 py-2.5 text-sm transition-colors hover:border-foreground"
+            onClick={() => navigateTo(user ? "/closet" : "/")}
+            className={`inline-flex items-center justify-center border px-4 py-2.5 text-sm transition-colors ${
+              user && isClosetRoute(route)
+                ? "border-foreground bg-foreground text-background"
+                : "border-border hover:border-foreground"
+            }`}
             style={{ fontFamily: "Outfit, sans-serif" }}
           >
-            Home
+            {user ? "Closet" : "Home"}
           </button>
 
           <div className="flex items-center gap-3">
             {user ? (
               <nav className="flex items-center gap-2">
-                <button
-                  onClick={() => navigateTo("/closet")}
-                  className={`inline-flex items-center justify-center border px-4 py-2.5 text-sm transition-colors ${
-                    isClosetRoute(route)
-                      ? "border-foreground bg-foreground text-background"
-                      : "border-border text-foreground hover:border-foreground"
-                  }`}
-                  style={{ fontFamily: "Outfit, sans-serif" }}
-                >
-                  Closet
-                </button>
                 <button
                   onClick={() => navigateTo("/outfits")}
                   className={`inline-flex items-center justify-center border px-4 py-2.5 text-sm transition-colors ${

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useDeferredValue, useEffect, useState } from "react";
 import { motion } from "motion/react";
-import { ArrowLeft, ArrowRight, Search, Users } from "lucide-react";
+import { ArrowLeft, ArrowRight, Search, Users, X } from "lucide-react";
 import { AddItemMenu } from "./components/AddItemMenu";
 import { ClothingCard } from "./components/ClothingCard";
 import { CreateItemPage } from "./components/CreateItemPage";
@@ -68,6 +68,7 @@ interface ClosetFilterMenuProps {
   label: string;
   options: string[];
   selectedValues: string[];
+  onClear: () => void;
   onToggleValue: (value: string) => void;
 }
 
@@ -112,34 +113,55 @@ function ClosetFilterMenu({
   label,
   options,
   selectedValues,
+  onClear,
   onToggleValue,
 }: ClosetFilterMenuProps) {
   const triggerLabel = formatFilterMenuTrigger(label, selectedValues);
+  const hasSelections = selectedValues.length > 0;
 
   return (
-    <PrimitiveDropdownMenu>
-      <PrimitiveDropdownMenuTrigger asChild>
-        <PrimitiveDropdownTriggerButton
-          disabled={options.length === 0}
-        >
-          {triggerLabel}
-        </PrimitiveDropdownTriggerButton>
-      </PrimitiveDropdownMenuTrigger>
-      <PrimitiveDropdownMenuContent align="start" className="max-h-80 w-64 overflow-y-auto">
-        <PrimitiveDropdownMenuLabel>{label}</PrimitiveDropdownMenuLabel>
-        <PrimitiveDropdownMenuSeparator />
-        {options.map((option) => (
-          <PrimitiveDropdownMenuCheckboxItem
-            key={option}
-            checked={selectedValues.includes(option)}
-            onCheckedChange={() => onToggleValue(option)}
-            onSelect={(event) => event.preventDefault()}
+    <div className="relative">
+      <PrimitiveDropdownMenu>
+        <PrimitiveDropdownMenuTrigger asChild>
+          <PrimitiveDropdownTriggerButton
+            disabled={options.length === 0}
+            className={hasSelections ? "pr-16" : undefined}
           >
-            {titleize(option)}
-          </PrimitiveDropdownMenuCheckboxItem>
-        ))}
-      </PrimitiveDropdownMenuContent>
-    </PrimitiveDropdownMenu>
+            {triggerLabel}
+          </PrimitiveDropdownTriggerButton>
+        </PrimitiveDropdownMenuTrigger>
+        <PrimitiveDropdownMenuContent align="start" className="max-h-80 w-64 overflow-y-auto">
+          <PrimitiveDropdownMenuLabel>{label}</PrimitiveDropdownMenuLabel>
+          <PrimitiveDropdownMenuSeparator />
+          {options.map((option) => (
+            <PrimitiveDropdownMenuCheckboxItem
+              key={option}
+              checked={selectedValues.includes(option)}
+              onCheckedChange={() => onToggleValue(option)}
+              onSelect={(event) => event.preventDefault()}
+            >
+              {titleize(option)}
+            </PrimitiveDropdownMenuCheckboxItem>
+          ))}
+        </PrimitiveDropdownMenuContent>
+      </PrimitiveDropdownMenu>
+      {hasSelections ? (
+        <PrimitiveButton
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="absolute top-1/2 right-7 z-10 size-7 -translate-y-1/2 rounded-full text-destructive hover:bg-destructive/10 hover:text-destructive"
+          onClick={(event) => {
+            event.stopPropagation();
+            onClear();
+          }}
+          aria-label={`Clear ${label.toLowerCase()} filters`}
+          title={`Clear ${label.toLowerCase()} filters`}
+        >
+          <X className="size-4" />
+        </PrimitiveButton>
+      ) : null}
+    </div>
   );
 }
 
@@ -261,6 +283,10 @@ export default function App() {
         ? current.filter((entry) => entry !== value)
         : [...current, value].sort((left, right) => left.localeCompare(right)),
     );
+  }
+
+  function clearSelectedValues(setSelectedValues: Dispatch<SetStateAction<string[]>>) {
+    setSelectedValues([]);
   }
 
   function addItemToOutfitDraft(itemId: number) {
@@ -584,6 +610,7 @@ export default function App() {
                     label="Tags"
                     options={groupedTagOptions.other}
                     selectedValues={selectedOtherTags}
+                    onClear={() => clearSelectedValues(setSelectedOtherTags)}
                     onToggleValue={(value) => toggleSelectedValue(value, setSelectedOtherTags)}
                   />
                 </div>
@@ -593,6 +620,7 @@ export default function App() {
                     label="Colors"
                     options={groupedTagOptions.colors}
                     selectedValues={selectedColors}
+                    onClear={() => clearSelectedValues(setSelectedColors)}
                     onToggleValue={(value) => toggleSelectedValue(value, setSelectedColors)}
                   />
                 </div>
@@ -602,6 +630,7 @@ export default function App() {
                     label="Brands"
                     options={groupedTagOptions.brands}
                     selectedValues={selectedBrands}
+                    onClear={() => clearSelectedValues(setSelectedBrands)}
                     onToggleValue={(value) => toggleSelectedValue(value, setSelectedBrands)}
                   />
                 </div>

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -9,6 +9,9 @@ import { MyOutfitsPage } from "./components/MyOutfitsPage";
 import { UserDetailPage } from "./components/UserDetailPage";
 import { UsersDirectoryPage } from "./components/UsersDirectoryPage";
 import {
+  PrimitiveButton,
+} from "./components/primitives/PrimitiveButton";
+import {
   PrimitiveDropdownMenu,
   PrimitiveDropdownMenuCheckboxItem,
   PrimitiveDropdownMenuContent,
@@ -24,6 +27,7 @@ import {
   PrimitiveSelectTrigger,
   PrimitiveSelectValue,
 } from "./components/primitives/PrimitiveSelect";
+import { PrimitiveText } from "./components/primitives/PrimitiveText";
 import { AccessRestrictedState } from "./components/shared/AccessRestrictedState";
 import { Input } from "./components/ui/input";
 import {
@@ -117,7 +121,6 @@ function ClosetFilterMenu({
       <PrimitiveDropdownMenuTrigger asChild>
         <PrimitiveDropdownTriggerButton
           disabled={options.length === 0}
-          style={{ fontFamily: "Outfit, sans-serif" }}
         >
           {triggerLabel}
         </PrimitiveDropdownTriggerButton>
@@ -289,23 +292,21 @@ export default function App() {
   }
 
   const globalAction = user ? (
-    <button
+    <PrimitiveButton
       onClick={() => void handleLogout()}
-      className="inline-flex items-center justify-center gap-3 border border-border px-4 py-2.5 text-sm transition-colors hover:border-foreground"
-      style={{ fontFamily: "Outfit, sans-serif" }}
+      variant="outline"
     >
       <Users className="h-4 w-4" />
       Sign Out
-    </button>
+    </PrimitiveButton>
   ) : (
-    <button
+    <PrimitiveButton
       onClick={() => beginGoogleSignIn()}
-      className="inline-flex items-center justify-center gap-3 border border-border px-4 py-2.5 text-sm transition-colors hover:border-foreground"
-      style={{ fontFamily: "Outfit, sans-serif" }}
+      variant="outline"
     >
       Sign In
       <ArrowRight className="h-4 w-4" />
-    </button>
+    </PrimitiveButton>
   );
 
   let pageContent;
@@ -323,31 +324,36 @@ export default function App() {
           transition={{ duration: 0.5 }}
           className="max-w-2xl text-center"
         >
-          <h1
+          <PrimitiveText
+            as="h1"
+            variant="display"
+            font="serif"
             className="mb-6"
             style={{
-              fontFamily: "Cormorant Garamond, serif",
               fontSize: "clamp(3rem, 8vw, 5.5rem)",
               lineHeight: "0.95",
             }}
           >
             Closet Organizer
-          </h1>
-          <p
-            className="mb-10 text-lg text-muted-foreground"
-            style={{ fontFamily: "Outfit, sans-serif", lineHeight: "1.7" }}
+          </PrimitiveText>
+          <PrimitiveText
+            as="p"
+            variant="title"
+            tone="muted"
+            className="mb-10"
+            style={{ lineHeight: "1.7" }}
           >
             Organize clothing items, manage closet details.
-          </p>
+          </PrimitiveText>
           <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
-            <button
+            <PrimitiveButton
               onClick={() => beginGoogleSignIn()}
-              className="inline-flex items-center justify-center gap-3 border border-border px-6 py-3 transition-colors hover:border-foreground"
-              style={{ fontFamily: "Outfit, sans-serif" }}
+              variant="outline"
+              className="h-auto px-6 py-3"
             >
               Sign in with Google
               <ArrowRight className="h-4 w-4" />
-            </button>
+            </PrimitiveButton>
           </div>
           {homeMessage ? (
             <div
@@ -357,7 +363,7 @@ export default function App() {
                   : "border border-destructive/30 bg-destructive/10 text-destructive"
               }`}
             >
-              <p style={{ fontFamily: "Outfit, sans-serif" }}>{homeMessage.text}</p>
+              <PrimitiveText as="p" variant="bodySm">{homeMessage.text}</PrimitiveText>
             </div>
           ) : null}
         </motion.div>
@@ -367,23 +373,21 @@ export default function App() {
     pageContent = (
       <div className="max-w-3xl mx-auto px-6 py-16">
         <div className="border border-border bg-card p-8">
-          <p
-            className="uppercase tracking-[0.3em] text-xs text-muted-foreground mb-3"
-            style={{ fontFamily: "Outfit, sans-serif" }}
-          >
+          <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
             Page Not Found
-          </p>
-          <h1 className="mb-3">We couldn&apos;t find that page.</h1>
-          <p className="mb-6 text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+          </PrimitiveText>
+          <PrimitiveText as="h1" variant="display" font="serif" className="mb-3">
+            We couldn&apos;t find that page.
+          </PrimitiveText>
+          <PrimitiveText as="p" tone="muted" className="mb-6">
             The link may be out of date, or the page may have been moved.
-          </p>
-          <button
+          </PrimitiveText>
+          <PrimitiveButton
             onClick={() => navigateTo(user ? "/closet" : "/")}
-            className="inline-flex items-center justify-center border border-border px-4 py-2.5 text-sm transition-colors hover:border-foreground"
-            style={{ fontFamily: "Outfit, sans-serif" }}
+            variant="outline"
           >
             {user ? "Back to closet" : "Back home"}
-          </button>
+          </PrimitiveButton>
         </div>
       </div>
     );
@@ -479,32 +483,37 @@ export default function App() {
       <div className="max-w-7xl mx-auto px-6 py-12">
         <div className="mb-8 flex flex-col items-start justify-between gap-6 md:flex-row md:items-end">
           <div>
-            <motion.h1
+            <motion.div
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8 }}
-              className="mb-2 tracking-tight"
-              style={{
-                fontFamily: "Cormorant Garamond, serif",
-                fontSize: "clamp(2.5rem, 5vw, 4rem)",
-                lineHeight: "1",
-              }}
             >
-              {closetTitle}
-            </motion.h1>
-            <motion.p
+              <PrimitiveText
+                as="h1"
+                variant="display"
+                font="serif"
+                className="mb-2 tracking-tight"
+                style={{
+                  fontSize: "clamp(2.5rem, 5vw, 4rem)",
+                  lineHeight: "1",
+                }}
+              >
+                {closetTitle}
+              </PrimitiveText>
+            </motion.div>
+            <motion.div
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ duration: 0.8, delay: 0.2 }}
-              className="tracking-wide text-muted-foreground"
-              style={{ fontFamily: "Outfit, sans-serif" }}
             >
-              {isLoading
-                ? "Loading items from your backend..."
-                : `${clothingItems.length} ${clothingItems.length === 1 ? "item" : "items"}${
-                    preferredStyle ? ` · ${preferredStyle} style` : ""
-                  }`}
-            </motion.p>
+              <PrimitiveText as="p" tone="muted" className="tracking-wide">
+                {isLoading
+                  ? "Loading items from your backend..."
+                  : `${clothingItems.length} ${clothingItems.length === 1 ? "item" : "items"}${
+                      preferredStyle ? ` · ${preferredStyle} style` : ""
+                    }`}
+              </PrimitiveText>
+            </motion.div>
           </div>
 
           <motion.div
@@ -534,12 +543,12 @@ export default function App() {
 
         {errorMessage ? (
           <div className="border border-destructive/20 bg-destructive/5 p-6">
-            <p className="mb-2 text-lg" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+            <PrimitiveText as="p" variant="title" font="serif" className="mb-2">
               The closet data could not be loaded.
-            </p>
-            <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
               {errorMessage}. Make sure both dev servers are running through `./start.sh`.
-            </p>
+            </PrimitiveText>
           </div>
         ) : isLoading ? (
           <div className="grid grid-cols-1 gap-x-6 gap-y-12 sm:grid-cols-2 lg:grid-cols-4">
@@ -628,16 +637,16 @@ export default function App() {
               </div>
             ) : (
               <div className="border border-dashed border-border p-10 text-center">
-                <p className="mb-3 text-2xl" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+                <PrimitiveText as="p" variant="display" font="serif" className="mb-3">
                   {user ? "No matching items found" : "No closet data found"}
-                </p>
-                <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                </PrimitiveText>
+                <PrimitiveText as="p" tone="muted">
                   {user
                     ? hasActiveFilters
                       ? "Try a different tag, search phrase, or sort."
                       : "Add a new item to start building out this closet."
                     : "Sign in with Google to load your closet."}
-                </p>
+                </PrimitiveText>
               </div>
             )}
           </>
@@ -654,44 +663,44 @@ export default function App() {
     <div className="flex min-h-screen flex-col bg-background">
       <header className="border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85">
         <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-6 py-5">
-          <button
+          <PrimitiveButton
             onClick={() => navigateTo(user ? "/closet" : "/")}
-            className={`inline-flex items-center justify-center border px-4 py-2.5 text-sm transition-colors ${
+            variant="outline"
+            className={`${
               user && isClosetRoute(route)
                 ? "border-foreground bg-foreground text-background"
                 : "border-border hover:border-foreground"
             }`}
-            style={{ fontFamily: "Outfit, sans-serif" }}
           >
             {user ? "Closet" : "Home"}
-          </button>
+          </PrimitiveButton>
 
           <div className="flex items-center gap-3">
             {user ? (
               <nav className="flex items-center gap-2">
-                <button
+                <PrimitiveButton
                   onClick={() => navigateTo("/outfits")}
-                  className={`inline-flex items-center justify-center border px-4 py-2.5 text-sm transition-colors ${
+                  variant="outline"
+                  className={`${
                     isOutfitRoute(route)
                       ? "border-foreground bg-foreground text-background"
                       : "border-border text-foreground hover:border-foreground"
                   }`}
-                  style={{ fontFamily: "Outfit, sans-serif" }}
                 >
                   My Outfits
-                </button>
+                </PrimitiveButton>
                 {user.admin ? (
-                  <button
+                  <PrimitiveButton
                     onClick={() => navigateTo("/users")}
-                    className={`inline-flex items-center justify-center border px-4 py-2.5 text-sm transition-colors ${
+                    variant="outline"
+                    className={`${
                       isUsersRoute(route)
                         ? "border-foreground bg-foreground text-background"
                         : "border-border text-foreground hover:border-foreground"
                     }`}
-                    style={{ fontFamily: "Outfit, sans-serif" }}
                   >
                     Users
-                  </button>
+                  </PrimitiveButton>
                 ) : null}
               </nav>
             ) : null}
@@ -707,7 +716,6 @@ export default function App() {
           initial={{ opacity: 0, y: 14 }}
           animate={{ opacity: 1, y: 0 }}
           className="fixed bottom-6 right-6 z-50 max-w-sm border border-foreground/20 bg-background/95 px-4 py-3 text-sm shadow-lg backdrop-blur"
-          style={{ fontFamily: "Outfit, sans-serif" }}
         >
           {outfitDraftNotice} Draft has {outfitDraft.itemIds.length}{" "}
           {outfitDraft.itemIds.length === 1 ? "item" : "items"}.
@@ -716,10 +724,10 @@ export default function App() {
 
       <footer className="border-t border-border">
         <div className="mx-auto flex max-w-7xl flex-col gap-2 px-6 py-5 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-          <p style={{ fontFamily: "Outfit, sans-serif" }}>
+          <PrimitiveText as="p" variant="bodySm">
             Curating closets and serving looks, one hanger at a time.
-          </p>
-          <p style={{ fontFamily: "Outfit, sans-serif" }}>Pressed, polished, and ready for the runway.</p>
+          </PrimitiveText>
+          <PrimitiveText as="p" variant="bodySm">Pressed, polished, and ready for the runway.</PrimitiveText>
         </div>
       </footer>
     </div>

--- a/front-end/src/app/components/AddItemMenu.tsx
+++ b/front-end/src/app/components/AddItemMenu.tsx
@@ -41,7 +41,7 @@ export function AddItemMenu({
           <Camera className="w-4 h-4" />
           <div className="flex flex-col">
             <PrimitiveText as="span" variant="bodySm">
-              Upload image
+              Detect Items from Image
             </PrimitiveText>
             <PrimitiveText as="span" variant="caption" tone="muted">
               Choose a photo in the next step before reviewing detected items.
@@ -52,7 +52,7 @@ export function AddItemMenu({
           <PencilLine className="w-4 h-4" />
           <div className="flex flex-col">
             <PrimitiveText as="span" variant="bodySm">
-              Upload manually
+              Add Item
             </PrimitiveText>
             <PrimitiveText as="span" variant="caption" tone="muted">
               Enter the item details yourself.

--- a/front-end/src/app/components/AddItemMenu.tsx
+++ b/front-end/src/app/components/AddItemMenu.tsx
@@ -5,6 +5,7 @@ import {
   PrimitiveDropdownMenuItem,
   PrimitiveDropdownMenuTrigger,
 } from "./primitives/PrimitiveDropdownMenu";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 
 interface AddItemMenuProps {
@@ -21,17 +22,18 @@ export function AddItemMenu({
   return (
     <PrimitiveDropdownMenu>
       <PrimitiveDropdownMenuTrigger asChild>
-        <button
+        <PrimitiveButton
           type="button"
           disabled={disabled}
-          className="flex items-center justify-center gap-3 px-5 py-3 border border-border hover:border-foreground transition-colors disabled:opacity-50"
+          variant="outline"
+          className="h-auto gap-3 px-5 py-3"
         >
           <Plus className="w-4 h-4" />
           <PrimitiveText as="span" variant="bodySm">
             Add Item
           </PrimitiveText>
           <ChevronDown className="w-4 h-4" />
-        </button>
+        </PrimitiveButton>
       </PrimitiveDropdownMenuTrigger>
 
       <PrimitiveDropdownMenuContent align="end" className="w-56">

--- a/front-end/src/app/components/AddItemMenu.tsx
+++ b/front-end/src/app/components/AddItemMenu.tsx
@@ -1,10 +1,10 @@
 import { Camera, ChevronDown, PencilLine, Plus } from "lucide-react";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "./ui/dropdown-menu";
+  PrimitiveDropdownMenu,
+  PrimitiveDropdownMenuContent,
+  PrimitiveDropdownMenuItem,
+  PrimitiveDropdownMenuTrigger,
+} from "./primitives/PrimitiveDropdownMenu";
 
 interface AddItemMenuProps {
   disabled?: boolean;
@@ -18,8 +18,8 @@ export function AddItemMenu({
   onSelectManual,
 }: AddItemMenuProps) {
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
+    <PrimitiveDropdownMenu>
+      <PrimitiveDropdownMenuTrigger asChild>
         <button
           type="button"
           disabled={disabled}
@@ -30,24 +30,24 @@ export function AddItemMenu({
           Add Item
           <ChevronDown className="w-4 h-4" />
         </button>
-      </DropdownMenuTrigger>
+      </PrimitiveDropdownMenuTrigger>
 
-      <DropdownMenuContent align="end" className="w-56">
-        <DropdownMenuItem onSelect={onSelectImage}>
+      <PrimitiveDropdownMenuContent align="end" className="w-56">
+        <PrimitiveDropdownMenuItem onSelect={onSelectImage}>
           <Camera className="w-4 h-4" />
           <div className="flex flex-col">
             <span>Upload image</span>
             <span className="text-xs text-muted-foreground">Choose a photo in the next step before reviewing detected items.</span>
           </div>
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onSelectManual}>
+        </PrimitiveDropdownMenuItem>
+        <PrimitiveDropdownMenuItem onSelect={onSelectManual}>
           <PencilLine className="w-4 h-4" />
           <div className="flex flex-col">
             <span>Upload manually</span>
             <span className="text-xs text-muted-foreground">Enter the item details yourself.</span>
           </div>
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+        </PrimitiveDropdownMenuItem>
+      </PrimitiveDropdownMenuContent>
+    </PrimitiveDropdownMenu>
   );
 }

--- a/front-end/src/app/components/AddItemMenu.tsx
+++ b/front-end/src/app/components/AddItemMenu.tsx
@@ -5,6 +5,7 @@ import {
   PrimitiveDropdownMenuItem,
   PrimitiveDropdownMenuTrigger,
 } from "./primitives/PrimitiveDropdownMenu";
+import { PrimitiveText } from "./primitives/PrimitiveText";
 
 interface AddItemMenuProps {
   disabled?: boolean;
@@ -24,10 +25,11 @@ export function AddItemMenu({
           type="button"
           disabled={disabled}
           className="flex items-center justify-center gap-3 px-5 py-3 border border-border hover:border-foreground transition-colors disabled:opacity-50"
-          style={{ fontFamily: "Outfit, sans-serif" }}
         >
           <Plus className="w-4 h-4" />
-          Add Item
+          <PrimitiveText as="span" variant="bodySm">
+            Add Item
+          </PrimitiveText>
           <ChevronDown className="w-4 h-4" />
         </button>
       </PrimitiveDropdownMenuTrigger>
@@ -36,15 +38,23 @@ export function AddItemMenu({
         <PrimitiveDropdownMenuItem onSelect={onSelectImage}>
           <Camera className="w-4 h-4" />
           <div className="flex flex-col">
-            <span>Upload image</span>
-            <span className="text-xs text-muted-foreground">Choose a photo in the next step before reviewing detected items.</span>
+            <PrimitiveText as="span" variant="bodySm">
+              Upload image
+            </PrimitiveText>
+            <PrimitiveText as="span" variant="caption" tone="muted">
+              Choose a photo in the next step before reviewing detected items.
+            </PrimitiveText>
           </div>
         </PrimitiveDropdownMenuItem>
         <PrimitiveDropdownMenuItem onSelect={onSelectManual}>
           <PencilLine className="w-4 h-4" />
           <div className="flex flex-col">
-            <span>Upload manually</span>
-            <span className="text-xs text-muted-foreground">Enter the item details yourself.</span>
+            <PrimitiveText as="span" variant="bodySm">
+              Upload manually
+            </PrimitiveText>
+            <PrimitiveText as="span" variant="caption" tone="muted">
+              Enter the item details yourself.
+            </PrimitiveText>
           </div>
         </PrimitiveDropdownMenuItem>
       </PrimitiveDropdownMenuContent>

--- a/front-end/src/app/components/AiCleanImageButton.tsx
+++ b/front-end/src/app/components/AiCleanImageButton.tsx
@@ -1,4 +1,5 @@
 import { Sparkles } from "lucide-react";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
 
 interface AiCleanImageButtonProps {
   className?: string;
@@ -16,14 +17,15 @@ export function AiCleanImageButton({
   onClick,
 }: AiCleanImageButtonProps) {
   return (
-    <button
+    <PrimitiveButton
       type="button"
       onClick={onClick}
       disabled={disabled || isLoading}
-      className={`inline-flex items-center gap-2 px-4 py-2 border border-border hover:border-foreground transition-colors disabled:opacity-50 ${className}`.trim()}
+      variant="outline"
+      className={className}
     >
       <Sparkles className="w-4 h-4" />
       {isLoading ? "Cleaning..." : label}
-    </button>
+    </PrimitiveButton>
   );
 }

--- a/front-end/src/app/components/ClothingCard.tsx
+++ b/front-end/src/app/components/ClothingCard.tsx
@@ -1,6 +1,7 @@
 import { motion } from "motion/react";
 import { Plus } from "lucide-react";
 import { useState } from "react";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 import {
   formatDisplaySize,
@@ -111,18 +112,18 @@ export function ClothingCard({
           animate={{ opacity: isHovered ? 1 : 0, y: isHovered ? 0 : 20 }}
           className="absolute bottom-4 left-4 right-4"
         >
-          <button
+          <PrimitiveButton
             onClick={(event) => {
               event.stopPropagation();
               onAddToOutfit?.(id);
             }}
-            className="w-full bg-white/90 backdrop-blur-sm px-4 py-2 hover:bg-white transition-colors flex items-center justify-center gap-2"
+            className="h-auto w-full bg-white/90 px-4 py-2 backdrop-blur-sm hover:bg-white"
           >
             <Plus className="w-5 h-5" />
             <PrimitiveText as="span" variant="bodySm">
               Add to Outfit
             </PrimitiveText>
-          </button>
+          </PrimitiveButton>
         </motion.div>
       </div>
     </motion.div>

--- a/front-end/src/app/components/ClothingCard.tsx
+++ b/front-end/src/app/components/ClothingCard.tsx
@@ -1,9 +1,10 @@
 import { motion } from "motion/react";
 import { Plus } from "lucide-react";
 import { useState } from "react";
+import { PrimitiveText } from "./primitives/PrimitiveText";
 import {
-  formatTagLabel,
   formatDisplaySize,
+  formatTagLabel,
 } from "../lib/closet";
 
 interface ClothingCardProps {
@@ -29,7 +30,8 @@ export function ClothingCard({
 }: ClothingCardProps) {
   const [isHovered, setIsHovered] = useState(false);
   const visibleTags = tags.slice(0, 3);
-  const itemMetadata = visibleTags.map(formatTagLabel).join(" · ");
+  const detailParts = [formatDisplaySize(size), ...visibleTags.slice(1).map(formatTagLabel)];
+  const itemMetadata = detailParts.join(" · ");
   const handleSelect = () => onSelect?.(id);
 
   return (
@@ -69,20 +71,14 @@ export function ClothingCard({
           >
             <div className="space-y-2">
               {tags[0] && (
-                <p
-                  className="uppercase tracking-[0.25em] text-xs"
-                  style={{ fontFamily: "Outfit, sans-serif" }}
-                >
+                <PrimitiveText as="p" variant="overline">
                   {formatTagLabel(tags[0])}
-                </p>
+                </PrimitiveText>
               )}
               {itemMetadata && (
-                <p
-                  className="text-sm opacity-70"
-                  style={{ fontFamily: "Outfit, sans-serif" }}
-                >
+                <PrimitiveText as="p" variant="bodySm" className="opacity-70">
                   {itemMetadata}
-                </p>
+                </PrimitiveText>
               )}
             </div>
           </div>
@@ -94,27 +90,20 @@ export function ClothingCard({
           className="absolute inset-0 bg-gradient-to-t from-neutral-950/88 via-neutral-900/46 to-neutral-900/10"
         />
 
-        <div className="absolute inset-x-0 top-0 p-5">
-          <p
-            className="uppercase tracking-[0.3em] text-[11px] mb-3"
-            style={{
-              color: image_url ? "rgba(255,255,255,0.75)" : "rgba(68,64,60,0.72)",
-              fontFamily: "Outfit, sans-serif",
-            }}
-          >
-            Clothing Item
-          </p>
-          <h3
+        <div className="absolute inset-x-0 top-0 p-5 pt-8">
+          <PrimitiveText
+            as="h3"
+            variant="display"
+            font="serif"
             className="max-w-[11ch] break-words"
             style={{
               color: image_url ? "white" : "rgba(68, 64, 60, 0.92)",
-              fontFamily: "Cormorant Garamond, serif",
               fontSize: "clamp(2rem, 4vw, 3rem)",
               lineHeight: "0.95",
             }}
           >
             {name}
-          </h3>
+          </PrimitiveText>
         </div>
 
         <motion.div
@@ -130,26 +119,11 @@ export function ClothingCard({
             className="w-full bg-white/90 backdrop-blur-sm px-4 py-2 hover:bg-white transition-colors flex items-center justify-center gap-2"
           >
             <Plus className="w-5 h-5" />
-            <span style={{ fontFamily: 'Outfit, sans-serif' }}>Add to Outfit</span>
+            <PrimitiveText as="span" variant="bodySm">
+              Add to Outfit
+            </PrimitiveText>
           </button>
         </motion.div>
-      </div>
-
-      <div className="mt-3 space-y-1">
-        <div className="flex items-center gap-2 text-muted-foreground" style={{ fontFamily: 'Outfit, sans-serif' }}>
-          <span className="uppercase tracking-wider">{formatDisplaySize(size)}</span>
-          {tags[0] && (
-            <>
-              <span>·</span>
-              <span>{formatTagLabel(tags[0])}</span>
-            </>
-          )}
-        </div>
-        {tags[1] && (
-          <p className="italic opacity-60" style={{ fontFamily: 'Outfit, sans-serif' }}>
-            {visibleTags.slice(1).map(formatTagLabel).join(" · ")}
-          </p>
-        )}
       </div>
     </motion.div>
   );

--- a/front-end/src/app/components/CreateItemPage.tsx
+++ b/front-end/src/app/components/CreateItemPage.tsx
@@ -25,6 +25,7 @@ import { AiCleanImageButton } from "./AiCleanImageButton";
 import { CreateItemImageMode } from "./create-item/CreateItemImageMode";
 import { ItemMetadataFields } from "./ItemMetadataFields";
 import { ItemPhotoField } from "./ItemPhotoField";
+import { PrimitiveText } from "./primitives/PrimitiveText";
 import { UploadWorkspace } from "./UploadWorkspace";
 import { useItemPhotoState } from "../lib/useItemPhotoState";
 
@@ -353,12 +354,12 @@ export function CreateItemPage({
           Back
         </button>
         <div className="border border-destructive/20 bg-destructive/5 p-6">
-          <p className="text-lg mb-2" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+          <PrimitiveText as="p" variant="title" font="serif" className="mb-2">
             A user is required before you can add an item.
-          </p>
-          <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+          </PrimitiveText>
+          <PrimitiveText as="p" tone="muted">
             {errorMessage || "Pick a valid user and try again."}
-          </p>
+          </PrimitiveText>
         </div>
       </div>
     );
@@ -422,13 +423,15 @@ export function CreateItemPage({
           previewTitle={previewName}
         >
           <div>
-            <p className="uppercase tracking-[0.3em] text-xs text-muted-foreground mb-3">
+            <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
               Add Item
-            </p>
-            <h2 className="mb-1">Create New Item</h2>
-            <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            </PrimitiveText>
+            <PrimitiveText as="h2" variant="title" font="serif" className="mb-1">
+              Create New Item
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
               Fill in the details for {titleize(user.username)} and create a new clothing item in Rails.
-            </p>
+            </PrimitiveText>
           </div>
 
           {errorMessage && (
@@ -447,11 +450,11 @@ export function CreateItemPage({
             />
 
             <div className="mt-4 flex flex-wrap items-center justify-between gap-4 border border-border bg-background/40 px-4 py-3">
-              <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+              <PrimitiveText as="p" variant="bodySm" tone="muted">
                 {photoState.selectedFile
                   ? "Use sparkle to turn the uploaded item photo into a cleaner catalog-style PNG before you save."
                   : "Upload a photo first to use the AI cleaner."}
-              </p>
+              </PrimitiveText>
               <AiCleanImageButton
                 disabled={!photoState.selectedFile}
                 isLoading={isCleaningUploadedPhoto}
@@ -462,12 +465,12 @@ export function CreateItemPage({
 
           <div className="border border-border bg-card p-5">
             <div className="mb-4">
-              <p className="uppercase tracking-[0.2em] text-xs text-muted-foreground mb-2">
+              <PrimitiveText as="p" variant="overline" tone="muted" className="mb-2">
                 Item Details
-              </p>
-              <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+              </PrimitiveText>
+              <PrimitiveText as="p" variant="bodySm" tone="muted">
                 Add the core metadata that should be saved with this item.
-              </p>
+              </PrimitiveText>
             </div>
             <div className="grid gap-5 sm:grid-cols-2">
               <ItemMetadataFields values={formValues} onChange={setFormValues} />

--- a/front-end/src/app/components/CreateItemPage.tsx
+++ b/front-end/src/app/components/CreateItemPage.tsx
@@ -25,6 +25,7 @@ import { AiCleanImageButton } from "./AiCleanImageButton";
 import { CreateItemImageMode } from "./create-item/CreateItemImageMode";
 import { ItemMetadataFields } from "./ItemMetadataFields";
 import { ItemPhotoField } from "./ItemPhotoField";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 import { UploadWorkspace } from "./UploadWorkspace";
 import { useItemPhotoState } from "../lib/useItemPhotoState";
@@ -346,13 +347,14 @@ export function CreateItemPage({
   if (!user) {
     return (
       <div className="max-w-5xl mx-auto px-6 py-12">
-        <button
+        <PrimitiveButton
           onClick={onBack}
-          className="inline-flex items-center gap-2 mb-8 text-muted-foreground hover:text-foreground transition-colors"
+          variant="ghost"
+          className="mb-8 h-auto px-0 py-0 text-muted-foreground"
         >
           <ArrowLeft className="w-4 h-4" />
           Back
-        </button>
+        </PrimitiveButton>
         <div className="border border-destructive/20 bg-destructive/5 p-6">
           <PrimitiveText as="p" variant="title" font="serif" className="mb-2">
             A user is required before you can add an item.
@@ -400,13 +402,14 @@ export function CreateItemPage({
 
   return (
     <div className="max-w-7xl mx-auto px-6 py-12">
-      <button
+      <PrimitiveButton
         onClick={onBack}
-        className="inline-flex items-center gap-2 mb-8 text-muted-foreground hover:text-foreground transition-colors"
+        variant="ghost"
+        className="mb-8 h-auto px-0 py-0 text-muted-foreground"
       >
         <ArrowLeft className="w-4 h-4" />
         Back
-      </button>
+      </PrimitiveButton>
 
       <motion.form
         initial={{ opacity: 0, y: 18 }}
@@ -478,14 +481,14 @@ export function CreateItemPage({
           </div>
 
           <div className="border-t border-border pt-5 flex items-center justify-end">
-            <button
+            <PrimitiveButton
               type="submit"
               disabled={isCreating}
-              className="inline-flex items-center gap-2 px-5 py-3 bg-foreground text-background hover:bg-foreground/90 transition-colors disabled:opacity-50"
+              className="h-auto bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
             >
               <Plus className="w-4 h-4" />
               {isCreating ? "Creating..." : "Create Item"}
-            </button>
+            </PrimitiveButton>
           </div>
         </UploadWorkspace>
       </motion.form>

--- a/front-end/src/app/components/ItemDetailPage.tsx
+++ b/front-end/src/app/components/ItemDetailPage.tsx
@@ -19,6 +19,7 @@ import { AiCleanImageButton } from "./AiCleanImageButton";
 import { ItemHeroPreview } from "./ItemHeroPreview";
 import { ItemMetadataFields } from "./ItemMetadataFields";
 import { ItemPhotoField } from "./ItemPhotoField";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 import { useItemPhotoState } from "../lib/useItemPhotoState";
 
@@ -179,13 +180,14 @@ export function ItemDetailPage({
   if (!item || !formValues) {
     return (
       <div className="max-w-5xl mx-auto px-6 py-12">
-        <button
+        <PrimitiveButton
           onClick={onBack}
-          className="inline-flex items-center gap-2 mb-8 text-muted-foreground hover:text-foreground transition-colors"
+          variant="ghost"
+          className="mb-8 h-auto px-0 py-0 text-muted-foreground"
         >
           <ArrowLeft className="w-4 h-4" />
           Back to closet
-        </button>
+        </PrimitiveButton>
         <div className="border border-destructive/20 bg-destructive/5 p-6">
           <PrimitiveText as="p" variant="title" font="serif" className="mb-2">
             This item could not be loaded.
@@ -200,13 +202,14 @@ export function ItemDetailPage({
 
   return (
     <div className="max-w-7xl mx-auto px-6 py-12">
-      <button
+      <PrimitiveButton
         onClick={onBack}
-        className="inline-flex items-center gap-2 mb-8 text-muted-foreground hover:text-foreground transition-colors"
+        variant="ghost"
+        className="mb-8 h-auto px-0 py-0 text-muted-foreground"
       >
         <ArrowLeft className="w-4 h-4" />
         Back to closet
-      </button>
+      </PrimitiveButton>
 
       <div className="grid gap-10 lg:grid-cols-[1.1fr_1fr] items-start">
         <ItemHeroPreview
@@ -238,15 +241,16 @@ export function ItemDetailPage({
               </PrimitiveText>
             </div>
 
-            <button
+            <PrimitiveButton
               type="button"
               onClick={() => void handleDelete()}
               disabled={isDeleting}
-              className="inline-flex items-center gap-2 px-4 py-2 border border-destructive/30 text-destructive hover:bg-destructive/5 transition-colors disabled:opacity-60"
+              variant="outline"
+              className="border-destructive/30 text-destructive hover:bg-destructive/5"
             >
               <Trash2 className="w-4 h-4" />
               {isDeleting ? "Deleting..." : "Delete"}
-            </button>
+            </PrimitiveButton>
           </div>
 
           {errorMessage && (
@@ -298,14 +302,14 @@ export function ItemDetailPage({
               {isDirty ? "Unsaved changes" : "All changes saved"}
             </PrimitiveText>
 
-            <button
+            <PrimitiveButton
               type="submit"
               disabled={isSaving || !isDirty}
-              className="inline-flex items-center gap-2 px-5 py-3 bg-foreground text-background hover:bg-foreground/90 transition-colors disabled:opacity-50"
+              className="h-auto bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
             >
               <Save className="w-4 h-4" />
               {isSaving ? "Saving..." : "Save Changes"}
-            </button>
+            </PrimitiveButton>
           </div>
         </motion.form>
       </div>

--- a/front-end/src/app/components/ItemDetailPage.tsx
+++ b/front-end/src/app/components/ItemDetailPage.tsx
@@ -19,6 +19,7 @@ import { AiCleanImageButton } from "./AiCleanImageButton";
 import { ItemHeroPreview } from "./ItemHeroPreview";
 import { ItemMetadataFields } from "./ItemMetadataFields";
 import { ItemPhotoField } from "./ItemPhotoField";
+import { PrimitiveText } from "./primitives/PrimitiveText";
 import { useItemPhotoState } from "../lib/useItemPhotoState";
 
 interface ItemDetailPageProps {
@@ -186,12 +187,12 @@ export function ItemDetailPage({
           Back to closet
         </button>
         <div className="border border-destructive/20 bg-destructive/5 p-6">
-          <p className="text-lg mb-2" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+          <PrimitiveText as="p" variant="title" font="serif" className="mb-2">
             This item could not be loaded.
-          </p>
-          <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+          </PrimitiveText>
+          <PrimitiveText as="p" tone="muted">
             {errorMessage || "The requested item may have been deleted."}
-          </p>
+          </PrimitiveText>
         </div>
       </div>
     );
@@ -226,13 +227,15 @@ export function ItemDetailPage({
         >
           <div className="flex items-start justify-between gap-4">
             <div>
-              <p className="uppercase tracking-[0.3em] text-xs text-muted-foreground mb-3">
+              <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
                 Item Details
-              </p>
-              <h2 className="mb-1">Edit Item</h2>
-              <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+              </PrimitiveText>
+              <PrimitiveText as="h2" variant="title" font="serif" className="mb-1">
+                Edit Item
+              </PrimitiveText>
+              <PrimitiveText as="p" tone="muted">
                 Update the metadata shown in the closet and save it back to Rails.
-              </p>
+              </PrimitiveText>
             </div>
 
             <button
@@ -273,13 +276,13 @@ export function ItemDetailPage({
               />
 
               <div className="flex flex-wrap items-center justify-between gap-4 border border-border bg-card px-4 py-3">
-                <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                <PrimitiveText as="p" variant="bodySm" tone="muted">
                   {photoState.selectedFile
                     ? "Run the AI cleaner on the newly selected image before saving."
                     : item.image_url
                       ? "Generate a cleaner catalog-style PNG from the current saved image."
                       : "Upload a photo first to use the AI cleaner."}
-                </p>
+                </PrimitiveText>
                 <AiCleanImageButton
                   disabled={photoState.removeExisting || (!photoState.selectedFile && !item.image_url)}
                   isLoading={isCleaningImage}
@@ -291,9 +294,9 @@ export function ItemDetailPage({
           </div>
 
           <div className="border-t border-border pt-5 flex items-center justify-between gap-4">
-            <div className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            <PrimitiveText as="div" variant="bodySm" tone="muted">
               {isDirty ? "Unsaved changes" : "All changes saved"}
-            </div>
+            </PrimitiveText>
 
             <button
               type="submit"

--- a/front-end/src/app/components/ItemHeroPreview.tsx
+++ b/front-end/src/app/components/ItemHeroPreview.tsx
@@ -6,6 +6,7 @@ import {
   DialogDescription,
   DialogTitle,
 } from "./ui/dialog";
+import { PrimitiveText } from "./primitives/PrimitiveText";
 
 interface ItemHeroPreviewProps {
   allowExpand?: boolean;
@@ -47,47 +48,50 @@ export function ItemHeroPreview({
         )}
 
         <div>
-          <p
-            className="relative uppercase tracking-[0.3em] text-xs mb-4"
+          <PrimitiveText
+            as="p"
+            variant="overline"
+            className="relative mb-4"
             style={{
               color: imageUrl ? "rgba(255,255,255,0.78)" : undefined,
-              fontFamily: "Outfit, sans-serif",
             }}
           >
             {label}
-          </p>
-          <h1
+          </PrimitiveText>
+          <PrimitiveText
+            as="h1"
+            variant="display"
+            font="serif"
             className="relative mb-0 max-w-[12ch] break-words"
             style={{
               color: imageUrl ? "white" : "rgba(68, 64, 60, 0.85)",
-              fontFamily: "Cormorant Garamond, serif",
               fontSize: "clamp(2.75rem, 5vw, 4.75rem)",
               lineHeight: "0.95",
             }}
           >
             {title}
-          </h1>
+          </PrimitiveText>
         </div>
 
         <div className="relative space-y-3">
-          <p
+          <PrimitiveText
+            as="p"
             style={{
               color: imageUrl ? "rgba(255,255,255,0.82)" : undefined,
-              fontFamily: "Outfit, sans-serif",
             }}
           >
             {primaryDetail}
-          </p>
+          </PrimitiveText>
           {secondaryDetail && (
-            <p
-              className="text-sm"
+            <PrimitiveText
+              as="p"
+              variant="bodySm"
               style={{
                 color: imageUrl ? "rgba(255,255,255,0.82)" : undefined,
-                fontFamily: "Outfit, sans-serif",
               }}
             >
               {secondaryDetail}
-            </p>
+            </PrimitiveText>
           )}
         </div>
       </motion.div>

--- a/front-end/src/app/components/ItemMetadataFields.tsx
+++ b/front-end/src/app/components/ItemMetadataFields.tsx
@@ -2,6 +2,7 @@ import {
   ClothingItemFormValues,
   formatDisplaySize,
 } from "../lib/closet";
+import { PrimitiveText } from "./primitives/PrimitiveText";
 
 interface ItemMetadataFieldsProps {
   onChange: (nextValues: ClothingItemFormValues) => void;
@@ -24,7 +25,7 @@ export function ItemMetadataFields({ onChange, values }: ItemMetadataFieldsProps
   return (
     <>
       <label className="space-y-2 sm:col-span-2">
-        <span>Name</span>
+        <PrimitiveText as="span" variant="label">Name</PrimitiveText>
         <input
           value={values.name}
           onChange={(event) => updateField("name", event.target.value)}
@@ -34,7 +35,7 @@ export function ItemMetadataFields({ onChange, values }: ItemMetadataFieldsProps
       </label>
 
       <label className="space-y-2">
-        <span>Size</span>
+        <PrimitiveText as="span" variant="label">Size</PrimitiveText>
         <select
           value={values.size}
           onChange={(event) => updateField("size", event.target.value)}
@@ -49,7 +50,7 @@ export function ItemMetadataFields({ onChange, values }: ItemMetadataFieldsProps
       </label>
 
       <label className="space-y-2">
-        <span>Purchase Date</span>
+        <PrimitiveText as="span" variant="label">Purchase Date</PrimitiveText>
         <input
           type="date"
           value={values.date}
@@ -59,16 +60,16 @@ export function ItemMetadataFields({ onChange, values }: ItemMetadataFieldsProps
       </label>
 
       <label className="space-y-2 sm:col-span-2">
-        <span>Tags</span>
+        <PrimitiveText as="span" variant="label">Tags</PrimitiveText>
         <textarea
           value={values.tags}
           onChange={(event) => updateField("tags", event.target.value)}
           className="min-h-28 w-full border border-border bg-card px-4 py-3"
           placeholder="Try tags like cotton, blue, weekend, office"
         />
-        <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+        <PrimitiveText as="p" variant="bodySm" tone="muted">
           Add comma-separated tags so people can search and filter this item naturally.
-        </p>
+        </PrimitiveText>
       </label>
     </>
   );

--- a/front-end/src/app/components/ItemPhotoField.tsx
+++ b/front-end/src/app/components/ItemPhotoField.tsx
@@ -1,4 +1,5 @@
 import { RefObject } from "react";
+import { PrimitiveText } from "./primitives/PrimitiveText";
 
 interface ItemPhotoFieldProps {
   description: string;
@@ -27,7 +28,9 @@ export function ItemPhotoField({
 
   return (
     <label className="space-y-2 sm:col-span-2">
-      <span>Photo</span>
+      <PrimitiveText as="span" variant="label">
+        Photo
+      </PrimitiveText>
       <input
         ref={inputRef}
         type="file"
@@ -35,15 +38,15 @@ export function ItemPhotoField({
         onChange={(event) => onFileChange(event.target.files?.[0] ?? null)}
         className="w-full border border-border bg-card px-4 py-3 file:mr-4 file:border-0 file:bg-transparent file:font-medium"
       />
-      <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+      <PrimitiveText as="p" variant="bodySm" tone="muted">
         {description}
-      </p>
+      </PrimitiveText>
 
       {isShowingPhotoRow && (
         <div className="flex items-center justify-between gap-4 border border-border bg-card px-4 py-3">
-          <span className="text-sm" style={{ fontFamily: "Outfit, sans-serif" }}>
+          <PrimitiveText as="span" variant="bodySm">
             {selectedFileName || "Current photo attached"}
-          </span>
+          </PrimitiveText>
           <button
             type="button"
             onClick={selectedFileName ? onClearSelection : onRemoveExisting}
@@ -56,9 +59,9 @@ export function ItemPhotoField({
 
       {isRemovingExisting && (
         <div className="flex items-center justify-between gap-4 border border-dashed border-border px-4 py-3">
-          <span className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+          <PrimitiveText as="span" variant="bodySm" tone="muted">
             The current photo will be removed when you save.
-          </span>
+          </PrimitiveText>
           <button
             type="button"
             onClick={onKeepExisting}

--- a/front-end/src/app/components/ItemPhotoField.tsx
+++ b/front-end/src/app/components/ItemPhotoField.tsx
@@ -1,4 +1,5 @@
 import { RefObject } from "react";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 
 interface ItemPhotoFieldProps {
@@ -47,13 +48,15 @@ export function ItemPhotoField({
           <PrimitiveText as="span" variant="bodySm">
             {selectedFileName || "Current photo attached"}
           </PrimitiveText>
-          <button
+          <PrimitiveButton
             type="button"
             onClick={selectedFileName ? onClearSelection : onRemoveExisting}
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            variant="ghost"
+            size="sm"
+            className="h-auto px-0 py-0 text-muted-foreground"
           >
             {selectedFileName ? "Clear Selection" : "Remove Photo"}
-          </button>
+          </PrimitiveButton>
         </div>
       )}
 
@@ -62,13 +65,15 @@ export function ItemPhotoField({
           <PrimitiveText as="span" variant="bodySm" tone="muted">
             The current photo will be removed when you save.
           </PrimitiveText>
-          <button
+          <PrimitiveButton
             type="button"
             onClick={onKeepExisting}
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            variant="ghost"
+            size="sm"
+            className="h-auto px-0 py-0 text-muted-foreground"
           >
             Keep Photo
-          </button>
+          </PrimitiveButton>
         </div>
       )}
     </label>

--- a/front-end/src/app/components/MyOutfitsPage.tsx
+++ b/front-end/src/app/components/MyOutfitsPage.tsx
@@ -15,6 +15,7 @@ import {
   updateOutfit,
   User,
 } from "../lib/closet";
+import { PrimitiveText } from "./primitives/PrimitiveText";
 
 interface MyOutfitsPageProps {
   user: User;
@@ -230,20 +231,19 @@ export function MyOutfitsPage({
     <div className="max-w-7xl mx-auto px-6 py-12 space-y-10">
       <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
         <div>
-          <p
-            className="uppercase tracking-[0.3em] text-xs text-muted-foreground mb-3"
-            style={{ fontFamily: "Outfit, sans-serif" }}
-          >
+          <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
             My Outfits
-          </p>
-          <h1 className="mb-2">Lookbook Builder</h1>
-          <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+          </PrimitiveText>
+          <PrimitiveText as="h1" variant="display" font="serif" className="mb-2">
+            Lookbook Builder
+          </PrimitiveText>
+          <PrimitiveText as="p" tone="muted">
             Group your closet pieces into reusable outfit combos.
-          </p>
+          </PrimitiveText>
         </div>
-        <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+        <PrimitiveText as="p" variant="bodySm" tone="muted">
           {outfits.length} {outfits.length === 1 ? "outfit" : "outfits"} saved
-        </p>
+        </PrimitiveText>
       </div>
 
       <section ref={formSectionRef} className="border border-border bg-card p-6">
@@ -255,9 +255,7 @@ export function MyOutfitsPage({
         <form onSubmit={handleSubmit} className="space-y-5">
           <div className="grid gap-4 md:grid-cols-2">
             <label className="space-y-2">
-              <span className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
-                Name
-              </span>
+              <PrimitiveText as="span" variant="bodySm" tone="muted">Name</PrimitiveText>
               <input
                 value={formState.name}
                 onChange={(event) => setFormField("name", event.target.value)}
@@ -267,9 +265,9 @@ export function MyOutfitsPage({
             </label>
 
             <label className="space-y-2">
-              <span className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+              <PrimitiveText as="span" variant="bodySm" tone="muted">
                 Tags (comma separated)
-              </span>
+              </PrimitiveText>
               <input
                 value={formState.tagInput}
                 onChange={(event) => setFormField("tagInput", event.target.value)}
@@ -280,9 +278,7 @@ export function MyOutfitsPage({
           </div>
 
           <label className="space-y-2 block">
-            <span className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
-              Notes
-            </span>
+            <PrimitiveText as="span" variant="bodySm" tone="muted">Notes</PrimitiveText>
             <textarea
               value={formState.notes}
               onChange={(event) => setFormField("notes", event.target.value)}
@@ -293,26 +289,27 @@ export function MyOutfitsPage({
 
           <div className="space-y-3">
             <div className="flex items-center justify-between gap-3">
-              <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+              <PrimitiveText as="p" variant="bodySm" tone="muted">
                 Items in this outfit
-              </p>
+              </PrimitiveText>
               <button
                 type="button"
                 onClick={onBrowseCloset}
                 className="inline-flex items-center justify-center border border-border px-3 py-1.5 text-xs transition-colors hover:border-foreground"
-                style={{ fontFamily: "Outfit, sans-serif" }}
               >
                 Add from closet
               </button>
             </div>
 
             {selectedItems.length === 0 ? (
-              <div
-                className="border border-dashed border-border p-4 text-sm text-muted-foreground"
-                style={{ fontFamily: "Outfit, sans-serif" }}
+              <PrimitiveText
+                as="div"
+                variant="bodySm"
+                tone="muted"
+                className="border border-dashed border-border p-4"
               >
                 Use “Add to Outfit” on any closet item, then come back here to save.
-              </div>
+              </PrimitiveText>
             ) : (
               <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
                 {selectedItems.map((item) => (
@@ -321,25 +318,21 @@ export function MyOutfitsPage({
                       {item.image_url ? (
                         <img src={item.image_url} alt={item.name} className="h-full w-full object-cover" />
                       ) : (
-                        <div
-                          className="h-full w-full flex items-center justify-center text-xs"
-                          style={{ fontFamily: "Outfit, sans-serif" }}
+                        <PrimitiveText
+                          as="div"
+                          variant="caption"
+                          className="h-full w-full flex items-center justify-center"
                         >
                           {buildPlaceholderLabel(item.name)}
-                        </div>
+                        </PrimitiveText>
                       )}
                     </div>
 
                     <div className="min-w-0 flex-1">
-                      <p className="truncate" style={{ fontFamily: "Outfit, sans-serif" }}>
-                        {item.name}
-                      </p>
-                      <p
-                        className="text-xs text-muted-foreground truncate"
-                        style={{ fontFamily: "Outfit, sans-serif" }}
-                      >
+                      <PrimitiveText as="p" className="truncate">{item.name}</PrimitiveText>
+                      <PrimitiveText as="p" variant="caption" tone="muted" className="truncate">
                         {item.tags.length > 0 ? formatTagLabel(item.tags[0]) : "Unstyled"}
-                      </p>
+                      </PrimitiveText>
                     </div>
 
                     <button
@@ -361,7 +354,6 @@ export function MyOutfitsPage({
               type="submit"
               disabled={isSaving}
               className="inline-flex items-center justify-center gap-2 border border-border px-4 py-2.5 text-sm transition-colors hover:border-foreground disabled:opacity-50"
-              style={{ fontFamily: "Outfit, sans-serif" }}
             >
               {editingOutfitId ? "Save Changes" : "Save Outfit"}
             </button>
@@ -371,7 +363,6 @@ export function MyOutfitsPage({
                 type="button"
                 onClick={resetForm}
                 className="inline-flex items-center justify-center gap-2 border border-border px-4 py-2.5 text-sm transition-colors hover:border-foreground"
-                style={{ fontFamily: "Outfit, sans-serif" }}
               >
                 Cancel Edit
               </button>
@@ -393,12 +384,12 @@ export function MyOutfitsPage({
           </div>
         ) : outfits.length === 0 ? (
           <div className="border border-dashed border-border p-8 text-center">
-            <p className="text-2xl mb-2" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+            <PrimitiveText as="p" variant="display" font="serif" className="mb-2">
               No outfits yet
-            </p>
-            <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
               Build your first look above and it will appear here.
-            </p>
+            </PrimitiveText>
           </div>
         ) : (
           <div className="grid gap-4 md:grid-cols-2">
@@ -414,9 +405,9 @@ export function MyOutfitsPage({
                   <div>
                     <h3>{outfit.name}</h3>
                     {outfit.tags && outfit.tags.length > 0 ? (
-                      <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                      <PrimitiveText as="p" variant="bodySm" tone="muted">
                         {outfit.tags.join(" · ")}
-                      </p>
+                      </PrimitiveText>
                     ) : null}
                   </div>
                   <div className="flex items-center gap-2">
@@ -438,9 +429,7 @@ export function MyOutfitsPage({
                 </div>
 
                 {outfit.notes ? (
-                  <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
-                    {outfit.notes}
-                  </p>
+                  <PrimitiveText as="p" variant="bodySm" tone="muted">{outfit.notes}</PrimitiveText>
                 ) : null}
 
                 <div className="grid gap-2 sm:grid-cols-2">
@@ -459,17 +448,17 @@ export function MyOutfitsPage({
                               className="h-full w-full rounded-full object-cover"
                             />
                           ) : (
-                            <span className="text-xs" style={{ fontFamily: "Outfit, sans-serif" }}>
+                            <PrimitiveText as="span" variant="caption">
                               {buildPlaceholderLabel(item.name)}
-                            </span>
+                            </PrimitiveText>
                           )}
                         </div>
                         <div>
-                          <p style={{ fontFamily: "Outfit, sans-serif" }}>{item.name}</p>
-                          <p className="text-xs text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                          <PrimitiveText as="p">{item.name}</PrimitiveText>
+                          <PrimitiveText as="p" variant="caption" tone="muted">
                             <Shirt className="inline w-3 h-3 mr-1" />
                             {item.tags.length > 0 ? formatTagLabel(item.tags[0]) : "Unstyled"}
-                          </p>
+                          </PrimitiveText>
                         </div>
                       </div>
                     </button>
@@ -490,7 +479,6 @@ export function MyOutfitsPage({
               ? "border-foreground/20 bg-background/95 text-foreground"
               : "border-destructive/25 bg-destructive/10 text-destructive"
           }`}
-          style={{ fontFamily: "Outfit, sans-serif" }}
         >
           {flash.message}
         </motion.div>

--- a/front-end/src/app/components/MyOutfitsPage.tsx
+++ b/front-end/src/app/components/MyOutfitsPage.tsx
@@ -15,6 +15,7 @@ import {
   updateOutfit,
   User,
 } from "../lib/closet";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 
 interface MyOutfitsPageProps {
@@ -292,13 +293,14 @@ export function MyOutfitsPage({
               <PrimitiveText as="p" variant="bodySm" tone="muted">
                 Items in this outfit
               </PrimitiveText>
-              <button
+              <PrimitiveButton
                 type="button"
                 onClick={onBrowseCloset}
-                className="inline-flex items-center justify-center border border-border px-3 py-1.5 text-xs transition-colors hover:border-foreground"
+                variant="outline"
+                size="sm"
               >
                 Add from closet
-              </button>
+              </PrimitiveButton>
             </div>
 
             {selectedItems.length === 0 ? (
@@ -335,14 +337,16 @@ export function MyOutfitsPage({
                       </PrimitiveText>
                     </div>
 
-                    <button
+                    <PrimitiveButton
                       type="button"
                       onClick={() => removeSelectedItem(item.id)}
-                      className="inline-flex items-center justify-center border border-border p-1.5 hover:border-foreground transition-colors"
+                      variant="outline"
+                      size="icon"
+                      className="size-8 p-1.5"
                       aria-label={`Remove ${item.name}`}
                     >
                       <X className="w-3.5 h-3.5" />
-                    </button>
+                    </PrimitiveButton>
                   </div>
                 ))}
               </div>
@@ -350,22 +354,22 @@ export function MyOutfitsPage({
           </div>
 
           <div className="flex items-center gap-2">
-            <button
+            <PrimitiveButton
               type="submit"
               disabled={isSaving}
-              className="inline-flex items-center justify-center gap-2 border border-border px-4 py-2.5 text-sm transition-colors hover:border-foreground disabled:opacity-50"
+              variant="outline"
             >
               {editingOutfitId ? "Save Changes" : "Save Outfit"}
-            </button>
+            </PrimitiveButton>
 
             {editingOutfitId ? (
-              <button
+              <PrimitiveButton
                 type="button"
                 onClick={resetForm}
-                className="inline-flex items-center justify-center gap-2 border border-border px-4 py-2.5 text-sm transition-colors hover:border-foreground"
+                variant="outline"
               >
                 Cancel Edit
-              </button>
+              </PrimitiveButton>
             ) : null}
           </div>
         </form>
@@ -411,20 +415,23 @@ export function MyOutfitsPage({
                     ) : null}
                   </div>
                   <div className="flex items-center gap-2">
-                    <button
+                    <PrimitiveButton
                       onClick={() => startEditing(outfit)}
-                      className="inline-flex items-center justify-center border border-border p-2 hover:border-foreground transition-colors"
+                      variant="outline"
+                      size="icon"
                       aria-label="Edit outfit"
                     >
                       <Pencil className="w-4 h-4" />
-                    </button>
-                    <button
+                    </PrimitiveButton>
+                    <PrimitiveButton
                       onClick={() => void handleDelete(outfit.id)}
-                      className="inline-flex items-center justify-center border border-border p-2 hover:border-destructive transition-colors"
+                      variant="outline"
+                      size="icon"
+                      className="hover:border-destructive"
                       aria-label="Delete outfit"
                     >
                       <Trash2 className="w-4 h-4" />
-                    </button>
+                    </PrimitiveButton>
                   </div>
                 </div>
 
@@ -434,10 +441,11 @@ export function MyOutfitsPage({
 
                 <div className="grid gap-2 sm:grid-cols-2">
                   {outfit.items.map((item: ClothingItem) => (
-                    <button
+                    <PrimitiveButton
                       key={item.id}
                       onClick={() => onOpenItem(item.id)}
-                      className="w-full text-left border border-border px-3 py-2 hover:border-foreground transition-colors"
+                      variant="outline"
+                      className="h-auto w-full justify-start px-3 py-2 text-left"
                     >
                       <div className="flex items-center gap-3">
                         <div className="h-9 w-9 shrink-0 border border-border rounded-full flex items-center justify-center bg-muted">
@@ -461,7 +469,7 @@ export function MyOutfitsPage({
                           </PrimitiveText>
                         </div>
                       </div>
-                    </button>
+                    </PrimitiveButton>
                   ))}
                 </div>
               </motion.article>

--- a/front-end/src/app/components/OutfitBuilder.tsx
+++ b/front-end/src/app/components/OutfitBuilder.tsx
@@ -1,5 +1,7 @@
 import { motion } from "motion/react";
 import { Plus, X } from "lucide-react";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
+import { PrimitiveText } from "./primitives/PrimitiveText";
 
 interface OutfitItem {
   id: number;
@@ -38,16 +40,18 @@ export function OutfitBuilder({ outfits, isOpen, onClose }: OutfitBuilderProps) 
         className="bg-background max-w-4xl w-full max-h-[90vh] overflow-y-auto p-8 relative"
         onClick={(e) => e.stopPropagation()}
       >
-        <button
+        <PrimitiveButton
           onClick={onClose}
-          className="absolute top-6 right-6 p-2 hover:bg-muted transition-colors"
+          variant="ghost"
+          size="icon"
+          className="absolute top-6 right-6"
         >
           <X className="w-6 h-6" />
-        </button>
+        </PrimitiveButton>
 
-        <h2 className="mb-8" style={{ fontFamily: 'Cormorant Garamond, serif' }}>
+        <PrimitiveText as="h2" variant="display" font="serif" className="mb-8">
           Saved Outfits
-        </h2>
+        </PrimitiveText>
 
         <div className="space-y-8">
           {outfits.map((outfit, index) => (
@@ -60,16 +64,16 @@ export function OutfitBuilder({ outfits, isOpen, onClose }: OutfitBuilderProps) 
             >
               <div className="flex items-center justify-between mb-4">
                 <div>
-                  <h3 className="mb-1" style={{ fontFamily: 'Cormorant Garamond, serif' }}>
+                  <PrimitiveText as="h3" variant="title" font="serif" className="mb-1">
                     {outfit.name}
-                  </h3>
-                  <p className="text-muted-foreground" style={{ fontFamily: 'Outfit, sans-serif' }}>
+                  </PrimitiveText>
+                  <PrimitiveText as="p" tone="muted">
                     {outfit.date}
-                  </p>
+                  </PrimitiveText>
                 </div>
-                <button className="px-4 py-2 border border-foreground hover:bg-foreground hover:text-background transition-colors">
-                  <span style={{ fontFamily: 'Outfit, sans-serif' }}>Wear Today</span>
-                </button>
+                <PrimitiveButton variant="outline" className="border-foreground hover:bg-foreground hover:text-background">
+                  Wear Today
+                </PrimitiveButton>
               </div>
 
               <div className="grid grid-cols-4 gap-4">
@@ -86,12 +90,15 @@ export function OutfitBuilder({ outfits, isOpen, onClose }: OutfitBuilderProps) 
             </motion.div>
           ))}
 
-          <button className="w-full py-8 border-2 border-dashed border-border hover:border-foreground transition-colors flex flex-col items-center justify-center gap-3">
+          <PrimitiveButton
+            variant="outline"
+            className="h-auto w-full flex-col gap-3 border-2 border-dashed py-8 hover:border-foreground"
+          >
             <Plus className="w-8 h-8" />
-            <span className="uppercase tracking-wider" style={{ fontFamily: 'Outfit, sans-serif' }}>
+            <PrimitiveText as="span" variant="overline">
               Create New Outfit
-            </span>
-          </button>
+            </PrimitiveText>
+          </PrimitiveButton>
         </div>
       </motion.div>
     </motion.div>

--- a/front-end/src/app/components/UserDetailPage.tsx
+++ b/front-end/src/app/components/UserDetailPage.tsx
@@ -10,6 +10,7 @@ import {
   User,
 } from "../lib/closet";
 import { usePageData } from "../lib/usePageData";
+import { PrimitiveText } from "./primitives/PrimitiveText";
 import { AccessRestrictedState } from "./shared/AccessRestrictedState";
 
 interface UserDetailPageProps {
@@ -78,12 +79,12 @@ export function UserDetailPage({
             Back to all users
           </button>
           <div className="border border-destructive/20 bg-destructive/5 p-6">
-            <p className="text-lg mb-2" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+            <PrimitiveText as="p" variant="title" font="serif" className="mb-2">
               This user could not be loaded.
-            </p>
-            <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
               {errorMessage || "The requested user may have been removed."}
-            </p>
+            </PrimitiveText>
           </div>
         </div>
       </div>
@@ -109,29 +110,32 @@ export function UserDetailPage({
             transition={{ duration: 0.45 }}
             className="border border-border bg-gradient-to-br from-stone-100 via-neutral-50 to-stone-200 p-8"
           >
-            <p
-              className="uppercase tracking-[0.3em] text-xs text-muted-foreground mb-4"
-              style={{ fontFamily: "Outfit, sans-serif" }}
-            >
+            <PrimitiveText as="p" variant="overline" tone="muted" className="mb-4">
               User Profile
-            </p>
-            <h1 className="mb-2">{titleize(user.username)}</h1>
-            <p className="text-muted-foreground mb-8" style={{ fontFamily: "Outfit, sans-serif" }}>
+            </PrimitiveText>
+            <PrimitiveText as="h1" variant="display" font="serif" className="mb-2">
+              {titleize(user.username)}
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted" className="mb-8">
               {formatPossessive(titleize(user.username))}
-            </p>
+            </PrimitiveText>
 
             <div className="grid sm:grid-cols-2 gap-4">
               <div className="border border-white/70 bg-white/60 p-5">
-                <p className="text-muted-foreground mb-2">Preferred style</p>
-                <p className="text-2xl" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+                <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-2">
+                  Preferred style
+                </PrimitiveText>
+                <PrimitiveText as="p" variant="display" font="serif">
                   {preferredStyle ?? "Not set"}
-                </p>
+                </PrimitiveText>
               </div>
               <div className="border border-white/70 bg-white/60 p-5">
-                <p className="text-muted-foreground mb-2">Closet size</p>
-                <p className="text-2xl" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+                <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-2">
+                  Closet size
+                </PrimitiveText>
+                <PrimitiveText as="p" variant="display" font="serif">
                   {user.clothing_items.length} items
-                </p>
+                </PrimitiveText>
               </div>
             </div>
           </motion.div>
@@ -143,27 +147,26 @@ export function UserDetailPage({
             className="space-y-6"
           >
             <div>
-              <p
-                className="uppercase tracking-[0.3em] text-xs text-muted-foreground mb-3"
-                style={{ fontFamily: "Outfit, sans-serif" }}
-              >
+              <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
                 Clothing Items
-              </p>
-              <h2 className="mb-1">Closet Contents</h2>
-              <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+              </PrimitiveText>
+              <PrimitiveText as="h2" variant="title" font="serif" className="mb-1">
+                Closet Contents
+              </PrimitiveText>
+              <PrimitiveText as="p" tone="muted">
                 Click any item to jump straight into its editable detail page.
-              </p>
+              </PrimitiveText>
             </div>
 
             <div className="space-y-4">
               {user.clothing_items.length === 0 ? (
                 <div className="border border-dashed border-border p-8 text-center">
-                  <p className="text-2xl mb-2" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+                  <PrimitiveText as="p" variant="display" font="serif" className="mb-2">
                     No items yet
-                  </p>
-                  <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+                  </PrimitiveText>
+                  <PrimitiveText as="p" tone="muted">
                     This user does not have any clothing items in the API right now.
-                  </p>
+                  </PrimitiveText>
                 </div>
               ) : (
                 user.clothing_items.map((item, index) => {
@@ -185,21 +188,15 @@ export function UserDetailPage({
                           </div>
                           <div>
                             <h3 className="mb-1">{item.name}</h3>
-                            <p
-                              className="text-muted-foreground"
-                              style={{ fontFamily: "Outfit, sans-serif" }}
-                            >
+                            <PrimitiveText as="p" tone="muted">
                               {formatDisplaySize(item.size)}
                               {visibleTags[0] ? ` · ${formatTagLabel(visibleTags[0])}` : ""}
-                            </p>
-                            <p
-                              className="mt-2 text-sm text-muted-foreground"
-                              style={{ fontFamily: "Outfit, sans-serif" }}
-                            >
+                            </PrimitiveText>
+                            <PrimitiveText as="p" variant="bodySm" tone="muted" className="mt-2">
                               {visibleTags.length > 0
                                 ? visibleTags.map(formatTagLabel).join(" · ")
                                 : "No tags added yet"}
-                            </p>
+                            </PrimitiveText>
                           </div>
                         </div>
                         <ChevronRight className="mt-1 h-4 w-4 shrink-0" />

--- a/front-end/src/app/components/UserDetailPage.tsx
+++ b/front-end/src/app/components/UserDetailPage.tsx
@@ -10,6 +10,7 @@ import {
   User,
 } from "../lib/closet";
 import { usePageData } from "../lib/usePageData";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 import { AccessRestrictedState } from "./shared/AccessRestrictedState";
 
@@ -19,6 +20,8 @@ interface UserDetailPageProps {
   onBack: () => void;
   onOpenItem: (itemId: number) => void;
 }
+
+const MotionPrimitiveButton = motion.create(PrimitiveButton);
 
 export function UserDetailPage({
   userId,
@@ -72,12 +75,13 @@ export function UserDetailPage({
     return (
       <div className="min-h-screen bg-background">
         <div className="max-w-7xl mx-auto px-6 py-12">
-          <button
+          <PrimitiveButton
             onClick={onBack}
-            className="inline-flex items-center gap-2 mb-8 text-muted-foreground hover:text-foreground transition-colors"
+            variant="ghost"
+            className="mb-8 h-auto px-0 py-0 text-muted-foreground"
           >
             Back to all users
-          </button>
+          </PrimitiveButton>
           <div className="border border-destructive/20 bg-destructive/5 p-6">
             <PrimitiveText as="p" variant="title" font="serif" className="mb-2">
               This user could not be loaded.
@@ -96,12 +100,13 @@ export function UserDetailPage({
   return (
     <div className="min-h-screen bg-background">
       <div className="max-w-7xl mx-auto px-6 py-12">
-        <button
+        <PrimitiveButton
           onClick={onBack}
-          className="inline-flex items-center gap-2 mb-8 text-muted-foreground hover:text-foreground transition-colors"
+          variant="ghost"
+          className="mb-8 h-auto px-0 py-0 text-muted-foreground"
         >
           Back to all users
-        </button>
+        </PrimitiveButton>
 
         <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] items-start">
           <motion.div
@@ -173,13 +178,14 @@ export function UserDetailPage({
                   const visibleTags = item.tags.slice(0, 3);
 
                   return (
-                    <motion.button
+                    <MotionPrimitiveButton
                       key={item.id}
                       initial={{ opacity: 0, y: 12 }}
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ duration: 0.35, delay: index * 0.03 }}
                       onClick={() => onOpenItem(item.id)}
-                      className="w-full text-left border border-border bg-card p-5 hover:border-foreground transition-colors"
+                      variant="outline"
+                      className="h-auto w-full justify-start bg-card p-5 text-left hover:border-foreground"
                     >
                       <div className="flex items-start justify-between gap-4">
                         <div className="flex items-start gap-4">
@@ -201,7 +207,7 @@ export function UserDetailPage({
                         </div>
                         <ChevronRight className="mt-1 h-4 w-4 shrink-0" />
                       </div>
-                    </motion.button>
+                    </MotionPrimitiveButton>
                   );
                 })
               )}

--- a/front-end/src/app/components/UsersDirectoryPage.tsx
+++ b/front-end/src/app/components/UsersDirectoryPage.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import { ChevronRight, Users } from "lucide-react";
 import { fetchUsers, formatPossessive, formatPreferredStyle, titleize, User } from "../lib/closet";
 import { usePageData } from "../lib/usePageData";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 import { AccessRestrictedState } from "./shared/AccessRestrictedState";
 
@@ -9,6 +10,8 @@ interface UsersDirectoryPageProps {
   onBack: () => void;
   onSelectUser: (userId: number) => void;
 }
+
+const MotionPrimitiveButton = motion.create(PrimitiveButton);
 
 export function UsersDirectoryPage({ onBack, onSelectUser }: UsersDirectoryPageProps) {
   const {
@@ -36,12 +39,13 @@ export function UsersDirectoryPage({ onBack, onSelectUser }: UsersDirectoryPageP
   return (
     <div className="min-h-screen bg-background">
       <div className="max-w-7xl mx-auto px-6 py-12">
-        <button
+        <PrimitiveButton
           onClick={onBack}
-          className="inline-flex items-center gap-2 mb-8 text-muted-foreground hover:text-foreground transition-colors"
+          variant="ghost"
+          className="mb-8 h-auto px-0 py-0 text-muted-foreground"
         >
           Back home
-        </button>
+        </PrimitiveButton>
 
         <div className="flex items-end justify-between gap-6 mb-10">
           <div>
@@ -87,13 +91,14 @@ export function UsersDirectoryPage({ onBack, onSelectUser }: UsersDirectoryPageP
             {users.map((user, index) => {
               const preferredStyle = formatPreferredStyle(user.preferred_style);
               return (
-                <motion.button
+                <MotionPrimitiveButton
                   key={user.id}
                   initial={{ opacity: 0, y: 18 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ duration: 0.45, delay: index * 0.04 }}
                   onClick={() => onSelectUser(user.id)}
-                  className="text-left border border-border bg-card p-6 hover:border-foreground transition-colors"
+                  variant="outline"
+                  className="h-auto justify-start bg-card p-6 text-left hover:border-foreground"
                 >
                   <PrimitiveText as="p" variant="overline" tone="muted" className="mb-4">
                     Closet Owner
@@ -128,7 +133,7 @@ export function UsersDirectoryPage({ onBack, onSelectUser }: UsersDirectoryPageP
                     </PrimitiveText>
                     <ChevronRight className="w-4 h-4" />
                   </div>
-                </motion.button>
+                </MotionPrimitiveButton>
               );
             })}
           </div>

--- a/front-end/src/app/components/UsersDirectoryPage.tsx
+++ b/front-end/src/app/components/UsersDirectoryPage.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import { ChevronRight, Users } from "lucide-react";
 import { fetchUsers, formatPossessive, formatPreferredStyle, titleize, User } from "../lib/closet";
 import { usePageData } from "../lib/usePageData";
+import { PrimitiveText } from "./primitives/PrimitiveText";
 import { AccessRestrictedState } from "./shared/AccessRestrictedState";
 
 interface UsersDirectoryPageProps {
@@ -44,31 +45,32 @@ export function UsersDirectoryPage({ onBack, onSelectUser }: UsersDirectoryPageP
 
         <div className="flex items-end justify-between gap-6 mb-10">
           <div>
-            <p
-              className="uppercase tracking-[0.3em] text-xs text-muted-foreground mb-3"
-              style={{ fontFamily: "Outfit, sans-serif" }}
-            >
+            <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
               User Directory
-            </p>
-            <h1 className="mb-2">All Users</h1>
-            <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            </PrimitiveText>
+            <PrimitiveText as="h1" variant="display" font="serif" className="mb-2">
+              All Users
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
               Browse every closet owner in the system and open a detailed profile.
-            </p>
+            </PrimitiveText>
           </div>
           <div className="hidden sm:flex items-center gap-3 px-5 py-3 border border-border bg-card">
             <Users className="w-4 h-4" />
-            <span style={{ fontFamily: "Outfit, sans-serif" }}>{users.length} users</span>
+            <PrimitiveText as="span" variant="bodySm">
+              {users.length} users
+            </PrimitiveText>
           </div>
         </div>
 
         {errorMessage ? (
           <div className="border border-destructive/20 bg-destructive/5 p-6">
-            <p className="text-lg mb-2" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+            <PrimitiveText as="p" variant="title" font="serif" className="mb-2">
               Users could not be loaded.
-            </p>
-            <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
               {errorMessage}
-            </p>
+            </PrimitiveText>
           </div>
         ) : isLoading ? (
           <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
@@ -93,32 +95,37 @@ export function UsersDirectoryPage({ onBack, onSelectUser }: UsersDirectoryPageP
                   onClick={() => onSelectUser(user.id)}
                   className="text-left border border-border bg-card p-6 hover:border-foreground transition-colors"
                 >
-                  <p
-                    className="uppercase tracking-[0.3em] text-xs text-muted-foreground mb-4"
-                    style={{ fontFamily: "Outfit, sans-serif" }}
-                  >
+                  <PrimitiveText as="p" variant="overline" tone="muted" className="mb-4">
                     Closet Owner
-                  </p>
-                  <h2 className="mb-2">{titleize(user.username)}</h2>
-                  <p className="text-muted-foreground mb-6" style={{ fontFamily: "Outfit, sans-serif" }}>
+                  </PrimitiveText>
+                  <PrimitiveText as="h2" variant="title" font="serif" className="mb-2">
+                    {titleize(user.username)}
+                  </PrimitiveText>
+                  <PrimitiveText as="p" tone="muted" className="mb-6">
                     {formatPossessive(titleize(user.username))}
-                  </p>
+                  </PrimitiveText>
                   <div className="grid grid-cols-2 gap-4 text-sm mb-6">
                     <div className="border border-border p-4">
-                      <p className="text-muted-foreground mb-1">Items</p>
-                      <p className="text-xl" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+                      <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-1">
+                        Items
+                      </PrimitiveText>
+                      <PrimitiveText as="p" variant="stat" font="serif">
                         {user.clothing_items.length}
-                      </p>
+                      </PrimitiveText>
                     </div>
                     <div className="border border-border p-4">
-                      <p className="text-muted-foreground mb-1">Style</p>
-                      <p className="text-xl" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+                      <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-1">
+                        Style
+                      </PrimitiveText>
+                      <PrimitiveText as="p" variant="stat" font="serif">
                         {preferredStyle ?? "N/A"}
-                      </p>
+                      </PrimitiveText>
                     </div>
                   </div>
                   <div className="flex items-center justify-between text-sm">
-                    <span style={{ fontFamily: "Outfit, sans-serif" }}>Open details</span>
+                    <PrimitiveText as="span" variant="bodySm">
+                      Open details
+                    </PrimitiveText>
                     <ChevronRight className="w-4 h-4" />
                   </div>
                 </motion.button>

--- a/front-end/src/app/components/create-item/CreateItemImageMode.tsx
+++ b/front-end/src/app/components/create-item/CreateItemImageMode.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../lib/closet";
 import { DetectionReviewCard } from "./DetectionReviewCard";
 import { ItemPhotoField } from "../ItemPhotoField";
+import { PrimitiveText } from "../primitives/PrimitiveText";
 import { UploadWorkspace } from "../UploadWorkspace";
 
 interface CreateItemImageModeProps {
@@ -93,14 +94,16 @@ export function CreateItemImageMode({
         previewTitle={selectedFileName ?? "Upload an image"}
       >
         <div>
-          <p className="uppercase tracking-[0.3em] text-xs text-muted-foreground mb-3">
+          <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
             Image Upload
-          </p>
-          <h1 className="mb-1">Review Detected Items</h1>
-          <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+          </PrimitiveText>
+          <PrimitiveText as="h1" variant="display" font="serif" className="mb-1">
+            Review Detected Items
+          </PrimitiveText>
+          <PrimitiveText as="p" tone="muted">
             Upload an image first, then run detection when you are ready. Verified pieces can be saved
             directly to {formatPossessive(titleize(user.username))}.
-          </p>
+          </PrimitiveText>
         </div>
 
         {errorMessage && (
@@ -110,9 +113,9 @@ export function CreateItemImageMode({
         )}
 
         <div className="border border-border bg-card p-5">
-          <p className="uppercase tracking-[0.2em] text-xs text-muted-foreground mb-3">
+          <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
             Upload Photo
-          </p>
+          </PrimitiveText>
           <ItemPhotoField
             description="Choose the source image now. Detection only runs after you click the button below."
             inputRef={inputRef}
@@ -123,12 +126,12 @@ export function CreateItemImageMode({
         </div>
 
         <div className="border border-border bg-card p-5">
-          <p className="uppercase tracking-[0.2em] text-xs text-muted-foreground mb-3">
+          <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
             Detection
-          </p>
-          <p className="text-sm text-muted-foreground mb-4" style={{ fontFamily: "Outfit, sans-serif" }}>
+          </PrimitiveText>
+          <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-4">
             We refine and verify each detected crop before it becomes selectable below.
-          </p>
+          </PrimitiveText>
           <div className="flex items-center justify-between gap-4">
             <button
               type="button"
@@ -153,46 +156,48 @@ export function CreateItemImageMode({
       <div className="space-y-4 border-t border-border pt-8">
         <div className="flex items-end justify-between gap-4">
           <div>
-            <p className="uppercase tracking-[0.3em] text-xs text-muted-foreground mb-3">
+            <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
               Detected Items
-            </p>
-            <h2 className="mb-1">Choose what to save</h2>
-            <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            </PrimitiveText>
+            <PrimitiveText as="h2" variant="title" font="serif" className="mb-1">
+              Choose what to save
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
               Review what the model found and choose any item you want to save to the closet.
-            </p>
+            </PrimitiveText>
           </div>
-          <div className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+          <PrimitiveText as="div" variant="bodySm" tone="muted">
             {selectedCount} selected
-          </div>
+          </PrimitiveText>
         </div>
 
         {!selectedFileName ? (
           <div className="border border-dashed border-border p-8 text-center">
-            <p className="text-2xl mb-2" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+            <PrimitiveText as="p" variant="display" font="serif" className="mb-2">
               Upload an image to begin
-            </p>
-            <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
               Choosing an image from the closet page will bring you here automatically.
-            </p>
+            </PrimitiveText>
           </div>
         ) : isDetecting ? (
           <div className="border border-border bg-card p-8 text-center">
-            <p className="text-2xl mb-2" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+            <PrimitiveText as="p" variant="display" font="serif" className="mb-2">
               Detecting, refining, and verifying crops
-            </p>
-            <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
               We are running the automated crop pipeline and preparing item-specific previews.
-            </p>
+            </PrimitiveText>
           </div>
         ) : !outfitUpload ? (
           <div className="border border-dashed border-border p-8 text-center">
-            <p className="text-2xl mb-2" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+            <PrimitiveText as="p" variant="display" font="serif" className="mb-2">
               Detect items when you are ready
-            </p>
-            <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
               The selected image is ready. Click the button on the right to populate detected items
               below.
-            </p>
+            </PrimitiveText>
           </div>
         ) : outfitUpload.status === "failed" && outfitUpload.error_message ? (
           <div className="border border-destructive/20 bg-destructive/5 p-6 text-sm">
@@ -200,12 +205,12 @@ export function CreateItemImageMode({
           </div>
         ) : detectionCount === 0 ? (
           <div className="border border-dashed border-border p-8 text-center">
-            <p className="text-2xl mb-2" style={{ fontFamily: "Cormorant Garamond, serif" }}>
+            <PrimitiveText as="p" variant="display" font="serif" className="mb-2">
               No items detected yet
-            </p>
-            <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
               Try another image if the visible pieces are not being picked up clearly.
-            </p>
+            </PrimitiveText>
           </div>
         ) : (
           <div className="grid gap-4 xl:grid-cols-2 2xl:grid-cols-3">
@@ -232,9 +237,9 @@ export function CreateItemImageMode({
       </div>
 
       <div className="border-t border-border pt-6 flex items-center justify-between gap-4">
-        <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+        <PrimitiveText as="p" variant="bodySm" tone="muted">
           Selected items will use the best available crop from the uploaded image.
-        </p>
+        </PrimitiveText>
         <button
           type="button"
           onClick={onSaveSelectedItems}

--- a/front-end/src/app/components/create-item/CreateItemImageMode.tsx
+++ b/front-end/src/app/components/create-item/CreateItemImageMode.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../lib/closet";
 import { DetectionReviewCard } from "./DetectionReviewCard";
 import { ItemPhotoField } from "../ItemPhotoField";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
 import { PrimitiveText } from "../primitives/PrimitiveText";
 import { UploadWorkspace } from "../UploadWorkspace";
 
@@ -70,13 +71,14 @@ export function CreateItemImageMode({
 
   return (
     <div className="max-w-5xl mx-auto px-6 py-12 space-y-8">
-      <button
+      <PrimitiveButton
         onClick={onBack}
-        className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
+        variant="ghost"
+        className="h-auto px-0 py-0 text-muted-foreground"
       >
         <ArrowLeft className="w-4 h-4" />
         Back
-      </button>
+      </PrimitiveButton>
 
       <UploadWorkspace
         imageUrl={sourceImageUrl}
@@ -133,22 +135,24 @@ export function CreateItemImageMode({
             We refine and verify each detected crop before it becomes selectable below.
           </PrimitiveText>
           <div className="flex items-center justify-between gap-4">
-            <button
+            <PrimitiveButton
               type="button"
               onClick={onClearImageSelection}
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              variant="ghost"
+              size="sm"
+              className="h-auto px-0 py-0 text-muted-foreground"
             >
               Reset
-            </button>
-            <button
+            </PrimitiveButton>
+            <PrimitiveButton
               type="button"
               onClick={onDetectItems}
               disabled={isDetecting || !selectedFileName}
-              className="inline-flex items-center gap-2 px-5 py-3 bg-foreground text-background hover:bg-foreground/90 transition-colors disabled:opacity-50"
+              className="h-auto bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
             >
               <Sparkles className="w-4 h-4" />
               {isDetecting ? "Detecting items..." : "Detect items"}
-            </button>
+            </PrimitiveButton>
           </div>
         </div>
       </UploadWorkspace>
@@ -240,15 +244,15 @@ export function CreateItemImageMode({
         <PrimitiveText as="p" variant="bodySm" tone="muted">
           Selected items will use the best available crop from the uploaded image.
         </PrimitiveText>
-        <button
+        <PrimitiveButton
           type="button"
           onClick={onSaveSelectedItems}
           disabled={isCreating || selectedCount === 0}
-          className="inline-flex items-center gap-2 px-5 py-3 bg-foreground text-background hover:bg-foreground/90 transition-colors disabled:opacity-50"
+          className="h-auto bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
         >
           <Check className="w-4 h-4" />
           {isCreating ? "Saving..." : "Save to closet"}
-        </button>
+        </PrimitiveButton>
       </div>
     </div>
   );

--- a/front-end/src/app/components/create-item/DetectionReviewCard.tsx
+++ b/front-end/src/app/components/create-item/DetectionReviewCard.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../lib/closet";
 import { AiCleanImageButton } from "../AiCleanImageButton";
 import { ItemMetadataFields } from "../ItemMetadataFields";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
 import { PrimitiveText } from "../primitives/PrimitiveText";
 
 interface DetectionReviewCardProps {
@@ -126,27 +127,28 @@ export function DetectionReviewCard({
       )}
 
       <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
-        <button
+        <PrimitiveButton
           type="button"
           onClick={onToggleEdit}
-          className="inline-flex items-center gap-2 px-4 py-2 border border-border hover:border-foreground transition-colors"
+          variant="outline"
         >
           <PencilLine className="w-4 h-4" />
           {isEditing ? "Done editing" : "Edit"}
-        </button>
-        <button
+        </PrimitiveButton>
+        <PrimitiveButton
           type="button"
           onClick={onToggle}
           disabled={!canSave}
-          className={`inline-flex items-center gap-2 px-4 py-2 border transition-colors disabled:opacity-50 ${
+          className={`disabled:opacity-50 ${
             isSelected
               ? "border-foreground bg-foreground text-background"
               : "border-border hover:border-foreground"
           }`}
+          variant="outline"
         >
           <Check className="w-4 h-4" />
           {isSelected ? "Will save to closet" : canSave ? "Add to closet" : "Preview unavailable"}
-        </button>
+        </PrimitiveButton>
       </div>
     </motion.div>
   );

--- a/front-end/src/app/components/create-item/DetectionReviewCard.tsx
+++ b/front-end/src/app/components/create-item/DetectionReviewCard.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../lib/closet";
 import { AiCleanImageButton } from "../AiCleanImageButton";
 import { ItemMetadataFields } from "../ItemMetadataFields";
+import { PrimitiveText } from "../primitives/PrimitiveText";
 
 interface DetectionReviewCardProps {
   cleanImageError?: string;
@@ -62,9 +63,9 @@ export function DetectionReviewCard({
     >
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="uppercase tracking-[0.2em] text-xs text-muted-foreground mb-2">
+          <PrimitiveText as="p" variant="overline" tone="muted" className="mb-2">
             {formatTagLabel(detection.category)}
-          </p>
+          </PrimitiveText>
           <h3>{suggestedName}</h3>
         </div>
         <div className="h-10 w-10 border border-border rounded-full flex items-center justify-center bg-muted">
@@ -72,14 +73,12 @@ export function DetectionReviewCard({
         </div>
       </div>
 
-      <p className="text-sm text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
-        {confidenceLabel}
-      </p>
+      <PrimitiveText as="p" variant="bodySm" tone="muted">{confidenceLabel}</PrimitiveText>
 
       <div className="flex items-center justify-between gap-4">
-        <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+        <PrimitiveText as="p" variant="overline" tone="muted">
           {cleanedImageUrl ? "AI-Cleaned Preview" : "Automated Crop Preview"}
-        </p>
+        </PrimitiveText>
         <AiCleanImageButton
           disabled={!cleanedImageUrl && !previewBox}
           isLoading={isCleaningImage}
@@ -111,7 +110,7 @@ export function DetectionReviewCard({
         </div>
       )}
 
-      <div className="grid gap-3 sm:grid-cols-2 text-sm" style={{ fontFamily: "Outfit, sans-serif" }}>
+      <div className="grid gap-3 sm:grid-cols-2">
         <DetectionDetail label="Color" value={detection.details.dominant_color} />
         <DetectionDetail label="Material" value={detection.details.material_guess} />
         <DetectionDetail label="Style" value={detection.details.style_guess} />
@@ -211,8 +210,12 @@ function DetectionCropPreview({
 function DetectionDetail({ label, value }: { label: string; value?: string | null }) {
   return (
     <div className="border border-border/80 bg-background/40 px-3 py-3">
-      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-2">{label}</p>
-      <p>{value?.trim() ? value : "Not provided"}</p>
+      <PrimitiveText as="p" variant="overline" tone="muted" className="mb-2">
+        {label}
+      </PrimitiveText>
+      <PrimitiveText as="p" variant="bodySm">
+        {value?.trim() ? value : "Not provided"}
+      </PrimitiveText>
     </div>
   );
 }

--- a/front-end/src/app/components/primitives/PrimitiveButton.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveButton.tsx
@@ -2,9 +2,9 @@ import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "./utils";
+import { cn } from "../ui/utils";
 
-const buttonVariants = cva(
+const primitiveButtonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
@@ -34,14 +34,14 @@ const buttonVariants = cva(
   },
 );
 
-function Button({
+function PrimitiveButton({
   className,
   variant,
   size,
   asChild = false,
   ...props
 }: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
+  VariantProps<typeof primitiveButtonVariants> & {
     asChild?: boolean;
   }) {
   const Comp = asChild ? Slot : "button";
@@ -49,10 +49,10 @@ function Button({
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(primitiveButtonVariants({ variant, size, className }))}
       {...props}
     />
   );
 }
 
-export { Button, buttonVariants };
+export { PrimitiveButton, primitiveButtonVariants };

--- a/front-end/src/app/components/primitives/PrimitiveButton.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveButton.tsx
@@ -39,6 +39,7 @@ function PrimitiveButton({
   variant,
   size,
   asChild = false,
+  style,
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof primitiveButtonVariants> & {
@@ -50,6 +51,7 @@ function PrimitiveButton({
     <Comp
       data-slot="button"
       className={cn(primitiveButtonVariants({ variant, size, className }))}
+      style={{ fontFamily: "Outfit, sans-serif", ...style }}
       {...props}
     />
   );

--- a/front-end/src/app/components/primitives/PrimitiveDropdownMenu.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveDropdownMenu.tsx
@@ -4,15 +4,15 @@ import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
-import { cn } from "./utils";
+import { cn } from "../ui/utils";
 
-function DropdownMenu({
+function PrimitiveDropdownMenu({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
-function DropdownMenuPortal({
+function PrimitiveDropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
   return (
@@ -20,7 +20,7 @@ function DropdownMenuPortal({
   );
 }
 
-function DropdownMenuTrigger({
+function PrimitiveDropdownMenuTrigger({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
   return (
@@ -31,7 +31,7 @@ function DropdownMenuTrigger({
   );
 }
 
-function DropdownMenuContent({
+function PrimitiveDropdownMenuContent({
   className,
   sideOffset = 4,
   ...props
@@ -51,7 +51,7 @@ function DropdownMenuContent({
   );
 }
 
-function DropdownMenuGroup({
+function PrimitiveDropdownMenuGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
   return (
@@ -59,7 +59,7 @@ function DropdownMenuGroup({
   );
 }
 
-function DropdownMenuItem({
+function PrimitiveDropdownMenuItem({
   className,
   inset,
   variant = "default",
@@ -82,7 +82,7 @@ function DropdownMenuItem({
   );
 }
 
-function DropdownMenuCheckboxItem({
+function PrimitiveDropdownMenuCheckboxItem({
   className,
   children,
   checked,
@@ -108,7 +108,7 @@ function DropdownMenuCheckboxItem({
   );
 }
 
-function DropdownMenuRadioGroup({
+function PrimitiveDropdownMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
   return (
@@ -119,7 +119,7 @@ function DropdownMenuRadioGroup({
   );
 }
 
-function DropdownMenuRadioItem({
+function PrimitiveDropdownMenuRadioItem({
   className,
   children,
   ...props
@@ -143,7 +143,7 @@ function DropdownMenuRadioItem({
   );
 }
 
-function DropdownMenuLabel({
+function PrimitiveDropdownMenuLabel({
   className,
   inset,
   ...props
@@ -163,7 +163,7 @@ function DropdownMenuLabel({
   );
 }
 
-function DropdownMenuSeparator({
+function PrimitiveDropdownMenuSeparator({
   className,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
@@ -176,7 +176,7 @@ function DropdownMenuSeparator({
   );
 }
 
-function DropdownMenuShortcut({
+function PrimitiveDropdownMenuShortcut({
   className,
   ...props
 }: React.ComponentProps<"span">) {
@@ -192,13 +192,13 @@ function DropdownMenuShortcut({
   );
 }
 
-function DropdownMenuSub({
+function PrimitiveDropdownMenuSub({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
   return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
 }
 
-function DropdownMenuSubTrigger({
+function PrimitiveDropdownMenuSubTrigger({
   className,
   inset,
   children,
@@ -222,7 +222,7 @@ function DropdownMenuSubTrigger({
   );
 }
 
-function DropdownMenuSubContent({
+function PrimitiveDropdownMenuSubContent({
   className,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
@@ -239,19 +239,19 @@ function DropdownMenuSubContent({
 }
 
 export {
-  DropdownMenu,
-  DropdownMenuPortal,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuLabel,
-  DropdownMenuItem,
-  DropdownMenuCheckboxItem,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSeparator,
-  DropdownMenuShortcut,
-  DropdownMenuSub,
-  DropdownMenuSubTrigger,
-  DropdownMenuSubContent,
+  PrimitiveDropdownMenu,
+  PrimitiveDropdownMenuPortal,
+  PrimitiveDropdownMenuTrigger,
+  PrimitiveDropdownMenuContent,
+  PrimitiveDropdownMenuGroup,
+  PrimitiveDropdownMenuLabel,
+  PrimitiveDropdownMenuItem,
+  PrimitiveDropdownMenuCheckboxItem,
+  PrimitiveDropdownMenuRadioGroup,
+  PrimitiveDropdownMenuRadioItem,
+  PrimitiveDropdownMenuSeparator,
+  PrimitiveDropdownMenuShortcut,
+  PrimitiveDropdownMenuSub,
+  PrimitiveDropdownMenuSubTrigger,
+  PrimitiveDropdownMenuSubContent,
 };

--- a/front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { ChevronDown } from "lucide-react";
+
+import { primitiveSelectTriggerVariants } from "./PrimitiveSelect";
+import { cn } from "../ui/utils";
+
+function PrimitiveDropdownTriggerButton({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"button">) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        primitiveSelectTriggerVariants({ size: "default" }),
+        "h-14 bg-stone-200 hover:bg-stone-200",
+        className,
+      )}
+      {...props}
+    >
+      <span className="flex min-w-0 flex-1 items-center gap-2 truncate text-left">
+        {children}
+      </span>
+      <ChevronDown className="size-4 opacity-50" />
+    </button>
+  );
+}
+
+export { PrimitiveDropdownTriggerButton };

--- a/front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx
@@ -15,16 +15,16 @@ function PrimitiveDropdownTriggerButton({
       type="button"
       className={cn(
         primitiveSelectTriggerVariants({ size: "default" }),
-        "h-14 bg-stone-200 hover:bg-stone-200",
+        "relative h-14 bg-stone-200 pr-10 hover:bg-stone-200",
         className,
       )}
       style={{ fontFamily: "Outfit, sans-serif", ...style }}
       {...props}
     >
-      <span className="flex min-w-0 flex-1 items-center gap-2 truncate text-left">
+      <span className="block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-left">
         {children}
       </span>
-      <ChevronDown className="size-4 opacity-50" />
+      <ChevronDown className="pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 opacity-50" />
     </button>
   );
 }

--- a/front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx
@@ -7,6 +7,7 @@ import { cn } from "../ui/utils";
 function PrimitiveDropdownTriggerButton({
   children,
   className,
+  style,
   ...props
 }: React.ComponentProps<"button">) {
   return (
@@ -17,6 +18,7 @@ function PrimitiveDropdownTriggerButton({
         "h-14 bg-stone-200 hover:bg-stone-200",
         className,
       )}
+      style={{ fontFamily: "Outfit, sans-serif", ...style }}
       {...props}
     >
       <span className="flex min-w-0 flex-1 items-center gap-2 truncate text-left">

--- a/front-end/src/app/components/primitives/PrimitiveSelect.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveSelect.tsx
@@ -2,33 +2,49 @@
 
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
+import { cva } from "class-variance-authority";
 import {
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
 } from "lucide-react";
 
-import { cn } from "./utils";
+import { cn } from "../ui/utils";
 
-function Select({
+function PrimitiveSelect({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
   return <SelectPrimitive.Root data-slot="select" {...props} />;
 }
 
-function SelectGroup({
+function PrimitiveSelectGroup({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Group>) {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
-function SelectValue({
+function PrimitiveSelectValue({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Value>) {
   return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
-function SelectTrigger({
+const primitiveSelectTriggerVariants = cva(
+  "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-full items-center justify-between gap-2 rounded-md border bg-input-background px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      size: {
+        default: "h-9",
+        sm: "h-8",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  },
+);
+
+function PrimitiveSelectTrigger({
   className,
   size = "default",
   children,
@@ -40,10 +56,7 @@ function SelectTrigger({
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
-      className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-full items-center justify-between gap-2 rounded-md border bg-input-background px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className,
-      )}
+      className={cn(primitiveSelectTriggerVariants({ size }), className)}
       {...props}
     >
       {children}
@@ -54,7 +67,7 @@ function SelectTrigger({
   );
 }
 
-function SelectContent({
+function PrimitiveSelectContent({
   className,
   children,
   position = "popper",
@@ -73,7 +86,7 @@ function SelectContent({
         position={position}
         {...props}
       >
-        <SelectScrollUpButton />
+        <PrimitiveSelectScrollUpButton />
         <SelectPrimitive.Viewport
           className={cn(
             "p-1",
@@ -83,13 +96,13 @@ function SelectContent({
         >
           {children}
         </SelectPrimitive.Viewport>
-        <SelectScrollDownButton />
+        <PrimitiveSelectScrollDownButton />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
   );
 }
 
-function SelectLabel({
+function PrimitiveSelectLabel({
   className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Label>) {
@@ -102,7 +115,7 @@ function SelectLabel({
   );
 }
 
-function SelectItem({
+function PrimitiveSelectItem({
   className,
   children,
   ...props
@@ -126,7 +139,7 @@ function SelectItem({
   );
 }
 
-function SelectSeparator({
+function PrimitiveSelectSeparator({
   className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Separator>) {
@@ -139,7 +152,7 @@ function SelectSeparator({
   );
 }
 
-function SelectScrollUpButton({
+function PrimitiveSelectScrollUpButton({
   className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
@@ -157,7 +170,7 @@ function SelectScrollUpButton({
   );
 }
 
-function SelectScrollDownButton({
+function PrimitiveSelectScrollDownButton({
   className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
@@ -176,14 +189,15 @@ function SelectScrollDownButton({
 }
 
 export {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectScrollDownButton,
-  SelectScrollUpButton,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue,
+  PrimitiveSelect,
+  PrimitiveSelectContent,
+  PrimitiveSelectGroup,
+  PrimitiveSelectItem,
+  PrimitiveSelectLabel,
+  PrimitiveSelectScrollDownButton,
+  PrimitiveSelectScrollUpButton,
+  PrimitiveSelectSeparator,
+  PrimitiveSelectTrigger,
+  PrimitiveSelectValue,
+  primitiveSelectTriggerVariants,
 };

--- a/front-end/src/app/components/primitives/PrimitiveText.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveText.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../ui/utils";
+
+const primitiveTextVariants = cva("", {
+  variants: {
+    variant: {
+      display: "text-2xl leading-tight md:text-3xl",
+      title: "text-lg leading-snug",
+      body: "text-base leading-relaxed",
+      bodySm: "text-sm leading-relaxed",
+      caption: "text-xs leading-normal",
+      label: "text-sm leading-none font-medium",
+      overline: "text-xs leading-normal uppercase tracking-[0.3em]",
+      stat: "text-xl leading-none",
+    },
+    tone: {
+      default: "text-foreground",
+      muted: "text-muted-foreground",
+      destructive: "text-destructive",
+      destructiveSoft: "text-destructive/80",
+    },
+    weight: {
+      regular: "font-normal",
+      medium: "font-medium",
+      semibold: "font-semibold",
+    },
+  },
+  defaultVariants: {
+    variant: "body",
+    tone: "default",
+    weight: "regular",
+  },
+});
+
+const primitiveTextFontStyles = {
+  inherit: undefined,
+  sans: { fontFamily: "Outfit, sans-serif" },
+  serif: { fontFamily: "Cormorant Garamond, serif" },
+} satisfies Record<string, React.CSSProperties | undefined>;
+
+type PrimitiveTextOwnProps = VariantProps<typeof primitiveTextVariants> & {
+  as?: React.ElementType;
+  font?: keyof typeof primitiveTextFontStyles;
+};
+
+type PrimitiveTextProps<C extends React.ElementType> = PrimitiveTextOwnProps &
+  Omit<React.ComponentPropsWithoutRef<C>, keyof PrimitiveTextOwnProps | "as">;
+
+function PrimitiveText<C extends React.ElementType = "p">({
+  as,
+  className,
+  font = "sans",
+  style,
+  tone,
+  variant,
+  weight,
+  ...props
+}: PrimitiveTextProps<C>) {
+  const Component = as ?? "p";
+
+  return (
+    <Component
+      className={cn(primitiveTextVariants({ variant, tone, weight }), className)}
+      style={{
+        ...primitiveTextFontStyles[font],
+        ...style,
+      }}
+      {...props}
+    />
+  );
+}
+
+export { PrimitiveText, primitiveTextVariants };

--- a/front-end/src/app/components/shared/AccessRestrictedState.tsx
+++ b/front-end/src/app/components/shared/AccessRestrictedState.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft } from "lucide-react";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
 import { PrimitiveText } from "../primitives/PrimitiveText";
 
 interface AccessRestrictedStateProps {
@@ -15,13 +16,14 @@ export function AccessRestrictedState({
   return (
     <div className="min-h-screen bg-background">
       <div className="max-w-3xl mx-auto px-6 py-16">
-        <button
+        <PrimitiveButton
           onClick={onBack}
-          className="inline-flex items-center gap-2 mb-8 text-muted-foreground hover:text-foreground transition-colors"
+          variant="ghost"
+          className="mb-8 h-auto px-0 py-0 text-muted-foreground"
         >
           <ArrowLeft className="w-4 h-4" />
           {backLabel}
-        </button>
+        </PrimitiveButton>
 
         <div className="border border-destructive/20 bg-destructive/5 p-8">
           <PrimitiveText

--- a/front-end/src/app/components/shared/AccessRestrictedState.tsx
+++ b/front-end/src/app/components/shared/AccessRestrictedState.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft } from "lucide-react";
+import { PrimitiveText } from "../primitives/PrimitiveText";
 
 interface AccessRestrictedStateProps {
   backLabel: string;
@@ -23,16 +24,20 @@ export function AccessRestrictedState({
         </button>
 
         <div className="border border-destructive/20 bg-destructive/5 p-8">
-          <p
-            className="uppercase tracking-[0.3em] text-xs text-destructive/80 mb-3"
-            style={{ fontFamily: "Outfit, sans-serif" }}
+          <PrimitiveText
+            as="p"
+            variant="overline"
+            tone="destructiveSoft"
+            className="mb-3"
           >
             Access Restricted
-          </p>
-          <h1 className="mb-3">You are not authorized to view this page.</h1>
-          <p className="text-muted-foreground" style={{ fontFamily: "Outfit, sans-serif" }}>
+          </PrimitiveText>
+          <PrimitiveText as="h1" variant="display" font="serif" className="mb-3">
+            You are not authorized to view this page.
+          </PrimitiveText>
+          <PrimitiveText as="p" tone="muted">
             {message}
-          </p>
+          </PrimitiveText>
         </div>
       </div>
     </div>

--- a/front-end/src/app/components/ui/alert-dialog.tsx
+++ b/front-end/src/app/components/ui/alert-dialog.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
 import { cn } from "./utils";
-import { buttonVariants } from "./button";
+import { primitiveButtonVariants } from "../primitives/PrimitiveButton";
 
 function AlertDialog({
   ...props
@@ -124,7 +124,7 @@ function AlertDialogAction({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
   return (
     <AlertDialogPrimitive.Action
-      className={cn(buttonVariants(), className)}
+      className={cn(primitiveButtonVariants(), className)}
       {...props}
     />
   );
@@ -136,7 +136,7 @@ function AlertDialogCancel({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
   return (
     <AlertDialogPrimitive.Cancel
-      className={cn(buttonVariants({ variant: "outline" }), className)}
+      className={cn(primitiveButtonVariants({ variant: "outline" }), className)}
       {...props}
     />
   );

--- a/front-end/src/app/components/ui/calendar.tsx
+++ b/front-end/src/app/components/ui/calendar.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { DayPicker } from "react-day-picker";
 
 import { cn } from "./utils";
-import { buttonVariants } from "./button";
+import { primitiveButtonVariants } from "../primitives/PrimitiveButton";
 
 function Calendar({
   className,
@@ -24,7 +24,7 @@ function Calendar({
         caption_label: "text-sm font-medium",
         nav: "flex items-center gap-1",
         nav_button: cn(
-          buttonVariants({ variant: "outline" }),
+          primitiveButtonVariants({ variant: "outline" }),
           "size-7 bg-transparent p-0 opacity-50 hover:opacity-100",
         ),
         nav_button_previous: "absolute left-1",
@@ -41,7 +41,7 @@ function Calendar({
             : "[&:has([aria-selected])]:rounded-md",
         ),
         day: cn(
-          buttonVariants({ variant: "ghost" }),
+          primitiveButtonVariants({ variant: "ghost" }),
           "size-8 p-0 font-normal aria-selected:opacity-100",
         ),
         day_range_start:

--- a/front-end/src/app/components/ui/carousel.tsx
+++ b/front-end/src/app/components/ui/carousel.tsx
@@ -7,7 +7,7 @@ import useEmblaCarousel, {
 import { ArrowLeft, ArrowRight } from "lucide-react";
 
 import { cn } from "./utils";
-import { Button } from "./button";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
 
 type CarouselApi = UseEmblaCarouselType[1];
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
@@ -176,11 +176,11 @@ function CarouselPrevious({
   variant = "outline",
   size = "icon",
   ...props
-}: React.ComponentProps<typeof Button>) {
+}: React.ComponentProps<typeof PrimitiveButton>) {
   const { orientation, scrollPrev, canScrollPrev } = useCarousel();
 
   return (
-    <Button
+    <PrimitiveButton
       data-slot="carousel-previous"
       variant={variant}
       size={size}
@@ -197,7 +197,7 @@ function CarouselPrevious({
     >
       <ArrowLeft />
       <span className="sr-only">Previous slide</span>
-    </Button>
+    </PrimitiveButton>
   );
 }
 
@@ -206,11 +206,11 @@ function CarouselNext({
   variant = "outline",
   size = "icon",
   ...props
-}: React.ComponentProps<typeof Button>) {
+}: React.ComponentProps<typeof PrimitiveButton>) {
   const { orientation, scrollNext, canScrollNext } = useCarousel();
 
   return (
-    <Button
+    <PrimitiveButton
       data-slot="carousel-next"
       variant={variant}
       size={size}
@@ -227,7 +227,7 @@ function CarouselNext({
     >
       <ArrowRight />
       <span className="sr-only">Next slide</span>
-    </Button>
+    </PrimitiveButton>
   );
 }
 

--- a/front-end/src/app/components/ui/pagination.tsx
+++ b/front-end/src/app/components/ui/pagination.tsx
@@ -6,7 +6,10 @@ import {
 } from "lucide-react";
 
 import { cn } from "./utils";
-import { Button, buttonVariants } from "./button";
+import {
+  PrimitiveButton,
+  primitiveButtonVariants,
+} from "../primitives/PrimitiveButton";
 
 function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
   return (
@@ -39,7 +42,7 @@ function PaginationItem({ ...props }: React.ComponentProps<"li">) {
 
 type PaginationLinkProps = {
   isActive?: boolean;
-} & Pick<React.ComponentProps<typeof Button>, "size"> &
+} & Pick<React.ComponentProps<typeof PrimitiveButton>, "size"> &
   React.ComponentProps<"a">;
 
 function PaginationLink({
@@ -54,7 +57,7 @@ function PaginationLink({
       data-slot="pagination-link"
       data-active={isActive}
       className={cn(
-        buttonVariants({
+        primitiveButtonVariants({
           variant: isActive ? "outline" : "ghost",
           size,
         }),

--- a/front-end/src/app/components/ui/sidebar.tsx
+++ b/front-end/src/app/components/ui/sidebar.tsx
@@ -7,7 +7,7 @@ import { PanelLeftIcon } from "lucide-react";
 
 import { useIsMobile } from "./use-mobile";
 import { cn } from "./utils";
-import { Button } from "./button";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
 import { Input } from "./input";
 import { Separator } from "./separator";
 import {
@@ -257,11 +257,11 @@ function SidebarTrigger({
   className,
   onClick,
   ...props
-}: React.ComponentProps<typeof Button>) {
+}: React.ComponentProps<typeof PrimitiveButton>) {
   const { toggleSidebar } = useSidebar();
 
   return (
-    <Button
+    <PrimitiveButton
       data-sidebar="trigger"
       data-slot="sidebar-trigger"
       variant="ghost"
@@ -275,7 +275,7 @@ function SidebarTrigger({
     >
       <PanelLeftIcon />
       <span className="sr-only">Toggle Sidebar</span>
-    </Button>
+    </PrimitiveButton>
   );
 }
 

--- a/front-end/src/app/lib/closetFilters.ts
+++ b/front-end/src/app/lib/closetFilters.ts
@@ -2,6 +2,44 @@ import { ClothingItem } from "./closet";
 
 export type ClosetSortOption = "name-asc" | "newest-added" | "oldest-added" | "recent-purchase";
 
+const COLOR_TAGS = new Set([
+  "beige",
+  "black",
+  "blue",
+  "brown",
+  "burgundy",
+  "charcoal",
+  "cream",
+  "dark blue",
+  "gold",
+  "gray",
+  "green",
+  "grey",
+  "indigo",
+  "ivory",
+  "khaki",
+  "maroon",
+  "navy",
+  "oatmeal",
+  "olive",
+  "orange",
+  "pink",
+  "purple",
+  "red",
+  "sand",
+  "silver",
+  "tan",
+  "teal",
+  "white",
+  "yellow",
+]);
+
+export interface GroupedTagOptions {
+  brands: string[];
+  colors: string[];
+  other: string[];
+}
+
 export function matchesSearchQuery(item: ClothingItem, query: string) {
   const normalizedQuery = query.trim().toLowerCase();
   if (!normalizedQuery) {
@@ -44,15 +82,47 @@ export function buildTagOptions(items: ClothingItem[]) {
   );
 }
 
+export function buildGroupedTagOptions(items: ClothingItem[]): GroupedTagOptions {
+  const uniqueTags = buildTagOptions(items);
+  const brandCandidates = new Set(
+    items
+      .map((item) => item.tags[0]?.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  const grouped = uniqueTags.reduce<GroupedTagOptions>(
+    (result, tag) => {
+      const normalizedTag = tag.trim().toLowerCase();
+
+      if (COLOR_TAGS.has(normalizedTag)) {
+        result.colors.push(tag);
+      } else if (brandCandidates.has(normalizedTag)) {
+        result.brands.push(tag);
+      } else {
+        result.other.push(tag);
+      }
+
+      return result;
+    },
+    { brands: [], colors: [], other: [] },
+  );
+
+  return {
+    brands: grouped.brands.sort((left, right) => left.localeCompare(right)),
+    colors: grouped.colors.sort((left, right) => left.localeCompare(right)),
+    other: grouped.other.sort((left, right) => left.localeCompare(right)),
+  };
+}
+
 export function filterClothingItems(
   items: ClothingItem[],
   searchQuery: string,
-  selectedTag: string,
+  selectedTags: string[],
   sortOption: ClosetSortOption,
 ) {
   return sortClothingItems(
     items.filter((item) => {
-      if (selectedTag !== "all" && !item.tags.includes(selectedTag)) {
+      if (selectedTags.length > 0 && !selectedTags.some((tag) => item.tags.includes(tag))) {
         return false;
       }
 
@@ -64,8 +134,8 @@ export function filterClothingItems(
 
 export function hasActiveClosetControls(
   searchQuery: string,
-  selectedTag: string,
+  selectedTags: string[],
   sortOption: ClosetSortOption,
 ) {
-  return searchQuery.trim().length > 0 || selectedTag !== "all" || sortOption !== "name-asc";
+  return searchQuery.trim().length > 0 || selectedTags.length > 0 || sortOption !== "name-asc";
 }


### PR DESCRIPTION
# Standardize frontend primitives and polish closet filter controls

## Summary

This PR standardizes the frontend around a shared primitives layer and applies that system across the app. It also improves the closet filter experience by making multi-select filters easier to understand and clear.

## Why

We had a lot of repeated one-off styling for buttons, dropdowns, and typography, which made the UI harder to keep consistent and harder to evolve safely.

The closet filters also needed usability improvements: selected filter combinations were too restrictive, clearing filters was awkward, and long selected labels did not truncate cleanly.

## What changed

- Extracted and renamed the shared UI control layer into explicit primitives:
  - `PrimitiveButton`
  - `PrimitiveSelect`
  - `PrimitiveDropdownMenu`
  - `PrimitiveDropdownTriggerButton`
- Added a new `PrimitiveText` component to centralize typography styles, font choices, and text variants.
- Migrated app screens and shared components to use the primitives instead of custom button and text styling.
- Updated repo guidance in `AGENTS.md` so future UI work uses the primitives by default.
- Changed closet filter matching so selected tags behave as an OR selection instead of requiring every selected filter to match.
- Added per-filter clear actions for Tags, Colors, and Brands.
- Moved the clear action into the dropdown control itself as a small red X, positioned just to the left of the chevron.
- Fixed filter trigger truncation so long selected values render with an ellipsis instead of clipping.
- Updated the add-item dropdown labels to:
  - `Detect Items from Image`
  - `Add Item`

## Implementation details

- Shared primitives now live in `front-end/src/app/components/primitives/`.
- `PrimitiveButton` now carries the shared button font styling, so app-level buttons do not need one-off font declarations.
- `PrimitiveText` provides reusable variants for common patterns like display headings, titles, body text, captions, overlines, labels, and stat text.
- Animated card-style interactions that still needed motion behavior were updated to use `motion.create(PrimitiveButton)` where appropriate, so they stay aligned with the primitive system.
- The closet filter logic in `closetFilters.ts` now checks whether an item matches any selected filter value rather than all selected values.
- The filter trigger layout was adjusted so the chevron stays pinned on the far right, while the clear X appears just to its left without shifting the trigger contents.

## Outcome

This gives us a much more consistent component foundation, reduces repeated UI code, and makes future interface work easier to extend without reintroducing styling drift.

It also makes the closet filters more forgiving and easier to clear in day-to-day use.




Closes #74 
Closes #75 