### PR TITLE
Add, Edit, and Detect Item UI improvements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
       bigdecimal (>= 3.1, < 5)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)

--- a/back-end/Gemfile.lock
+++ b/back-end/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
       bigdecimal (>= 3.1, < 5)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)

--- a/back-end/app/models/clothing_item.rb
+++ b/back-end/app/models/clothing_item.rb
@@ -4,6 +4,7 @@ class ClothingItem < ApplicationRecord
   has_many :outfits, through: :outfit_items
   has_one_attached :photo
   has_one_attached :cleaned_photo
+  before_validation :apply_defaults, on: :create
   before_validation :normalize_tags
   before_validation :normalize_brand
 
@@ -12,7 +13,8 @@ class ClothingItem < ApplicationRecord
     small: 1,
     medium: 2,
     large: 3,
-    xl: 4
+    xl: 4,
+    na: 5
   }
   enum :clean_image_status, {
     idle: 0,
@@ -56,5 +58,9 @@ class ClothingItem < ApplicationRecord
 
   def normalize_brand
     self.brand = brand.to_s.strip.presence
+  end
+
+  def apply_defaults
+    self.size = :na if size.blank?
   end
 end

--- a/back-end/test/integration/clothing_items_flow_test.rb
+++ b/back-end/test/integration/clothing_items_flow_test.rb
@@ -41,6 +41,22 @@ class ClothingItemsFlowTest < ActionDispatch::IntegrationTest
     assert_equal [ "wool", "camel", "tailored", "studio north" ], response_json["tags"]
   end
 
+  test "defaults size to na when omitted" do
+    assert_difference("ClothingItem.count", 1) do
+      post clothing_items_url, params: {
+        clothing_item: {
+          name: "Defaulted Item",
+          user_id: @user.id,
+          tags: [ "simple" ]
+        }
+      }, headers: auth_headers(@user), as: :json
+    end
+
+    assert_response :created
+    assert_equal "na", response_json["size"]
+    assert_nil response_json["date"]
+  end
+
   test "can create a clothing item with a photo" do
     assert_difference("ClothingItem.count", 1) do
       post clothing_items_url, params: {

--- a/back-end/test/models/clothing_item_test.rb
+++ b/back-end/test/models/clothing_item_test.rb
@@ -45,4 +45,11 @@ class ClothingItemTest < ActiveSupport::TestCase
 
     assert_equal [ "cos", "workwear" ], item.tags
   end
+
+  test "defaults size to na on create" do
+    item = ClothingItem.create!(user: users(:one), name: "Everyday Tee")
+
+    assert_equal "na", item.size
+    assert_nil item.date
+  end
 end

--- a/front-end/src/app/components/AiCleanImageButton.tsx
+++ b/front-end/src/app/components/AiCleanImageButton.tsx
@@ -1,9 +1,11 @@
 import { Sparkles } from "lucide-react";
 import { PrimitiveButton } from "./primitives/PrimitiveButton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 interface AiCleanImageButtonProps {
   className?: string;
   disabled?: boolean;
+  iconOnly?: boolean;
   isLoading?: boolean;
   label?: string;
   onClick: () => void;
@@ -12,20 +14,32 @@ interface AiCleanImageButtonProps {
 export function AiCleanImageButton({
   className = "",
   disabled = false,
+  iconOnly = false,
   isLoading = false,
   label = "AI clean PNG",
   onClick,
 }: AiCleanImageButtonProps) {
+  const buttonLabel = isLoading ? "Cleaning..." : label;
+  const isDisabled = disabled || isLoading;
+
   return (
-    <PrimitiveButton
-      type="button"
-      onClick={onClick}
-      disabled={disabled || isLoading}
-      variant="outline"
-      className={className}
-    >
-      <Sparkles className="w-4 h-4" />
-      {isLoading ? "Cleaning..." : label}
-    </PrimitiveButton>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={`inline-flex ${isDisabled ? "cursor-default" : "cursor-pointer"}`}>
+          <PrimitiveButton
+            type="button"
+            onClick={onClick}
+            disabled={isDisabled}
+            variant="outline"
+            className={className}
+            aria-label={buttonLabel}
+          >
+            <Sparkles className="w-4 h-4" />
+            {iconOnly ? null : buttonLabel}
+          </PrimitiveButton>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent sideOffset={8}>{label}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/front-end/src/app/components/CreateItemPage.tsx
+++ b/front-end/src/app/components/CreateItemPage.tsx
@@ -1,6 +1,5 @@
 import { FormEvent, useEffect, useRef, useState } from "react";
-import { motion } from "motion/react";
-import { ArrowLeft, Plus } from "lucide-react";
+import { ArrowLeft, Plus, Upload } from "lucide-react";
 import {
   ClothingItem,
   ClothingItemFormValues,
@@ -12,7 +11,6 @@ import {
   fetchOutfitUpload,
   fetchUser,
   formatDisplaySize,
-  formatPossessive,
   generateOutfitDetectionCleanImage,
   OutfitDetection,
   OutfitUpload,
@@ -23,11 +21,10 @@ import {
 import { usePageData } from "../lib/usePageData";
 import { AiCleanImageButton } from "./AiCleanImageButton";
 import { CreateItemImageMode } from "./create-item/CreateItemImageMode";
+import { ItemEditorWorkspace } from "./ItemEditorWorkspace";
 import { ItemMetadataFields } from "./ItemMetadataFields";
-import { ItemPhotoField } from "./ItemPhotoField";
 import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
-import { UploadWorkspace } from "./UploadWorkspace";
 import { useItemPhotoState } from "../lib/useItemPhotoState";
 
 interface CreateItemPageProps {
@@ -52,7 +49,6 @@ export function CreateItemPage({
   const [isCleaningUploadedPhoto, setIsCleaningUploadedPhoto] = useState(false);
   const [outfitUpload, setOutfitUpload] = useState<OutfitUpload | null>(null);
   const [selectedDetectionIds, setSelectedDetectionIds] = useState<number[]>([]);
-  const [editingDetectionIds, setEditingDetectionIds] = useState<number[]>([]);
   const [cleaningDetectionIds, setCleaningDetectionIds] = useState<number[]>([]);
   const [detectionCleanErrors, setDetectionCleanErrors] = useState<Record<number, string>>({});
   const [editedDetections, setEditedDetections] = useState<Record<number, ClothingItemFormValues>>(
@@ -91,7 +87,6 @@ export function CreateItemPage({
   function resetDetectionState() {
     setOutfitUpload(null);
     setSelectedDetectionIds([]);
-    setEditingDetectionIds([]);
     setCleaningDetectionIds([]);
     setDetectionCleanErrors({});
     setEditedDetections({});
@@ -165,6 +160,10 @@ export function CreateItemPage({
   }
 
   function handleImageFileChange(file: File | null) {
+    if (!file) {
+      return;
+    }
+
     detectionPollControllerRef.current?.abort();
     photoState.updateSelectedFile(file);
     resetDetectionState();
@@ -192,25 +191,6 @@ export function CreateItemPage({
 
   function getDetectionDraft(detection: OutfitDetection) {
     return editedDetections[detection.id] ?? toClothingItemFormValuesFromDetection(detection);
-  }
-
-  function toggleDetectionEditing(detection: OutfitDetection) {
-    setEditedDetections((current) => {
-      if (current[detection.id]) {
-        return current;
-      }
-
-      return {
-        ...current,
-        [detection.id]: toClothingItemFormValuesFromDetection(detection),
-      };
-    });
-
-    setEditingDetectionIds((current) =>
-      current.includes(detection.id)
-        ? current.filter((id) => id !== detection.id)
-        : [...current, detection.id],
-    );
   }
 
   function updateDetectionDraft(detectionId: number, nextValues: ClothingItemFormValues) {
@@ -349,8 +329,8 @@ export function CreateItemPage({
       <div className="max-w-5xl mx-auto px-6 py-12">
         <PrimitiveButton
           onClick={onBack}
-          variant="ghost"
-          className="mb-8 h-auto px-0 py-0 text-muted-foreground"
+          variant="outline"
+          className="mb-8 h-auto px-5 py-3"
         >
           <ArrowLeft className="w-4 h-4" />
           Back
@@ -373,7 +353,6 @@ export function CreateItemPage({
         cleaningDetectionIds={cleaningDetectionIds}
         detectionCleanErrors={detectionCleanErrors}
         detections={detections}
-        editingDetectionIds={editingDetectionIds}
         errorMessage={errorMessage}
         getDetectionDraft={getDetectionDraft}
         inputRef={photoState.inputRef}
@@ -386,7 +365,6 @@ export function CreateItemPage({
         onDraftChange={updateDetectionDraft}
         onFileChange={handleImageFileChange}
         onSaveSelectedItems={() => void handleSaveSelectedItems()}
-        onToggleEdit={toggleDetectionEditing}
         onToggleSelection={toggleDetectionSelection}
         outfitUpload={outfitUpload}
         selectedCount={selectedCount}
@@ -401,97 +379,67 @@ export function CreateItemPage({
   const previewName = formValues.name.trim() || "Untitled Item";
 
   return (
-    <div className="max-w-7xl mx-auto px-6 py-12">
-      <PrimitiveButton
-        onClick={onBack}
-        variant="ghost"
-        className="mb-8 h-auto px-0 py-0 text-muted-foreground"
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Back
-      </PrimitiveButton>
+    <ItemEditorWorkspace
+      backLabel="Back"
+      formLabel="Add Item"
+      imageUrl={photoState.imageUrl}
+      onBack={onBack}
+      onPreviewClick={() => photoState.inputRef.current?.click()}
+      onPreviewClear={photoState.clearSelectedFile}
+      onPreviewEdit={() => photoState.inputRef.current?.click()}
+      onSubmit={handleManualSubmit}
+      previewAriaLabel={photoState.selectedFile ? "Preview image" : "Upload photo"}
+      previewBackgroundDecoration={
+        <Upload
+          className="h-40 w-40 text-stone-700/18 sm:h-52 sm:w-52"
+          strokeWidth={1.1}
+        />
+      }
+      previewTopAction={
+        <AiCleanImageButton
+          className="size-11 border border-white/75 shadow-sm bg-white/70 p-0 backdrop-blur-sm hover:bg-white/85"
+          disabled={!photoState.selectedFile}
+          iconOnly
+          isLoading={isCleaningUploadedPhoto}
+          label="AI clean PNG"
+          onClick={() => void handleCleanUploadedPhoto()}
+        />
+      }
+      previewLabel="New Clothing Item"
+      previewPrimaryDetail={formatDisplaySize(formValues.size)}
+      previewTitle={previewName}
+      footer={
+        <div className="mt-auto pt-2 flex items-center justify-end">
+          <PrimitiveButton
+            type="submit"
+            disabled={isCreating}
+            className="h-auto bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
+          >
+            <Plus className="w-4 h-4" />
+            {isCreating ? "Creating..." : "Create Item"}
+          </PrimitiveButton>
+        </div>
+      }
+    >
+      <input
+        ref={photoState.inputRef}
+        type="file"
+        accept="image/*"
+        onChange={(event) => handleImageFileChange(event.target.files?.[0] ?? null)}
+        className="sr-only"
+      />
 
-      <motion.form
-        initial={{ opacity: 0, y: 18 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.45 }}
-        onSubmit={handleManualSubmit}
-        className="space-y-6"
-      >
-        <UploadWorkspace
-          imageUrl={photoState.imageUrl}
-          previewLabel="New Clothing Item"
-          previewPrimaryDetail={formatDisplaySize(formValues.size)}
-          previewSecondaryDetail={`Adding to ${formatPossessive(titleize(user.username))}`}
-          previewTitle={previewName}
-        >
-          <div>
-            <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
-              Add Item
-            </PrimitiveText>
-            <PrimitiveText as="h2" variant="title" font="serif" className="mb-1">
-              Create New Item
-            </PrimitiveText>
-            <PrimitiveText as="p" tone="muted">
-              Add the item details for {titleize(user.username)} and save it to the closet.
-            </PrimitiveText>
-          </div>
+      {errorMessage && (
+        <div className="border border-destructive/20 bg-destructive/5 p-4 text-sm" role="alert" aria-live="assertive">
+          {errorMessage}
+        </div>
+      )}
 
-          {errorMessage && (
-            <div className="border border-destructive/20 bg-destructive/5 p-4 text-sm" role="alert" aria-live="assertive">
-              {errorMessage}
-            </div>
-          )}
-
-          <div className="border border-border bg-card p-5">
-            <ItemPhotoField
-              description="Upload a photo to display behind the item title in the closet and detail views."
-              inputRef={photoState.inputRef}
-              onClearSelection={photoState.clearSelectedFile}
-              onFileChange={photoState.updateSelectedFile}
-              selectedFileName={photoState.selectedFile?.name}
-            />
-
-            <div className="mt-4 flex flex-wrap items-center justify-between gap-4 border border-border bg-background/40 px-4 py-3">
-              <PrimitiveText as="p" variant="bodySm" tone="muted">
-                {photoState.selectedFile
-                  ? "Use sparkle to turn the uploaded item photo into a cleaner catalog-style PNG before you save."
-                  : "Upload a photo first to use the AI cleaner."}
-              </PrimitiveText>
-              <AiCleanImageButton
-                disabled={!photoState.selectedFile}
-                isLoading={isCleaningUploadedPhoto}
-                onClick={() => void handleCleanUploadedPhoto()}
-              />
-            </div>
-          </div>
-
-          <div className="border border-border bg-card p-5">
-            <div className="mb-4">
-              <PrimitiveText as="p" variant="overline" tone="muted" className="mb-2">
-                Item Details
-              </PrimitiveText>
-              <PrimitiveText as="p" variant="bodySm" tone="muted">
-                Add the core metadata that should be saved with this item.
-              </PrimitiveText>
-            </div>
-            <div className="grid gap-5 sm:grid-cols-2">
-              <ItemMetadataFields values={formValues} onChange={setFormValues} />
-            </div>
-          </div>
-
-          <div className="border-t border-border pt-5 flex items-center justify-end">
-            <PrimitiveButton
-              type="submit"
-              disabled={isCreating}
-              className="h-auto bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
-            >
-              <Plus className="w-4 h-4" />
-              {isCreating ? "Creating..." : "Create Item"}
-            </PrimitiveButton>
-          </div>
-        </UploadWorkspace>
-      </motion.form>
-    </div>
+      <div className="border border-border bg-card p-5">
+        <div className="grid gap-5 sm:grid-cols-2">
+          <ItemMetadataFields values={formValues} onChange={setFormValues} />
+        </div>
+      </div>
+    </ItemEditorWorkspace>
   );
 }

--- a/front-end/src/app/components/ItemDetailPage.tsx
+++ b/front-end/src/app/components/ItemDetailPage.tsx
@@ -1,6 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
-import { motion } from "motion/react";
-import { ArrowLeft, Save, Trash2 } from "lucide-react";
+import { ArrowLeft, Save, Trash2, Upload } from "lucide-react";
 import {
   createCleanPreviewFile,
   ClothingItem,
@@ -16,9 +15,8 @@ import {
 } from "../lib/closet";
 import { usePageData } from "../lib/usePageData";
 import { AiCleanImageButton } from "./AiCleanImageButton";
-import { ItemHeroPreview } from "./ItemHeroPreview";
+import { ItemEditorWorkspace } from "./ItemEditorWorkspace";
 import { ItemMetadataFields } from "./ItemMetadataFields";
-import { ItemPhotoField } from "./ItemPhotoField";
 import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 import { useItemPhotoState } from "../lib/useItemPhotoState";
@@ -85,6 +83,23 @@ export function ItemDetailPage({
 
   const previewName = formValues?.name.trim() || item?.name?.trim() || "Untitled Item";
   const previewTags = formValues ? parseTagInput(formValues.tags).slice(0, 2) : [];
+
+  function handleEditImageFileChange(file: File | null) {
+    if (file) {
+      photoState.updateSelectedFile(file);
+    }
+  }
+
+  function handlePreviewClear() {
+    if (photoState.selectedFile) {
+      photoState.clearSelectedFile();
+      return;
+    }
+
+    if (item.image_url && !photoState.removeExisting) {
+      photoState.markExistingForRemoval();
+    }
+  }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -201,118 +216,90 @@ export function ItemDetailPage({
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-6 py-12">
-      <PrimitiveButton
-        onClick={onBack}
-        variant="ghost"
-        className="mb-8 h-auto px-0 py-0 text-muted-foreground"
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Back to closet
-      </PrimitiveButton>
-
-      <div className="grid gap-10 lg:grid-cols-[1.1fr_1fr] items-start">
-        <ItemHeroPreview
-          allowExpand
-          imageUrl={photoState.imageUrl}
-          label="Clothing Item"
-          primaryDetail={formatDisplaySize(formValues.size)}
-          secondaryDetail={previewTags.length > 0 ? previewTags.map(formatTagLabel).join(" · ") : null}
-          title={previewName}
-        />
-
-        <motion.form
-          initial={{ opacity: 0, y: 18 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.45, delay: 0.06 }}
-          onSubmit={handleSubmit}
-          className="space-y-6"
+    <ItemEditorWorkspace
+      backLabel="Back to closet"
+      formLabel="Edit Item"
+      formTopAction={
+        <PrimitiveButton
+          type="button"
+          onClick={() => void handleDelete()}
+          disabled={isDeleting}
+          variant="outline"
+          className="border-destructive/30 text-destructive hover:bg-destructive/5"
         >
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
-                Item Details
-              </PrimitiveText>
-              <PrimitiveText as="h2" variant="title" font="serif" className="mb-1">
-                Edit Item
-              </PrimitiveText>
-              <PrimitiveText as="p" tone="muted">
-                Update item details and save your changes.
-              </PrimitiveText>
-            </div>
+          <Trash2 className="w-4 h-4" />
+          {isDeleting ? "Deleting..." : "Delete"}
+        </PrimitiveButton>
+      }
+      imageUrl={photoState.imageUrl}
+      onBack={onBack}
+      onPreviewClick={() => photoState.inputRef.current?.click()}
+      onPreviewClear={handlePreviewClear}
+      onPreviewEdit={() => photoState.inputRef.current?.click()}
+      onSubmit={handleSubmit}
+      previewAriaLabel={photoState.imageUrl ? "Preview image" : "Upload photo"}
+      previewBackgroundDecoration={
+        <Upload
+          className="h-40 w-40 text-stone-700/18 sm:h-52 sm:w-52"
+          strokeWidth={1.1}
+        />
+      }
+      previewTopAction={
+        <AiCleanImageButton
+          className="size-11 border border-white/75 shadow-sm bg-white/70 p-0 backdrop-blur-sm hover:bg-white/85"
+          disabled={photoState.removeExisting || (!photoState.selectedFile && !item.image_url)}
+          iconOnly
+          isLoading={isCleaningImage}
+          label="AI clean PNG"
+          onClick={() => void handleCleanImage()}
+        />
+      }
+      previewLabel="Clothing Item"
+      previewPrimaryDetail={formatDisplaySize(formValues.size)}
+      previewSecondaryDetail={previewTags.length > 0 ? previewTags.map(formatTagLabel).join(" · ") : null}
+      previewTitle={previewName}
+      footer={
+        <div className="mt-auto pt-2 flex items-center justify-between gap-4">
+          <PrimitiveText as="div" variant="bodySm" tone="muted">
+            {isDirty ? "Unsaved changes" : "All changes saved"}
+          </PrimitiveText>
 
-            <PrimitiveButton
-              type="button"
-              onClick={() => void handleDelete()}
-              disabled={isDeleting}
-              variant="outline"
-              className="border-destructive/30 text-destructive hover:bg-destructive/5"
-            >
-              <Trash2 className="w-4 h-4" />
-              {isDeleting ? "Deleting..." : "Delete"}
-            </PrimitiveButton>
-          </div>
+          <PrimitiveButton
+            type="submit"
+            disabled={isSaving || !isDirty}
+            className="h-auto bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
+          >
+            <Save className="w-4 h-4" />
+            {isSaving ? "Saving..." : "Save Changes"}
+          </PrimitiveButton>
+        </div>
+      }
+    >
+      <input
+        ref={photoState.inputRef}
+        type="file"
+        accept="image/*"
+        onChange={(event) => handleEditImageFileChange(event.target.files?.[0] ?? null)}
+        className="sr-only"
+      />
 
-          {errorMessage && (
-            <div className="border border-destructive/20 bg-destructive/5 p-4 text-sm" role="alert" aria-live="assertive">
-              {errorMessage}
-            </div>
-          )}
+      {errorMessage && (
+        <div className="border border-destructive/20 bg-destructive/5 p-4 text-sm" role="alert" aria-live="assertive">
+          {errorMessage}
+        </div>
+      )}
 
-          {successMessage && (
-            <div className="border border-emerald-300/40 bg-emerald-50 p-4 text-sm text-emerald-900" role="status" aria-live="polite">
-              {successMessage}
-            </div>
-          )}
+      {successMessage && (
+        <div className="border border-emerald-300/40 bg-emerald-50 p-4 text-sm text-emerald-900" role="status" aria-live="polite">
+          {successMessage}
+        </div>
+      )}
 
-          <div className="grid gap-5 sm:grid-cols-2">
-            <div className="space-y-4 sm:col-span-2">
-              <ItemPhotoField
-                description="Upload a photo to display behind the item title throughout the closet."
-                hasExistingPhoto={Boolean(item.image_url)}
-                inputRef={photoState.inputRef}
-                isRemovingExisting={photoState.removeExisting}
-                onClearSelection={photoState.clearSelectedFile}
-                onFileChange={photoState.updateSelectedFile}
-                onKeepExisting={photoState.keepExistingPhoto}
-                onRemoveExisting={photoState.markExistingForRemoval}
-                selectedFileName={photoState.selectedFile?.name}
-              />
-
-              <div className="flex flex-wrap items-center justify-between gap-4 border border-border bg-card px-4 py-3">
-                <PrimitiveText as="p" variant="bodySm" tone="muted">
-                  {photoState.selectedFile
-                    ? "Run the AI cleaner on the newly selected image before saving."
-                    : item.image_url
-                      ? "Generate a cleaner catalog-style PNG from the current saved image."
-                      : "Upload a photo first to use the AI cleaner."}
-                </PrimitiveText>
-                <AiCleanImageButton
-                  disabled={photoState.removeExisting || (!photoState.selectedFile && !item.image_url)}
-                  isLoading={isCleaningImage}
-                  onClick={() => void handleCleanImage()}
-                />
-              </div>
-            </div>
-            <ItemMetadataFields values={formValues} onChange={setFormValues} />
-          </div>
-
-          <div className="border-t border-border pt-5 flex items-center justify-between gap-4">
-            <PrimitiveText as="div" variant="bodySm" tone="muted">
-              {isDirty ? "Unsaved changes" : "All changes saved"}
-            </PrimitiveText>
-
-            <PrimitiveButton
-              type="submit"
-              disabled={isSaving || !isDirty}
-              className="h-auto bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
-            >
-              <Save className="w-4 h-4" />
-              {isSaving ? "Saving..." : "Save Changes"}
-            </PrimitiveButton>
-          </div>
-        </motion.form>
+      <div className="border border-border bg-card p-5">
+        <div className="grid gap-5 sm:grid-cols-2">
+          <ItemMetadataFields values={formValues} onChange={setFormValues} />
+        </div>
       </div>
-    </div>
+    </ItemEditorWorkspace>
   );
 }

--- a/front-end/src/app/components/ItemEditorWorkspace.tsx
+++ b/front-end/src/app/components/ItemEditorWorkspace.tsx
@@ -1,0 +1,99 @@
+import { FormEvent, ReactNode } from "react";
+import { motion } from "motion/react";
+import { ArrowLeft } from "lucide-react";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
+import { PrimitiveText } from "./primitives/PrimitiveText";
+import { UploadWorkspace } from "./UploadWorkspace";
+
+interface ItemEditorWorkspaceProps {
+  backLabel?: string;
+  children: ReactNode;
+  footer: ReactNode;
+  formLabel: string;
+  formTopAction?: ReactNode;
+  imageUrl?: string | null;
+  onBack: () => void;
+  onPreviewClear?: () => void;
+  onPreviewClick?: () => void;
+  onPreviewEdit?: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  previewAriaLabel?: string;
+  previewBackgroundDecoration?: ReactNode;
+  previewLabel: string;
+  previewPrimaryDetail: string;
+  previewSecondaryDetail?: string | null;
+  previewTitle: string;
+  previewTopAction?: ReactNode;
+}
+
+export function ItemEditorWorkspace({
+  backLabel = "Back",
+  children,
+  footer,
+  formLabel,
+  formTopAction,
+  imageUrl,
+  onBack,
+  onPreviewClear,
+  onPreviewClick,
+  onPreviewEdit,
+  onSubmit,
+  previewAriaLabel,
+  previewBackgroundDecoration,
+  previewLabel,
+  previewPrimaryDetail,
+  previewSecondaryDetail,
+  previewTitle,
+  previewTopAction,
+}: ItemEditorWorkspaceProps) {
+  return (
+    <div className="max-w-7xl mx-auto px-6 py-12">
+      <PrimitiveButton
+        onClick={onBack}
+        variant="outline"
+        className="mb-8 h-auto px-5 py-3"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        {backLabel}
+      </PrimitiveButton>
+
+      <motion.form
+        initial={{ opacity: 0, y: 18 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.45 }}
+        onSubmit={onSubmit}
+        className="space-y-6"
+      >
+        <UploadWorkspace
+          imageUrl={imageUrl}
+          onPreviewClick={onPreviewClick}
+          onPreviewClear={onPreviewClear}
+          onPreviewEdit={onPreviewEdit}
+          previewAriaLabel={previewAriaLabel}
+          previewBackgroundDecoration={previewBackgroundDecoration}
+          previewTopAction={previewTopAction}
+          previewLabel={previewLabel}
+          previewPrimaryDetail={previewPrimaryDetail}
+          previewSecondaryDetail={previewSecondaryDetail}
+          previewTitle={previewTitle}
+        >
+          {formTopAction ? (
+            <div className="flex items-start justify-between gap-4">
+              <PrimitiveText as="p" variant="overline" tone="muted">
+                {formLabel}
+              </PrimitiveText>
+              {formTopAction}
+            </div>
+          ) : (
+            <PrimitiveText as="p" variant="overline" tone="muted">
+              {formLabel}
+            </PrimitiveText>
+          )}
+
+          {children}
+          {footer}
+        </UploadWorkspace>
+      </motion.form>
+    </div>
+  );
+}

--- a/front-end/src/app/components/ItemHeroPreview.tsx
+++ b/front-end/src/app/components/ItemHeroPreview.tsx
@@ -1,32 +1,57 @@
-import { useState } from "react";
+import { ReactNode, useState } from "react";
 import { motion } from "motion/react";
+import { Trash2, Upload } from "lucide-react";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from "./ui/dialog";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 
 interface ItemHeroPreviewProps {
   allowExpand?: boolean;
+  expandedPreview?: ReactNode;
   imageUrl?: string | null;
   label: string;
+  onPreviewClick?: () => void;
+  onPreviewClear?: () => void;
+  onPreviewEdit?: () => void;
   primaryDetail: string;
+  previewAriaLabel?: string;
+  previewBackgroundDecoration?: ReactNode;
+  previewMedia?: ReactNode;
+  previewTopAction?: ReactNode;
   secondaryDetail?: string | null;
   title: string;
 }
 
 export function ItemHeroPreview({
   allowExpand = false,
+  expandedPreview,
   imageUrl,
   label,
+  onPreviewClick,
+  onPreviewClear,
+  onPreviewEdit,
   primaryDetail,
+  previewAriaLabel,
+  previewBackgroundDecoration,
+  previewMedia,
+  previewTopAction,
   secondaryDetail,
   title,
 }: ItemHeroPreviewProps) {
   const [isImageExpanded, setIsImageExpanded] = useState(false);
-  const canExpand = Boolean(allowExpand && imageUrl);
+  const canExpand = Boolean(
+    (imageUrl || expandedPreview) && (allowExpand || onPreviewEdit || onPreviewClear),
+  );
+  const isInteractive = canExpand || Boolean(onPreviewClick);
+  const hasPreviewVisual = Boolean(imageUrl || previewMedia);
+  const baseBackgroundClass = hasPreviewVisual
+    ? "bg-gradient-to-br from-stone-100 via-neutral-50 to-stone-200"
+    : "bg-stone-300";
 
   return (
     <>
@@ -34,23 +59,64 @@ export function ItemHeroPreview({
         initial={{ opacity: 0, y: 18 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.45 }}
-        onClick={() => canExpand && setIsImageExpanded(true)}
+        onClick={() => {
+          if (canExpand) {
+            setIsImageExpanded(true);
+            return;
+          }
+
+          if (onPreviewClick) {
+            onPreviewClick();
+            return;
+          }
+        }}
         onKeyDown={(event) => {
-          if (!canExpand) {
+          if (!isInteractive) {
             return;
           }
 
           if (event.key === "Enter" || event.key === " ") {
             event.preventDefault();
-            setIsImageExpanded(true);
+            if (canExpand) {
+              setIsImageExpanded(true);
+              return;
+            }
+
+            if (onPreviewClick) {
+              onPreviewClick();
+              return;
+            }
           }
         }}
-        role={canExpand ? "button" : undefined}
-        tabIndex={canExpand ? 0 : undefined}
-        aria-label={canExpand ? `Expand image for ${title}` : undefined}
-        className={`relative aspect-[4/5] overflow-hidden border border-border p-8 flex flex-col justify-between bg-gradient-to-br from-stone-100 via-neutral-50 to-stone-200 ${canExpand ? "cursor-zoom-in" : ""}`}
+        role={isInteractive ? "button" : undefined}
+        tabIndex={isInteractive ? 0 : undefined}
+        aria-label={isInteractive ? (previewAriaLabel ?? `Expand image for ${title}`) : undefined}
+        className={`relative aspect-[4/5] w-full overflow-hidden border border-border p-8 flex flex-col justify-between lg:h-full lg:aspect-auto ${baseBackgroundClass} ${canExpand ? "cursor-zoom-in" : ""} ${onPreviewClick ? "cursor-pointer" : ""}`}
       >
-        {imageUrl && (
+        {previewTopAction ? (
+          <div
+            className="absolute top-6 right-6 z-30"
+            onClick={(event) => event.stopPropagation()}
+            onKeyDown={(event) => event.stopPropagation()}
+          >
+            {previewTopAction}
+          </div>
+        ) : null}
+
+        {previewBackgroundDecoration ? (
+          <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
+            {previewBackgroundDecoration}
+          </div>
+        ) : null}
+
+        {previewMedia ? (
+          <>
+            <div className="absolute inset-0">
+              {previewMedia}
+            </div>
+            <div className="absolute inset-0 bg-gradient-to-t from-black/75 via-black/30 to-black/10" />
+          </>
+        ) : imageUrl ? (
           <>
             <img
               src={imageUrl}
@@ -59,15 +125,15 @@ export function ItemHeroPreview({
             />
             <div className="absolute inset-0 bg-gradient-to-t from-black/75 via-black/30 to-black/10" />
           </>
-        )}
+        ) : null}
 
-        <div>
+        <div className="relative z-20">
           <PrimitiveText
             as="p"
             variant="overline"
-            className="relative mb-4"
+            className="mb-4"
             style={{
-              color: imageUrl ? "rgba(255,255,255,0.78)" : undefined,
+              color: hasPreviewVisual ? "rgba(255,255,255,0.78)" : undefined,
             }}
           >
             {label}
@@ -76,9 +142,9 @@ export function ItemHeroPreview({
             as="h1"
             variant="display"
             font="serif"
-            className="relative mb-0 max-w-[12ch] break-words"
+            className="mb-0 max-w-[12ch] break-words"
             style={{
-              color: imageUrl ? "white" : "rgba(68, 64, 60, 0.85)",
+              color: hasPreviewVisual ? "white" : "rgba(68, 64, 60, 0.85)",
               fontSize: "clamp(2.75rem, 5vw, 4.75rem)",
               lineHeight: "0.95",
             }}
@@ -87,11 +153,11 @@ export function ItemHeroPreview({
           </PrimitiveText>
         </div>
 
-        <div className="relative space-y-3">
+        <div className="relative z-20 space-y-3">
           <PrimitiveText
             as="p"
             style={{
-              color: imageUrl ? "rgba(255,255,255,0.82)" : undefined,
+              color: hasPreviewVisual ? "rgba(255,255,255,0.82)" : undefined,
             }}
           >
             {primaryDetail}
@@ -101,7 +167,7 @@ export function ItemHeroPreview({
               as="p"
               variant="bodySm"
               style={{
-                color: imageUrl ? "rgba(255,255,255,0.82)" : undefined,
+                color: hasPreviewVisual ? "rgba(255,255,255,0.82)" : undefined,
               }}
             >
               {secondaryDetail}
@@ -112,18 +178,61 @@ export function ItemHeroPreview({
 
       {canExpand && (
         <Dialog open={isImageExpanded} onOpenChange={setIsImageExpanded}>
-          <DialogContent className="max-w-[min(92vw,72rem)] border-none bg-black/95 p-4 shadow-2xl sm:p-6">
+          <DialogContent className="max-w-[min(88vw,56rem)] border-none bg-black/95 p-4 shadow-2xl sm:p-6">
             <DialogTitle className="sr-only">{title}</DialogTitle>
             <DialogDescription className="sr-only">
-              Full uncropped image preview for {title}.
+              Larger preview for {title} with options to update or clear the image.
             </DialogDescription>
-            <div className="flex max-h-[85vh] items-center justify-center overflow-hidden">
-              <img
-                src={imageUrl}
-                alt={title}
-                className="max-h-[85vh] w-auto max-w-full object-contain"
-              />
+            <div className="flex max-h-[72vh] items-center justify-center overflow-hidden">
+              {expandedPreview ? (
+                <div className="max-h-[72vh] w-full overflow-hidden">
+                  {expandedPreview}
+                </div>
+              ) : imageUrl ? (
+                <img
+                  src={imageUrl}
+                  alt={title}
+                  className="max-h-[72vh] w-auto max-w-full object-contain"
+                />
+              ) : null}
             </div>
+            {(onPreviewEdit || onPreviewClear) && (
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  {onPreviewEdit ? (
+                    <PrimitiveButton
+                      type="button"
+                      variant="outline"
+                      className="border-white/40 bg-white/10 text-white hover:bg-white/18"
+                      onClick={() => {
+                        setIsImageExpanded(false);
+                        onPreviewEdit();
+                      }}
+                    >
+                      <Upload className="w-4 h-4" />
+                      Edit image
+                    </PrimitiveButton>
+                  ) : null}
+                </div>
+
+                {onPreviewClear ? (
+                  <PrimitiveButton
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="border-white/40 bg-white/10 text-white hover:bg-white/18"
+                    onClick={() => {
+                      setIsImageExpanded(false);
+                      onPreviewClear();
+                    }}
+                    aria-label="Clear image"
+                    title="Clear image"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </PrimitiveButton>
+                ) : null}
+              </div>
+            )}
           </DialogContent>
         </Dialog>
       )}

--- a/front-end/src/app/components/ItemMetadataFields.tsx
+++ b/front-end/src/app/components/ItemMetadataFields.tsx
@@ -1,7 +1,12 @@
+import { KeyboardEvent, useState } from "react";
+import { Plus, X } from "lucide-react";
 import {
   ClothingItemFormValues,
   formatDisplaySize,
+  formatTagInput,
+  parseTagInput,
 } from "../lib/closet";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 
 interface ItemMetadataFieldsProps {
@@ -9,9 +14,15 @@ interface ItemMetadataFieldsProps {
   values: ClothingItemFormValues;
 }
 
-const sizeOptions = ["xs", "small", "medium", "large", "xl"];
+const sizeOptions = ["na", "xs", "small", "medium", "large", "xl"];
 
 export function ItemMetadataFields({ onChange, values }: ItemMetadataFieldsProps) {
+  const [draftTag, setDraftTag] = useState("");
+  const [editingTag, setEditingTag] = useState<string | null>(null);
+  const [isAddingTag, setIsAddingTag] = useState(false);
+  const tags = parseTagInput(values.tags);
+  const visibleTags = editingTag ? tags.filter((tag) => tag !== editingTag) : tags;
+
   function updateField<K extends keyof ClothingItemFormValues>(
     fieldName: K,
     value: ClothingItemFormValues[K],
@@ -20,6 +31,49 @@ export function ItemMetadataFields({ onChange, values }: ItemMetadataFieldsProps
       ...values,
       [fieldName]: value,
     });
+  }
+
+  function updateTags(nextTags: string[]) {
+    updateField("tags", formatTagInput(nextTags));
+  }
+
+  function handleAddTag() {
+    const baseTags = editingTag ? tags.filter((tag) => tag !== editingTag) : tags;
+    const nextTags = parseTagInput([...baseTags, draftTag].filter(Boolean).join(","));
+
+    updateTags(nextTags);
+    setDraftTag("");
+    setEditingTag(null);
+    setIsAddingTag(false);
+  }
+
+  function closeTagEditor() {
+    setDraftTag("");
+    setEditingTag(null);
+    setIsAddingTag(false);
+  }
+
+  function handleTagInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleAddTag();
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeTagEditor();
+    }
+  }
+
+  function removeTag(tagToRemove: string) {
+    updateTags(tags.filter((tag) => tag !== tagToRemove));
+  }
+
+  function beginTagEdit(tag: string) {
+    setDraftTag(tag);
+    setEditingTag(tag);
+    setIsAddingTag(true);
   }
 
   return (
@@ -67,23 +121,82 @@ export function ItemMetadataFields({ onChange, values }: ItemMetadataFieldsProps
           className="w-full border border-border bg-card px-4 py-3"
           placeholder="Optional, e.g. COS, Nike"
         />
-        <PrimitiveText as="p" variant="bodySm" tone="muted">
-          Used for the Brands filter on your closet. Tags stay separate.
-        </PrimitiveText>
       </label>
 
-      <label className="space-y-2 sm:col-span-2">
+      <div className="space-y-2 sm:col-span-2">
         <PrimitiveText as="span" variant="label">Tags</PrimitiveText>
-        <textarea
-          value={values.tags}
-          onChange={(event) => updateField("tags", event.target.value)}
-          className="min-h-28 w-full border border-border bg-card px-4 py-3"
-          placeholder="Try tags like cotton, blue, weekend, office"
-        />
-        <PrimitiveText as="p" variant="bodySm" tone="muted">
-          Add comma-separated tags so people can search and filter this item naturally.
-        </PrimitiveText>
-      </label>
+        <div className="flex min-h-14 flex-wrap items-center gap-2 border border-border bg-card px-3 py-3">
+          {visibleTags.map((tag) => (
+            <div
+              key={tag}
+              className="inline-flex h-9 items-center gap-1 border border-border bg-background px-3 py-1"
+              onDoubleClick={() => beginTagEdit(tag)}
+            >
+              <PrimitiveText as="span" variant="bodySm">
+                {tag}
+              </PrimitiveText>
+              <PrimitiveButton
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-5 p-0 text-muted-foreground hover:text-foreground"
+                onClick={() => removeTag(tag)}
+                aria-label={`Remove ${tag} tag`}
+              >
+                <X className="w-3 h-3" />
+              </PrimitiveButton>
+            </div>
+          ))}
+
+          {isAddingTag ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <input
+                value={draftTag}
+                onChange={(event) => setDraftTag(event.target.value)}
+                onKeyDown={handleTagInputKeyDown}
+                placeholder="Add tag"
+                className="h-9 w-32 border border-border bg-background px-3 py-1"
+                autoFocus
+              />
+              <PrimitiveButton
+                type="button"
+                size="icon"
+                variant="outline"
+                className="h-9 w-9"
+                onClick={handleAddTag}
+                disabled={!draftTag.trim()}
+                aria-label="Save tag"
+              >
+                <Plus className="w-4 h-4" />
+              </PrimitiveButton>
+              <PrimitiveButton
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-9 w-9"
+                onClick={closeTagEditor}
+                aria-label="Cancel adding tag"
+              >
+                <X className="w-4 h-4" />
+              </PrimitiveButton>
+            </div>
+          ) : (
+            <PrimitiveButton
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-9 w-9"
+              onClick={() => {
+                setEditingTag(null);
+                setIsAddingTag(true);
+              }}
+              aria-label="Add a tag"
+            >
+              <Plus className="w-4 h-4" />
+            </PrimitiveButton>
+          )}
+        </div>
+      </div>
     </>
   );
 }

--- a/front-end/src/app/components/ItemPhotoField.tsx
+++ b/front-end/src/app/components/ItemPhotoField.tsx
@@ -1,10 +1,12 @@
 import { RefObject } from "react";
+import { Upload } from "lucide-react";
 import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 
 interface ItemPhotoFieldProps {
-  description: string;
+  description?: string;
   hasExistingPhoto?: boolean;
+  hidePickerTrigger?: boolean;
   inputRef: RefObject<HTMLInputElement | null>;
   isRemovingExisting?: boolean;
   onClearSelection: () => void;
@@ -17,6 +19,7 @@ interface ItemPhotoFieldProps {
 export function ItemPhotoField({
   description,
   hasExistingPhoto = false,
+  hidePickerTrigger = false,
   inputRef,
   isRemovingExisting = false,
   onClearSelection,
@@ -29,19 +32,30 @@ export function ItemPhotoField({
 
   return (
     <label className="space-y-2 sm:col-span-2">
-      <PrimitiveText as="span" variant="label">
-        Photo
-      </PrimitiveText>
       <input
         ref={inputRef}
         type="file"
         accept="image/*"
         onChange={(event) => onFileChange(event.target.files?.[0] ?? null)}
-        className="w-full border border-border bg-card px-4 py-3 file:mr-4 file:border-0 file:bg-transparent file:font-medium"
+        className="sr-only"
       />
-      <PrimitiveText as="p" variant="bodySm" tone="muted">
-        {description}
-      </PrimitiveText>
+      {hidePickerTrigger ? null : (
+        <PrimitiveButton
+          type="button"
+          variant="outline"
+          size="icon"
+          className="size-12"
+          onClick={() => inputRef.current?.click()}
+          aria-label="Upload photo"
+        >
+          <Upload className="w-5 h-5" />
+        </PrimitiveButton>
+      )}
+      {description ? (
+        <PrimitiveText as="p" variant="bodySm" tone="muted">
+          {description}
+        </PrimitiveText>
+      ) : null}
 
       {isShowingPhotoRow && (
         <div className="flex items-center justify-between gap-4 border border-border bg-card px-4 py-3">

--- a/front-end/src/app/components/UploadWorkspace.tsx
+++ b/front-end/src/app/components/UploadWorkspace.tsx
@@ -4,7 +4,15 @@ import { ItemHeroPreview } from "./ItemHeroPreview";
 
 interface UploadWorkspaceProps {
   children: ReactNode;
+  expandedPreview?: ReactNode;
   imageUrl?: string | null;
+  onPreviewClick?: () => void;
+  onPreviewClear?: () => void;
+  onPreviewEdit?: () => void;
+  previewAriaLabel?: string;
+  previewBackgroundDecoration?: ReactNode;
+  previewMedia?: ReactNode;
+  previewTopAction?: ReactNode;
   previewLabel: string;
   previewPrimaryDetail: string;
   previewSecondaryDetail?: string | null;
@@ -13,27 +21,45 @@ interface UploadWorkspaceProps {
 
 export function UploadWorkspace({
   children,
+  expandedPreview,
   imageUrl,
+  onPreviewClick,
+  onPreviewClear,
+  onPreviewEdit,
+  previewAriaLabel,
+  previewBackgroundDecoration,
+  previewMedia,
+  previewTopAction,
   previewLabel,
   previewPrimaryDetail,
   previewSecondaryDetail,
   previewTitle,
 }: UploadWorkspaceProps) {
   return (
-    <div className="grid gap-10 lg:grid-cols-[1.1fr_1fr] items-start">
-      <ItemHeroPreview
-        imageUrl={imageUrl}
-        label={previewLabel}
-        primaryDetail={previewPrimaryDetail}
-        secondaryDetail={previewSecondaryDetail}
-        title={previewTitle}
-      />
+    <div className="grid gap-10 lg:h-[min(46rem,calc(100vh-8rem))] lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] lg:items-stretch">
+      <div className="lg:h-full">
+        <ItemHeroPreview
+          expandedPreview={expandedPreview}
+          imageUrl={imageUrl}
+          label={previewLabel}
+          onPreviewClick={onPreviewClick}
+          onPreviewClear={onPreviewClear}
+          onPreviewEdit={onPreviewEdit}
+          previewAriaLabel={previewAriaLabel}
+          previewBackgroundDecoration={previewBackgroundDecoration}
+          previewMedia={previewMedia}
+          previewTopAction={previewTopAction}
+          primaryDetail={previewPrimaryDetail}
+          secondaryDetail={previewSecondaryDetail}
+          title={previewTitle}
+        />
+      </div>
 
       <motion.div
         initial={{ opacity: 0, y: 18 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.45, delay: 0.06 }}
-        className="space-y-5"
+        className="flex h-full min-h-0 flex-col gap-5"
       >
         {children}
       </motion.div>

--- a/front-end/src/app/components/create-item/CreateItemImageMode.tsx
+++ b/front-end/src/app/components/create-item/CreateItemImageMode.tsx
@@ -1,24 +1,37 @@
-import { RefObject } from "react";
-import { ArrowLeft, Check, Sparkles } from "lucide-react";
+import { RefObject, useEffect, useMemo, useState } from "react";
+import { ArrowLeft, Check, RotateCcw, Sparkles, Upload } from "lucide-react";
 import {
   ClothingItemFormValues,
-  formatPossessive,
+  formatTagLabel,
   OutfitDetection,
   OutfitUpload,
+  preferredDetectionBox,
   titleize,
   User,
 } from "../../lib/closet";
-import { DetectionReviewCard } from "./DetectionReviewCard";
-import { ItemPhotoField } from "../ItemPhotoField";
+import { AiCleanImageButton } from "../AiCleanImageButton";
+import { ItemMetadataFields } from "../ItemMetadataFields";
 import { PrimitiveButton } from "../primitives/PrimitiveButton";
 import { PrimitiveText } from "../primitives/PrimitiveText";
 import { UploadWorkspace } from "../UploadWorkspace";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "../ui/alert-dialog";
+import { DetectionPreviewImage } from "./DetectionPreview";
+import { DetectionThumbnailStrip } from "./DetectionThumbnailStrip";
 
 interface CreateItemImageModeProps {
   cleaningDetectionIds: number[];
   detectionCleanErrors: Record<number, string>;
   detections: OutfitDetection[];
-  editingDetectionIds: number[];
   errorMessage: string;
   getDetectionDraft: (detection: OutfitDetection) => ClothingItemFormValues;
   isCreating: boolean;
@@ -31,7 +44,6 @@ interface CreateItemImageModeProps {
   onDraftChange: (detectionId: number, nextValues: ClothingItemFormValues) => void;
   onFileChange: (file: File | null) => void;
   onSaveSelectedItems: () => void;
-  onToggleEdit: (detection: OutfitDetection) => void;
   onToggleSelection: (detection: OutfitDetection) => void;
   outfitUpload: OutfitUpload | null;
   selectedCount: number;
@@ -45,7 +57,6 @@ export function CreateItemImageMode({
   cleaningDetectionIds,
   detectionCleanErrors,
   detections,
-  editingDetectionIds,
   errorMessage,
   getDetectionDraft,
   isCreating,
@@ -58,7 +69,6 @@ export function CreateItemImageMode({
   onDraftChange,
   onFileChange,
   onSaveSelectedItems,
-  onToggleEdit,
   onToggleSelection,
   outfitUpload,
   selectedCount,
@@ -68,45 +78,167 @@ export function CreateItemImageMode({
   user,
 }: CreateItemImageModeProps) {
   const detectionCount = detections.length;
+  const [previewTarget, setPreviewTarget] = useState<"source" | number>("source");
+  const [detailsDetectionId, setDetailsDetectionId] = useState<number | null>(null);
+  const [isRedetectDialogOpen, setIsRedetectDialogOpen] = useState(false);
+  const hasStartedDetectionFlow = Boolean(selectedFileName || isDetecting || outfitUpload);
+  const hasDetectedItems = detectionCount > 0;
+
+  useEffect(() => {
+    if (detections.length === 0) {
+      setPreviewTarget("source");
+      setDetailsDetectionId(null);
+      return;
+    }
+
+    setPreviewTarget((current) => {
+      if (current === "source") {
+        return current;
+      }
+
+      return detections.some((detection) => detection.id === current) ? current : detections[0].id;
+    });
+    setDetailsDetectionId((current) =>
+      current && detections.some((detection) => detection.id === current) ? current : detections[0].id,
+    );
+  }, [detections]);
+
+  const previewDetection =
+    typeof previewTarget === "number"
+      ? detections.find((detection) => detection.id === previewTarget) ?? null
+      : null;
+  const detailsDetection =
+    detailsDetectionId == null
+      ? null
+      : detections.find((detection) => detection.id === detailsDetectionId) ?? null;
+  const isSourceFocused = previewTarget === "source";
+  const previewDetectionBox = previewDetection ? preferredDetectionBox(previewDetection) : null;
+  const detailsPreviewBox = detailsDetection ? preferredDetectionBox(detailsDetection) : null;
+  const focusedDraft = detailsDetection ? getDetectionDraft(detailsDetection) : null;
+  const focusedSuggestedName = focusedDraft?.name.trim()
+    || detailsDetection?.suggested_name?.trim()
+    || (detailsDetection ? titleize(detailsDetection.category) : "");
+  const focusedIsSelected = detailsDetection
+    ? selectedDetectionIds.includes(detailsDetection.id)
+    : false;
+  const focusedCleanError = detailsDetection
+    ? detectionCleanErrors[detailsDetection.id]
+    : undefined;
+  const focusedIsCleaning = detailsDetection
+    ? cleaningDetectionIds.includes(detailsDetection.id)
+    : false;
+  const previewMedia = useMemo(() => {
+    if (!previewDetection || !sourceImageUrl || !previewDetectionBox || previewDetection.cleaned_image_url) {
+      return undefined;
+    }
+
+    return (
+      <DetectionPreviewImage
+        alt={`${focusedSuggestedName} preview`}
+        cropBox={previewDetectionBox}
+        sourceImageUrl={sourceImageUrl}
+      />
+    );
+  }, [focusedSuggestedName, previewDetection, previewDetectionBox, sourceImageUrl]);
+  const expandedPreview = useMemo(() => {
+    if (!previewDetection || !sourceImageUrl || !previewDetectionBox || previewDetection.cleaned_image_url) {
+      return undefined;
+    }
+
+    return (
+      <DetectionPreviewImage
+        alt={`${focusedSuggestedName} preview`}
+        cropBox={previewDetectionBox}
+        sourceImageUrl={sourceImageUrl}
+      />
+    );
+  }, [focusedSuggestedName, previewDetection, previewDetectionBox, sourceImageUrl]);
+  const sourcePreviewTitle = selectedFileName ?? "Upload an image";
+  const sourcePreviewPrimaryDetail = isDetecting
+    ? "Detecting items"
+    : detectionCount > 0
+      ? `${detectionCount} detected item${detectionCount === 1 ? "" : "s"}`
+      : selectedFileName
+        ? "Ready to detect"
+        : "Awaiting image";
+  const sourcePreviewSecondaryDetail = detectionCount > 0
+    ? `${selectedCount} selected to save`
+    : `Saving to ${titleize(user.username)}`;
+  const shouldShowUploadPrompt = !selectedFileName && !isDetecting && !outfitUpload;
+  const shouldShowInitialDetectPrompt = Boolean(selectedFileName) && !isDetecting && detectionCount === 0;
+  const shouldShowRedetectPrompt = hasStartedDetectionFlow && detectionCount > 0 && isSourceFocused;
 
   return (
-    <div className="max-w-5xl mx-auto px-6 py-12 space-y-8">
+    <div className="max-w-7xl mx-auto px-6 py-12 space-y-8">
       <PrimitiveButton
         onClick={onBack}
-        variant="ghost"
-        className="h-auto px-0 py-0 text-muted-foreground"
+        variant="outline"
+        className="h-auto px-5 py-3"
       >
         <ArrowLeft className="w-4 h-4" />
         Back
       </PrimitiveButton>
 
       <UploadWorkspace
-        imageUrl={sourceImageUrl}
-        previewLabel="Uploaded Image"
-        previewPrimaryDetail={
-          isDetecting
-            ? "Detecting items"
-            : detectionCount > 0
-              ? `${detectionCount} detected item${detectionCount === 1 ? "" : "s"}`
-              : selectedFileName
-                ? "Ready to detect"
-                : "Awaiting image"
+        expandedPreview={expandedPreview}
+        imageUrl={previewDetection?.cleaned_image_url ?? (isSourceFocused ? sourceImageUrl : null)}
+        onPreviewClick={() => inputRef.current?.click()}
+        onPreviewClear={selectedFileName ? onClearImageSelection : undefined}
+        onPreviewEdit={selectedFileName ? () => inputRef.current?.click() : undefined}
+        previewAriaLabel={selectedFileName ? "Change upload image" : "Upload photo"}
+        previewBackgroundDecoration={
+          isSourceFocused ? (
+            <Upload
+              className="h-40 w-40 text-stone-700/18 sm:h-52 sm:w-52"
+              strokeWidth={1.1}
+            />
+          ) : undefined
         }
-        previewSecondaryDetail={`Saving to ${formatPossessive(titleize(user.username))}`}
-        previewTitle={selectedFileName ?? "Upload an image"}
+        previewMedia={previewDetection ? previewMedia : undefined}
+        previewTopAction={
+          previewDetection ? (
+            <AiCleanImageButton
+              className="size-11 border border-white/75 bg-white/70 p-0 shadow-sm backdrop-blur-sm hover:bg-white/85"
+              disabled={!previewDetection.cleaned_image_url && !previewDetectionBox}
+              iconOnly
+              isLoading={focusedIsCleaning}
+              label="AI clean PNG"
+              onClick={() => onCleanDetectionImage(previewDetection.id)}
+            />
+          ) : undefined
+        }
+        previewLabel={previewDetection ? "Detected Item" : "Original Image"}
+        previewPrimaryDetail={
+          previewDetection
+            ? formatTagLabel(previewDetection.category)
+            : sourcePreviewPrimaryDetail
+        }
+        previewSecondaryDetail={
+          previewDetection
+            ? `${formatTagLabel(previewDetection.category)}${selectedDetectionIds.includes(previewDetection.id) ? " · selected for save" : ""}`
+            : sourcePreviewSecondaryDetail
+        }
+        previewTitle={previewDetection ? titleize(previewDetection.suggested_name?.trim() || previewDetection.category) : sourcePreviewTitle}
       >
-        <div>
-          <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
-            Image Upload
-          </PrimitiveText>
-          <PrimitiveText as="h1" variant="display" font="serif" className="mb-1">
-            Review Detected Items
-          </PrimitiveText>
-          <PrimitiveText as="p" tone="muted">
-            Upload an image first, then run detection when you are ready. Verified pieces can be saved
-            directly to {formatPossessive(titleize(user.username))}.
-          </PrimitiveText>
-        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          onChange={(event) => onFileChange(event.target.files?.[0] ?? null)}
+          className="sr-only"
+        />
+
+        <DetectionThumbnailStrip
+          detections={detections}
+          focusedTarget={previewTarget}
+          isDetecting={isDetecting}
+          onSelectDetection={(detectionId) => {
+            setPreviewTarget(detectionId);
+            setDetailsDetectionId(detectionId);
+          }}
+          onSelectSource={() => setPreviewTarget("source")}
+          sourceImageUrl={sourceImageUrl}
+        />
 
         {errorMessage && (
           <div className="border border-destructive/20 bg-destructive/5 p-4 text-sm">
@@ -114,146 +246,125 @@ export function CreateItemImageMode({
           </div>
         )}
 
-        <div className="border border-border bg-card p-5">
-          <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
-            Upload Photo
-          </PrimitiveText>
-          <ItemPhotoField
-            description="Choose the source image now. Detection only runs after you click the button below."
-            inputRef={inputRef}
-            onClearSelection={onClearImageSelection}
-            onFileChange={onFileChange}
-            selectedFileName={selectedFileName}
-          />
-        </div>
+        {shouldShowUploadPrompt ? (
+          <div className="border border-border bg-card p-5">
+            <PrimitiveText as="p" variant="title" font="serif" className="mb-3">
+              Upload an image to get started.
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
+              Our AI will analyze your image and pull out different items of clothing you&apos;re wearing, so you can add them to your closet.
+            </PrimitiveText>
+          </div>
+        ) : null}
 
-        <div className="border border-border bg-card p-5">
-          <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
-            Detection
-          </PrimitiveText>
-          <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-4">
-            We refine and verify each detected crop before it becomes selectable below.
-          </PrimitiveText>
-          <div className="flex items-center justify-between gap-4">
-            <PrimitiveButton
-              type="button"
-              onClick={onClearImageSelection}
-              variant="ghost"
-              size="sm"
-              className="h-auto px-0 py-0 text-muted-foreground"
-            >
-              Reset
-            </PrimitiveButton>
+        {shouldShowInitialDetectPrompt ? (
+          <div className="border border-border bg-card p-5 space-y-5">
+            <PrimitiveText as="p" tone="muted">
+              Press the button below to detect your items.
+            </PrimitiveText>
             <PrimitiveButton
               type="button"
               onClick={onDetectItems}
               disabled={isDetecting || !selectedFileName}
-              className="h-auto bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
+              className="h-auto self-start bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
             >
               <Sparkles className="w-4 h-4" />
-              {isDetecting ? "Detecting items..." : "Detect items"}
+              Detect Items
             </PrimitiveButton>
           </div>
-        </div>
-      </UploadWorkspace>
+        ) : null}
 
-      <div className="space-y-4 border-t border-border pt-8">
-        <div className="flex items-end justify-between gap-4">
-          <div>
-            <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
-              Detected Items
-            </PrimitiveText>
-            <PrimitiveText as="h2" variant="title" font="serif" className="mb-1">
-              Choose what to save
-            </PrimitiveText>
+        {shouldShowRedetectPrompt ? (
+          <div className="border border-border bg-card p-5 space-y-5">
             <PrimitiveText as="p" tone="muted">
-              Review what the model found and choose any item you want to save to the closet.
+              Press this button to re-detect your items. Warning: this will override your existing items.
             </PrimitiveText>
+            <AlertDialog open={isRedetectDialogOpen} onOpenChange={setIsRedetectDialogOpen}>
+              <AlertDialogTrigger asChild>
+                <PrimitiveButton
+                  type="button"
+                  disabled={isDetecting || !selectedFileName}
+                  className="h-auto self-start bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
+                >
+                  <Sparkles className="w-4 h-4" />
+                  <RotateCcw className="w-4 h-4" />
+                  Re-detect Items
+                </PrimitiveButton>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Proceed?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will discard all currently detected items. Proceed?
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={onDetectItems}>Proceed</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
-          <PrimitiveText as="div" variant="bodySm" tone="muted">
-            {selectedCount} selected
-          </PrimitiveText>
-        </div>
+        ) : null}
 
-        {!selectedFileName ? (
-          <div className="border border-dashed border-border p-8 text-center">
-            <PrimitiveText as="p" variant="display" font="serif" className="mb-2">
-              Upload an image to begin
-            </PrimitiveText>
-            <PrimitiveText as="p" tone="muted">
-              Choosing an image from the closet page will bring you here automatically.
-            </PrimitiveText>
-          </div>
-        ) : isDetecting ? (
-          <div className="border border-border bg-card p-8 text-center">
-            <PrimitiveText as="p" variant="display" font="serif" className="mb-2">
-              Detecting, refining, and verifying crops
-            </PrimitiveText>
-            <PrimitiveText as="p" tone="muted">
-              We are running the automated crop pipeline and preparing item-specific previews.
-            </PrimitiveText>
-          </div>
-        ) : !outfitUpload ? (
-          <div className="border border-dashed border-border p-8 text-center">
-            <PrimitiveText as="p" variant="display" font="serif" className="mb-2">
-              Detect items when you are ready
-            </PrimitiveText>
-            <PrimitiveText as="p" tone="muted">
-              The selected image is ready. Click the button on the right to populate detected items
-              below.
-            </PrimitiveText>
-          </div>
-        ) : outfitUpload.status === "failed" && outfitUpload.error_message ? (
-          <div className="border border-destructive/20 bg-destructive/5 p-6 text-sm">
-            {outfitUpload.error_message}
-          </div>
-        ) : detectionCount === 0 ? (
-          <div className="border border-dashed border-border p-8 text-center">
-            <PrimitiveText as="p" variant="display" font="serif" className="mb-2">
-              No items detected yet
-            </PrimitiveText>
-            <PrimitiveText as="p" tone="muted">
-              Try another image if the visible pieces are not being picked up clearly.
-            </PrimitiveText>
-          </div>
-        ) : (
-          <div className="grid gap-4 xl:grid-cols-2 2xl:grid-cols-3">
-            {detections.map((detection, index) => (
-              <DetectionReviewCard
-                key={detection.id}
-                cleanImageError={detectionCleanErrors[detection.id]}
-                cleanedImageUrl={detection.cleaned_image_url ?? null}
-                detection={detection}
-                draftValues={getDetectionDraft(detection)}
-                index={index}
-                isCleaningImage={cleaningDetectionIds.includes(detection.id)}
-                isEditing={editingDetectionIds.includes(detection.id)}
-                isSelected={selectedDetectionIds.includes(detection.id)}
-                onCleanImage={() => onCleanDetectionImage(detection.id)}
-                onDraftChange={(nextValues) => onDraftChange(detection.id, nextValues)}
-                onToggle={() => onToggleSelection(detection)}
-                onToggleEdit={() => onToggleEdit(detection)}
-                sourceImageUrl={sourceImageUrl}
+        {!hasStartedDetectionFlow || isDetecting || !outfitUpload || detectionCount === 0 || !detailsDetection || !focusedDraft || isSourceFocused ? null : (
+          <div className="border border-border bg-card p-5 space-y-5">
+            <div>
+              <PrimitiveText as="p" variant="overline" tone="muted" className="mb-2">
+                {formatTagLabel(detailsDetection.category)}
+              </PrimitiveText>
+              <PrimitiveText as="h2" variant="title" font="serif" className="mb-1">
+                {focusedSuggestedName}
+              </PrimitiveText>
+            </div>
+
+            {focusedCleanError && (
+              <div className="border border-destructive/20 bg-destructive/5 px-3 py-3 text-sm">
+                {focusedCleanError}
+              </div>
+            )}
+
+            <div className="grid gap-5 sm:grid-cols-2">
+              <ItemMetadataFields
+                values={focusedDraft}
+                onChange={(nextValues) => onDraftChange(detailsDetection.id, nextValues)}
               />
-            ))}
+            </div>
+
+            <div className="flex items-center justify-end gap-3">
+              <PrimitiveButton
+                type="button"
+                onClick={() => onToggleSelection(detailsDetection)}
+                disabled={!detailsPreviewBox}
+                variant="outline"
+                className={`disabled:opacity-50 ${
+                  focusedIsSelected
+                    ? "border-foreground bg-foreground text-background"
+                    : "border-border hover:border-foreground"
+                }`}
+              >
+                <Check className="w-4 h-4" />
+                {focusedIsSelected ? "Will save to closet" : "Add to closet"}
+              </PrimitiveButton>
+            </div>
           </div>
         )}
-      </div>
 
-      <div className="border-t border-border pt-6 flex items-center justify-between gap-4">
-        <PrimitiveText as="p" variant="bodySm" tone="muted">
-          Selected items will use the best available crop from the uploaded image.
-        </PrimitiveText>
-        <PrimitiveButton
-          type="button"
-          onClick={onSaveSelectedItems}
-          disabled={isCreating || selectedCount === 0}
-          className="h-auto bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
-        >
-          <Check className="w-4 h-4" />
-          {isCreating ? "Saving..." : "Save to closet"}
-        </PrimitiveButton>
-      </div>
+        {hasStartedDetectionFlow && detectionCount > 0 && !isSourceFocused ? (
+          <div className="mt-auto pt-2 flex items-center justify-between gap-4">
+            <div />
+            <PrimitiveButton
+              type="button"
+              onClick={onSaveSelectedItems}
+              disabled={isCreating || selectedCount === 0}
+              className="h-auto bg-foreground px-5 py-3 text-background hover:bg-foreground/90"
+            >
+              <Check className="w-4 h-4" />
+              {isCreating ? "Saving..." : "Save to closet"}
+            </PrimitiveButton>
+          </div>
+        ) : null}
+      </UploadWorkspace>
     </div>
   );
 }

--- a/front-end/src/app/components/create-item/DetectionPreview.tsx
+++ b/front-end/src/app/components/create-item/DetectionPreview.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef } from "react";
+import { OutfitDetectionBoundingBox } from "../../lib/closet";
+
+interface DetectionPreviewImageProps {
+  alt: string;
+  cleanedImageUrl?: string | null;
+  cropBox?: OutfitDetectionBoundingBox | null;
+  sourceImageUrl?: string | null;
+  variant?: "detail" | "thumbnail";
+}
+
+export function DetectionPreviewImage({
+  alt,
+  cleanedImageUrl = null,
+  cropBox = null,
+  sourceImageUrl = null,
+  variant = "detail",
+}: DetectionPreviewImageProps) {
+  if (cleanedImageUrl) {
+    return (
+      <img
+        src={cleanedImageUrl}
+        alt={alt}
+        className="block h-full w-full object-cover"
+      />
+    );
+  }
+
+  if (cropBox && sourceImageUrl) {
+    return (
+      <DetectionCropCanvas
+        alt={alt}
+        cropBox={cropBox}
+        sourceImageUrl={sourceImageUrl}
+        variant={variant}
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-muted text-center text-xs text-muted-foreground">
+      Preview unavailable
+    </div>
+  );
+}
+
+function DetectionCropCanvas({
+  alt,
+  cropBox,
+  sourceImageUrl,
+  variant,
+}: {
+  alt: string;
+  cropBox: OutfitDetectionBoundingBox;
+  sourceImageUrl: string;
+  variant: "detail" | "thumbnail";
+}) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    const image = new Image();
+    image.onload = () => {
+      const context = canvas.getContext("2d");
+      if (!context) {
+        return;
+      }
+
+      const sourceX = image.naturalWidth * cropBox.x;
+      const sourceY = image.naturalHeight * cropBox.y;
+      const sourceWidth = Math.max(1, image.naturalWidth * cropBox.width);
+      const sourceHeight = Math.max(1, image.naturalHeight * cropBox.height);
+
+      if (variant === "thumbnail") {
+        const outputSize = 160;
+        const scale = Math.max(outputSize / sourceWidth, outputSize / sourceHeight);
+        const destinationWidth = sourceWidth * scale;
+        const destinationHeight = sourceHeight * scale;
+        const destinationX = (outputSize - destinationWidth) / 2;
+        const destinationY = (outputSize - destinationHeight) / 2;
+
+        canvas.width = outputSize;
+        canvas.height = outputSize;
+        context.clearRect(0, 0, outputSize, outputSize);
+        context.drawImage(
+          image,
+          sourceX,
+          sourceY,
+          sourceWidth,
+          sourceHeight,
+          destinationX,
+          destinationY,
+          destinationWidth,
+          destinationHeight,
+        );
+        return;
+      }
+
+      const outputWidth = 720;
+      const outputHeight = Math.max(1, Math.round(outputWidth * (sourceHeight / sourceWidth)));
+
+      canvas.width = outputWidth;
+      canvas.height = outputHeight;
+      context.clearRect(0, 0, outputWidth, outputHeight);
+      context.drawImage(
+        image,
+        sourceX,
+        sourceY,
+        sourceWidth,
+        sourceHeight,
+        0,
+        0,
+        outputWidth,
+        outputHeight,
+      );
+    };
+    image.src = sourceImageUrl;
+  }, [cropBox, sourceImageUrl, variant]);
+
+  return <canvas ref={canvasRef} aria-label={alt} className="block h-full w-full object-cover" />;
+}

--- a/front-end/src/app/components/create-item/DetectionReviewCard.tsx
+++ b/front-end/src/app/components/create-item/DetectionReviewCard.tsx
@@ -1,11 +1,9 @@
-import { useEffect, useRef } from "react";
 import { motion } from "motion/react";
 import { Check, PencilLine, Sparkles } from "lucide-react";
 import {
   ClothingItemFormValues,
   formatTagLabel,
   OutfitDetection,
-  OutfitDetectionBoundingBox,
   preferredDetectionBox,
   titleize,
 } from "../../lib/closet";
@@ -13,6 +11,7 @@ import { AiCleanImageButton } from "../AiCleanImageButton";
 import { ItemMetadataFields } from "../ItemMetadataFields";
 import { PrimitiveButton } from "../primitives/PrimitiveButton";
 import { PrimitiveText } from "../primitives/PrimitiveText";
+import { DetectionPreviewImage } from "./DetectionPreview";
 
 interface DetectionReviewCardProps {
   cleanImageError?: string;
@@ -89,15 +88,20 @@ export function DetectionReviewCard({
 
       {cleanedImageUrl ? (
         <div className="overflow-hidden border border-border bg-muted">
-          <img
-            src={cleanedImageUrl}
+          <DetectionPreviewImage
             alt={`${suggestedName} AI cleaned preview`}
-            className="block w-full h-auto object-contain"
+            cleanedImageUrl={cleanedImageUrl}
           />
         </div>
       ) : sourceImageUrl && previewBox ? (
         <div className="space-y-3">
-          <DetectionCropPreview sourceImageUrl={sourceImageUrl} cropBox={previewBox} />
+          <div className="overflow-hidden border border-border bg-muted">
+            <DetectionPreviewImage
+              alt={`${suggestedName} automated crop preview`}
+              cropBox={previewBox}
+              sourceImageUrl={sourceImageUrl}
+            />
+          </div>
         </div>
       ) : (
         <div className="border border-dashed border-border p-4 text-sm text-muted-foreground">
@@ -151,61 +155,6 @@ export function DetectionReviewCard({
         </PrimitiveButton>
       </div>
     </motion.div>
-  );
-}
-
-function DetectionCropPreview({
-  cropBox,
-  sourceImageUrl,
-}: {
-  cropBox: OutfitDetectionBoundingBox;
-  sourceImageUrl: string;
-}) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) {
-      return;
-    }
-
-    const image = new Image();
-    image.onload = () => {
-      const context = canvas.getContext("2d");
-      if (!context) {
-        return;
-      }
-
-      const sourceX = image.naturalWidth * cropBox.x;
-      const sourceY = image.naturalHeight * cropBox.y;
-      const sourceWidth = Math.max(1, image.naturalWidth * cropBox.width);
-      const sourceHeight = Math.max(1, image.naturalHeight * cropBox.height);
-      const outputWidth = 320;
-      const outputHeight = Math.max(1, Math.round(outputWidth * (sourceHeight / sourceWidth)));
-
-      canvas.width = outputWidth;
-      canvas.height = outputHeight;
-
-      context.clearRect(0, 0, outputWidth, outputHeight);
-      context.drawImage(
-        image,
-        sourceX,
-        sourceY,
-        sourceWidth,
-        sourceHeight,
-        0,
-        0,
-        outputWidth,
-        outputHeight,
-      );
-    };
-    image.src = sourceImageUrl;
-  }, [cropBox, sourceImageUrl]);
-
-  return (
-    <div className="overflow-hidden border border-border bg-muted">
-      <canvas ref={canvasRef} className="block w-full h-auto" />
-    </div>
   );
 }
 

--- a/front-end/src/app/components/create-item/DetectionThumbnailStrip.tsx
+++ b/front-end/src/app/components/create-item/DetectionThumbnailStrip.tsx
@@ -1,0 +1,96 @@
+import { OutfitDetection, preferredDetectionBox, titleize } from "../../lib/closet";
+import { DetectionPreviewImage } from "./DetectionPreview";
+
+const stripFrameClass = "flex h-14 items-center border border-border bg-card px-4 lg:-mt-20";
+const stripShellClass = "grid h-full w-full grid-cols-[2.25rem_minmax(0,1fr)] items-center gap-3";
+const stripContentViewportClass = "min-w-0 overflow-x-auto";
+const stripContentClass = "flex h-full items-center gap-3";
+const stripItemClass = "relative size-9 shrink-0 overflow-hidden border box-border";
+
+interface DetectionThumbnailStripProps {
+  detections: OutfitDetection[];
+  focusedTarget: "source" | number;
+  isDetecting: boolean;
+  onSelectDetection: (detectionId: number) => void;
+  onSelectSource: () => void;
+  sourceImageUrl: string | null;
+}
+
+export function DetectionThumbnailStrip({
+  detections,
+  focusedTarget,
+  isDetecting,
+  onSelectDetection,
+  onSelectSource,
+  sourceImageUrl,
+}: DetectionThumbnailStripProps) {
+  function itemClass(isActive: boolean) {
+    return `${stripItemClass} ${
+      isActive
+        ? "border-foreground ring-1 ring-inset ring-foreground"
+        : "border-border"
+    }`;
+  }
+
+  return (
+    <div className={stripFrameClass}>
+      <div className={stripShellClass}>
+        {sourceImageUrl ? (
+          <button
+            type="button"
+            onClick={onSelectSource}
+            className={itemClass(focusedTarget === "source")}
+            aria-label="Show original image"
+            title="Original image"
+          >
+            <img
+              src={sourceImageUrl}
+              alt="Original source thumbnail"
+              className="block h-full w-full object-cover"
+            />
+          </button>
+        ) : null}
+        {sourceImageUrl ? null : (
+          <div
+            aria-hidden="true"
+            className={`${itemClass(false)} bg-muted/35`}
+          />
+        )}
+
+        <div className={stripContentViewportClass}>
+          <div className={stripContentClass}>
+            {detections.length === 0 ? (
+              <p className="shrink-0 text-sm text-muted-foreground">
+                {isDetecting ? "Detecting items..." : "Detected items will appear here"}
+              </p>
+            ) : (
+              detections.map((detection) => {
+                const previewBox = preferredDetectionBox(detection);
+                const label = detection.suggested_name?.trim() || titleize(detection.category);
+
+                return (
+                  <button
+                    key={detection.id}
+                    type="button"
+                    onClick={() => onSelectDetection(detection.id)}
+                    className={itemClass(focusedTarget === detection.id)}
+                    aria-label={`Show ${label}`}
+                    title={label}
+                  >
+                    <DetectionPreviewImage
+                      alt={`${label} thumbnail`}
+                      cleanedImageUrl={detection.cleaned_image_url ?? null}
+                      cropBox={previewBox}
+                      sourceImageUrl={sourceImageUrl}
+                      variant="thumbnail"
+                    />
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front-end/src/app/components/primitives/PrimitiveButton.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveButton.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../ui/utils";
 
 const primitiveButtonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-none text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -22,9 +22,9 @@ const primitiveButtonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9 rounded-md",
+        sm: "h-8 gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 px-6 has-[>svg]:px-4",
+        icon: "size-9",
       },
     },
     defaultVariants: {
@@ -34,26 +34,54 @@ const primitiveButtonVariants = cva(
   },
 );
 
+function textFromChildren(children: React.ReactNode): string {
+  return React.Children.toArray(children)
+    .map((child) => {
+      if (typeof child === "string" || typeof child === "number") {
+        return String(child);
+      }
+
+      if (React.isValidElement(child)) {
+        return textFromChildren(child.props.children);
+      }
+
+      return "";
+    })
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 function PrimitiveButton({
+  children,
   className,
   variant,
   size,
   asChild = false,
   style,
+  title,
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof primitiveButtonVariants> & {
     asChild?: boolean;
   }) {
   const Comp = asChild ? Slot : "button";
+  const childText = textFromChildren(children);
+  const resolvedTitle =
+    title ??
+    (typeof props["aria-label"] === "string" ? props["aria-label"] : undefined) ??
+    (childText || undefined);
 
   return (
     <Comp
       data-slot="button"
       className={cn(primitiveButtonVariants({ variant, size, className }))}
       style={{ fontFamily: "Outfit, sans-serif", ...style }}
+      title={resolvedTitle}
       {...props}
-    />
+    >
+      {children}
+    </Comp>
   );
 }
 

--- a/front-end/src/app/components/primitives/PrimitiveDropdownMenu.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveDropdownMenu.tsx
@@ -42,7 +42,7 @@ function PrimitiveDropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-none border p-1 shadow-md",
           className,
         )}
         {...props}
@@ -73,8 +73,8 @@ function PrimitiveDropdownMenuItem({
       data-slot="dropdown-menu-item"
       data-inset={inset}
       data-variant={variant}
-      className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-none px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -91,8 +91,8 @@ function PrimitiveDropdownMenuCheckboxItem({
   return (
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
-      className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-none py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
@@ -127,8 +127,8 @@ function PrimitiveDropdownMenuRadioItem({
   return (
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
-      className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-none py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -210,8 +210,8 @@ function PrimitiveDropdownMenuSubTrigger({
     <DropdownMenuPrimitive.SubTrigger
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
-      className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-none px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
         className,
       )}
       {...props}
@@ -229,8 +229,8 @@ function PrimitiveDropdownMenuSubContent({
   return (
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
-      className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-none border p-1 shadow-lg",
         className,
       )}
       {...props}

--- a/front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx
@@ -4,21 +4,47 @@ import { ChevronDown } from "lucide-react";
 import { primitiveSelectTriggerVariants } from "./PrimitiveSelect";
 import { cn } from "../ui/utils";
 
+function textFromChildren(children: React.ReactNode): string {
+  return React.Children.toArray(children)
+    .map((child) => {
+      if (typeof child === "string" || typeof child === "number") {
+        return String(child);
+      }
+
+      if (React.isValidElement(child)) {
+        return textFromChildren(child.props.children);
+      }
+
+      return "";
+    })
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 function PrimitiveDropdownTriggerButton({
   children,
   className,
   style,
+  title,
   ...props
 }: React.ComponentProps<"button">) {
+  const childText = textFromChildren(children);
+  const resolvedTitle =
+    title ??
+    (typeof props["aria-label"] === "string" ? props["aria-label"] : undefined) ??
+    (childText || undefined);
+
   return (
     <button
       type="button"
       className={cn(
         primitiveSelectTriggerVariants({ size: "default" }),
-        "relative h-14 bg-stone-200 pr-10 hover:bg-stone-200",
+        "relative h-14 rounded-none bg-stone-200 pr-10 hover:bg-stone-200",
         className,
       )}
       style={{ fontFamily: "Outfit, sans-serif", ...style }}
+      title={resolvedTitle}
       {...props}
     >
       <span className="block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-left">

--- a/front-end/src/app/components/primitives/PrimitiveSelect.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveSelect.tsx
@@ -30,7 +30,7 @@ function PrimitiveSelectValue({
 }
 
 const primitiveSelectTriggerVariants = cva(
-  "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-full items-center justify-between gap-2 rounded-md border bg-input-background px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-full items-center justify-between gap-2 rounded-none border bg-input-background px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       size: {
@@ -78,7 +78,7 @@ function PrimitiveSelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-none border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,
@@ -123,8 +123,8 @@ function PrimitiveSelectItem({
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
-      className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-none py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/front-end/src/app/lib/closet.ts
+++ b/front-end/src/app/lib/closet.ts
@@ -245,7 +245,7 @@ export function emptyClothingItemFormValues(): ClothingItemFormValues {
   return {
     name: "",
     brand: "",
-    size: "medium",
+    size: "na",
     date: "",
     tags: "",
   };
@@ -293,6 +293,10 @@ export function formatTagLabel(tag: string) {
 export function formatDisplaySize(size: string) {
   const normalized = size.trim().toLowerCase();
 
+  if (normalized === "na") {
+    return "N/A";
+  }
+
   if (normalized === "xl" || normalized === "xs") {
     return normalized.toUpperCase();
   }
@@ -328,7 +332,7 @@ export function toClothingItemFormValuesFromDetection(
   return {
     name: detection.suggested_name?.trim() || titleize(detection.category),
     brand: "",
-    size: "medium",
+    size: "na",
     date: "",
     tags: formatTagInput([
       detection.details.dominant_color?.trim() ?? "",


### PR DESCRIPTION
User-facing changes
This updates the Add Item, Edit Item, and Detect Item flows to use a more consistent preview-first layout and a sharper, more minimal control style. The create and edit experiences now share the same left-hand image preview, modal image management behavior, and tighter metadata form treatment, while the detect flow now uses a source-image thumbnail strip with per-item previews and a cleaner review experience. Tags were redesigned into inline chips with add/edit interactions, helper text was reduced across the flow, and image actions like upload, AI clean, detect, and re-detect were made more contextual. The overall result is a simpler, more consistent item-management UI with less visual noise and clearer image-driven interactions.

Internal changes
This refactors the item flows around shared layout and preview building blocks, especially through ItemEditorWorkspace, UploadWorkspace, and ItemHeroPreview, so create/edit/detect now compose from the same core structure. The detect-item experience was reworked to separate preview selection from detail editing state and to move the thumbnail strip into its own component, which stabilizes the layout and makes the source/detection states easier to reason about. Shared primitives were also extended so buttons, selects, and dropdown menus consistently use sharp corners and better built-in hover titles/tooltips. On the data side, the item defaults and size handling were updated to support N/A, with corresponding frontend and backend model/test updates.


Closes #87 