### PR TITLE
Add erb-lint for ERB template linting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+      - name: Lint ERB templates
+        run: bin/erblint --lint-all
+
   test:
     runs-on: ubuntu-latest
     defaults:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.12 - 2026-05-15
+
+- Added `erb_lint` gem and `.erb_lint.yml` config to lint ERB templates for safety, indentation, whitespace, and unused capture issues.
+- Added `bin/erblint` executable wrapper to run ERB linting locally.
+- Integrated ERB linting as a `Style: ERB templates` step in `bin/ci` and the GitHub Actions `lint` job.
+
 ## v1.0.11 - 2026-05-09
 
 - Split the frontend app shell into smaller route, filter, API, async-loading, and draft-persistence modules to make the main app flow easier to follow.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,8 +100,13 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
-    bcrypt_pbkdf (1.1.2-arm64-darwin)
-    bcrypt_pbkdf (1.1.2-x86_64-darwin)
+    better_html (2.2.0)
+      actionview (>= 7.0)
+      activesupport (>= 7.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.24.1)
@@ -132,6 +137,13 @@ GEM
     drb (2.2.3)
     ed25519 (1.4.0)
     erb (6.0.3)
+    erb_lint (0.9.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop (>= 1)
+      smart_properties
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
@@ -389,6 +401,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    smart_properties (1.17.0)
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
@@ -478,6 +491,7 @@ DEPENDENCIES
   bundler-audit
   capybara
   debug
+  erb_lint
   image_processing (~> 1.2)
   importmap-rails
   jbuilder

--- a/back-end/.erb_lint.yml
+++ b/back-end/.erb_lint.yml
@@ -1,0 +1,18 @@
+---
+EnableDefaultLinters: true
+
+linters:
+  ErbSafety:
+    enabled: true
+  Rubocop:
+    # Disabled: RuboCop already runs separately on .rb files via bin/rubocop.
+    # Enabling it here causes false positives on inline ERB snippets.
+    enabled: false
+  ClosingErbTagIndent:
+    enabled: true
+  FinalNewline:
+    enabled: true
+  TrailingWhitespace:
+    enabled: true
+  NoUnusedCaptures:
+    enabled: true

--- a/back-end/Gemfile
+++ b/back-end/Gemfile
@@ -61,6 +61,9 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+
+  # ERB template linting [https://github.com/Shopify/erb-lint]
+  gem "erb_lint", require: false
 end
 
 group :development do

--- a/back-end/Gemfile.lock
+++ b/back-end/Gemfile.lock
@@ -100,8 +100,13 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
-    bcrypt_pbkdf (1.1.2-arm64-darwin)
-    bcrypt_pbkdf (1.1.2-x86_64-darwin)
+    better_html (2.2.0)
+      actionview (>= 7.0)
+      activesupport (>= 7.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.24.1)
@@ -132,6 +137,13 @@ GEM
     drb (2.2.3)
     ed25519 (1.4.0)
     erb (6.0.3)
+    erb_lint (0.9.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop (>= 1)
+      smart_properties
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
@@ -389,6 +401,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    smart_properties (1.17.0)
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
@@ -478,6 +491,7 @@ DEPENDENCIES
   bundler-audit
   capybara
   debug
+  erb_lint
   image_processing (~> 1.2)
   importmap-rails
   jbuilder

--- a/back-end/bin/erblint
+++ b/back-end/bin/erblint
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+require "rubygems"
+require "bundler/setup"
+
+load Gem.bin_path("erb_lint", "erb_lint")

--- a/back-end/config/ci.rb
+++ b/back-end/config/ci.rb
@@ -4,6 +4,7 @@ CI.run do
   step "Setup", "bin/setup --skip-server"
 
   step "Style: Ruby", "bin/rubocop"
+  step "Style: ERB templates", "bin/erblint --lint-all"
 
   step "Security: Gem audit", "bin/bundler-audit"
   step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"


### PR DESCRIPTION
- Add erb_lint gem to Gemfile (development/test group)
- Add .erb_lint.yml config with ErbSafety, ClosingErbTagIndent, FinalNewline, TrailingWhitespace, and NoUnusedCaptures linters
- Add bin/erblint executable wrapper
- Add 'Style: ERB templates' step to config/ci.rb
- Add 'Lint ERB templates' step to GitHub Actions lint job