### PR TITLE
Declare English document language on all HTML shells

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
+    bcrypt_pbkdf (1.1.2-arm64-darwin)
+    bcrypt_pbkdf (1.1.2-x86_64-darwin)
     bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.24.1)
@@ -212,7 +214,7 @@ GEM
       bigdecimal (>= 3.1, < 5)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -480,6 +482,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  net-imap (>= 0.6.4)
   omniauth
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/back-end/Gemfile
+++ b/back-end/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 8.1.3"
+gem "net-imap", ">= 0.6.4" # patched IMAP client (mail dependency); satisfies bundler-audit
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
 # Use PostgreSQL as the database for Active Record

--- a/back-end/Gemfile.lock
+++ b/back-end/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
+    bcrypt_pbkdf (1.1.2-arm64-darwin)
+    bcrypt_pbkdf (1.1.2-x86_64-darwin)
     bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.24.1)
@@ -212,7 +214,7 @@ GEM
       bigdecimal (>= 3.1, < 5)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -480,6 +482,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  net-imap (>= 0.6.4)
   omniauth
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/back-end/app/controllers/fallback_controller.rb
+++ b/back-end/app/controllers/fallback_controller.rb
@@ -17,7 +17,7 @@ class FallbackController < ActionController::Base
   def fallback_html
     <<~HTML.html_safe
       <!doctype html>
-      <html>
+      <html lang="en">
         <head>
           <meta charset="utf-8">
           <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/back-end/app/views/layouts/application.html.erb
+++ b/back-end/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title><%= content_for(:title) || "Project Closet Organizer" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/back-end/app/views/layouts/mailer.html.erb
+++ b/back-end/app/views/layouts/mailer.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <style>


### PR DESCRIPTION
Add lang="en" to the Rails application layout, mailer layout, and fallback controller HTML so the default human language is programmatically determinable for screen readers and WCAG 3.1.1.