### PR TITLE
Optimize closet layout for narrow PWA screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added AI metadata suggestion endpoints for clothing items, outfit detections, and temporary image previews, and passed richer metadata/reference-image context into AI clean-image generation.
 - Refined the add, edit, and detect-item flows with a shared editor workspace, category-aware metadata panels, richer detection previews, safer overwrite confirmation dialogs, compact AI action buttons, and footer/filter polish.
 - Added explicit loading feedback while detected-item metadata is still being prepared so the detect workflow no longer leaves the details pane blank during AI autofill.
+- Tuned the closet page for narrow mobile/PWA installs by keeping filter controls in a horizontal row, tightening trigger spacing, and using a denser two-column mobile item grid with slightly squarer cards.
 - Hardened local startup checks so `start.sh` can surface missing Ruby/Node toolchains earlier and fall back to common local Ruby install paths more gracefully.
 
 ## v2.0.2 - 2026-05-14

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -126,7 +126,7 @@ function ClosetFilterMenu({
         <PrimitiveDropdownMenuTrigger asChild>
           <PrimitiveDropdownTriggerButton
             disabled={options.length === 0}
-            className={hasSelections ? "pr-16" : undefined}
+            className={hasSelections ? "pr-14" : "pr-8"}
             aria-label={filterDescription}
           >
             {triggerLabel}
@@ -587,7 +587,7 @@ export default function App() {
               transition={{ duration: 0.6, delay: 0.3 }}
               className="mb-8 space-y-5"
             >
-              <div className="grid gap-3 min-[660px]:grid-cols-[minmax(0,3.2fr)_repeat(3,minmax(0,0.8fr))_minmax(0,1fr)] min-[660px]:items-start">
+              <div className="space-y-3 min-[660px]:grid min-[660px]:gap-3 min-[660px]:space-y-0 min-[660px]:grid-cols-[minmax(0,3.2fr)_repeat(3,minmax(0,0.8fr))_minmax(0,1fr)] min-[660px]:items-start">
                 <div className="relative min-w-0 self-start">
                   <label htmlFor="closet-search" className="sr-only">
                     Search closet items
@@ -602,54 +602,56 @@ export default function App() {
                   />
                 </div>
 
-                <div className="min-w-0">
-                  <ClosetFilterMenu
-                    label="Tags"
-                    options={groupedTagOptions.other}
-                    selectedValues={selectedOtherTags}
-                    onClear={() => clearSelectedValues(setSelectedOtherTags)}
-                    onToggleValue={(value) => toggleSelectedValue(value, setSelectedOtherTags)}
-                  />
-                </div>
+                <div className="flex gap-3 overflow-x-auto pb-1 min-[660px]:contents">
+                  <div className="min-w-[8.5rem] shrink-0 min-[660px]:min-w-0 min-[660px]:shrink">
+                    <ClosetFilterMenu
+                      label="Tags"
+                      options={groupedTagOptions.other}
+                      selectedValues={selectedOtherTags}
+                      onClear={() => clearSelectedValues(setSelectedOtherTags)}
+                      onToggleValue={(value) => toggleSelectedValue(value, setSelectedOtherTags)}
+                    />
+                  </div>
 
-                <div className="min-w-0">
-                  <ClosetFilterMenu
-                    label="Colors"
-                    options={groupedTagOptions.colors}
-                    selectedValues={selectedColors}
-                    onClear={() => clearSelectedValues(setSelectedColors)}
-                    onToggleValue={(value) => toggleSelectedValue(value, setSelectedColors)}
-                  />
-                </div>
+                  <div className="min-w-[8.5rem] shrink-0 min-[660px]:min-w-0 min-[660px]:shrink">
+                    <ClosetFilterMenu
+                      label="Colors"
+                      options={groupedTagOptions.colors}
+                      selectedValues={selectedColors}
+                      onClear={() => clearSelectedValues(setSelectedColors)}
+                      onToggleValue={(value) => toggleSelectedValue(value, setSelectedColors)}
+                    />
+                  </div>
 
-                <div className="min-w-0">
-                  <ClosetFilterMenu
-                    label="Brands"
-                    options={groupedTagOptions.brands}
-                    selectedValues={selectedBrands}
-                    onClear={() => clearSelectedValues(setSelectedBrands)}
-                    onToggleValue={(value) => toggleSelectedValue(value, setSelectedBrands)}
-                  />
-                </div>
+                  <div className="min-w-[8.5rem] shrink-0 min-[660px]:min-w-0 min-[660px]:shrink">
+                    <ClosetFilterMenu
+                      label="Brands"
+                      options={groupedTagOptions.brands}
+                      selectedValues={selectedBrands}
+                      onClear={() => clearSelectedValues(setSelectedBrands)}
+                      onToggleValue={(value) => toggleSelectedValue(value, setSelectedBrands)}
+                    />
+                  </div>
 
-                <div className="min-w-0">
-                  <label id="closet-sort-label" className="sr-only">
-                    Sort closet items
-                  </label>
-                  <PrimitiveSelect value={sortOption} onValueChange={(value) => setSortOption(value as ClosetSortOption)}>
-                    <PrimitiveSelectTrigger
-                      aria-labelledby="closet-sort-label"
-                      className="h-14 w-full bg-stone-200 hover:bg-stone-200"
-                    >
-                      <PrimitiveSelectValue placeholder="Sort items" />
-                    </PrimitiveSelectTrigger>
-                    <PrimitiveSelectContent>
-                      <PrimitiveSelectItem value="name-asc">Name A-Z</PrimitiveSelectItem>
-                      <PrimitiveSelectItem value="newest-added">Newest added</PrimitiveSelectItem>
-                      <PrimitiveSelectItem value="oldest-added">Oldest added</PrimitiveSelectItem>
-                      <PrimitiveSelectItem value="recent-purchase">Most recent purchase</PrimitiveSelectItem>
-                    </PrimitiveSelectContent>
-                  </PrimitiveSelect>
+                  <div className="min-w-[8.5rem] shrink-0 min-[660px]:min-w-0 min-[660px]:shrink">
+                    <label id="closet-sort-label" className="sr-only">
+                      Sort closet items
+                    </label>
+                    <PrimitiveSelect value={sortOption} onValueChange={(value) => setSortOption(value as ClosetSortOption)}>
+                      <PrimitiveSelectTrigger
+                        aria-labelledby="closet-sort-label"
+                        className="h-14 w-full gap-1.5 bg-stone-200 px-2.5 hover:bg-stone-200"
+                      >
+                        <PrimitiveSelectValue placeholder="Sort items" />
+                      </PrimitiveSelectTrigger>
+                      <PrimitiveSelectContent>
+                        <PrimitiveSelectItem value="name-asc">Name A-Z</PrimitiveSelectItem>
+                        <PrimitiveSelectItem value="newest-added">Newest added</PrimitiveSelectItem>
+                        <PrimitiveSelectItem value="oldest-added">Oldest added</PrimitiveSelectItem>
+                        <PrimitiveSelectItem value="recent-purchase">Most recent purchase</PrimitiveSelectItem>
+                      </PrimitiveSelectContent>
+                    </PrimitiveSelect>
+                  </div>
                 </div>
               </div>
 
@@ -677,7 +679,7 @@ export default function App() {
             </motion.div>
 
             {user && filteredClothingItems.length > 0 ? (
-              <div className="grid grid-cols-1 gap-x-6 gap-y-12 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="grid grid-cols-2 gap-x-4 gap-y-8 sm:gap-x-6 sm:gap-y-12 lg:grid-cols-4">
                 {filteredClothingItems.map((item, index) => (
                   <ClothingCard
                     key={item.id}

--- a/front-end/src/app/components/ClothingCard.tsx
+++ b/front-end/src/app/components/ClothingCard.tsx
@@ -51,7 +51,7 @@ export function ClothingCard({
       role="button"
       tabIndex={0}
     >
-      <div className="relative overflow-hidden bg-muted aspect-[3/4]">
+      <div className="relative overflow-hidden bg-muted aspect-[5/6] sm:aspect-[3/4]">
         {image_url ? (
           <img
             src={image_url}

--- a/front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx
+++ b/front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx
@@ -40,7 +40,7 @@ function PrimitiveDropdownTriggerButton({
       type="button"
       className={cn(
         primitiveSelectTriggerVariants({ size: "default" }),
-        "relative h-14 rounded-none bg-stone-200 pr-10 hover:bg-stone-200",
+        "relative h-14 rounded-none bg-stone-200 pr-8 hover:bg-stone-200",
         className,
       )}
       style={{ fontFamily: "Outfit, sans-serif", ...style }}
@@ -50,7 +50,7 @@ function PrimitiveDropdownTriggerButton({
       <span className="block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-left">
         {children}
       </span>
-      <ChevronDown className="pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 opacity-50" />
+      <ChevronDown className="pointer-events-none absolute top-1/2 right-2.5 size-4 -translate-y-1/2 opacity-50" />
     </button>
   );
 }


### PR DESCRIPTION
## User-facing changes

- Improved the closet page layout for narrow mobile and PWA-installed screens.
- Kept the closet filter controls in a horizontal row on very thin viewports instead of stacking them vertically.
- Tightened the spacing inside the filter and sort triggers so the controls fit more comfortably on smaller screens.
- Updated the closet item grid to a denser two-column layout on mobile.
- Adjusted mobile closet item cards to use a slightly squarer aspect ratio for a more balanced small-screen presentation.

## Internal changes

- Reworked the closet filter/search section in [front-end/src/app/App.tsx](/Users/Annie/Desktop/  /NU/Master's/Q3/project-closet-organizer/front-end/src/app/App.tsx) so the mobile layout uses a search row plus a horizontally scrollable filter/sort row, while preserving the existing wider-screen grid layout.
- Tightened the shared dropdown trigger spacing in [front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx](/Users/Annie/Desktop/  /NU/Master's/Q3/project-closet-organizer/front-end/src/app/components/primitives/PrimitiveDropdownTriggerButton.tsx) to reduce excess width on narrow screens.
- Updated [front-end/src/app/components/ClothingCard.tsx](/Users/Annie/Desktop/  /NU/Master's/Q3/project-closet-organizer/front-end/src/app/components/ClothingCard.tsx) so closet cards render with a slightly squarer aspect ratio on mobile while keeping the existing larger-screen ratio.
- Added an `Unreleased` changelog entry in [CHANGELOG.md](/Users/Annie/Desktop/  /NU/Master's/Q3/project-closet-organizer/CHANGELOG.md:3) to capture the mobile/PWA layout work.

## Why we made these changes

We made these changes to make the app work better as an installable PWA on mobile devices. On narrow screens, the closet page needed a denser, more stable layout so filtering and browsing still feel usable without controls wrapping awkwardly or cards feeling overly tall.

Closes #53 