### PR TITLE
feat(users): paginate admin users index and seed large dev dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added Kaminari-backed pagination to the admin users index (`GET /users?page=&per_page=`) returning a `{ users, meta }` envelope, surfaced a paginated grid with Previous/Next/page controls on the admin users directory, and switched the directory cards to a `clothing_items_count` field so per-user item arrays no longer ship with the index payload.
+- Expanded `db/seeds.rb` to a development-scale dataset (~1,050 users, ~5,200 clothing items, ~2,100 outfits with linked items) so pagination and large-list performance are visible during local development.
 - Renamed the app to Curated Closet, added branded sign-in/logo assets plus a new favicon, refreshed the home sign-in copy, redirected signed-in visits to `/` back to `/closet`, and switched signed-out auth fallbacks to a single standalone sign-in screen without the main app shell.
 - Added persisted clothing item categories and detection-source links so AI-detected item types survive into saved closet records.
 - Added AI metadata suggestion endpoints for clothing items, outfit detections, and temporary image previews, and passed richer metadata/reference-image context into AI clean-image generation.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
+    bcrypt_pbkdf (1.1.2-arm64-darwin)
+    bcrypt_pbkdf (1.1.2-x86_64-darwin)
     better_html (2.2.0)
       actionview (>= 7.0)
       activesupport (>= 7.0)
@@ -201,6 +203,18 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -496,6 +510,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  kaminari
   net-imap (>= 0.6.4)
   omniauth
   omniauth-google-oauth2

--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -29,7 +29,7 @@ project-closet-organizer/
 - `app/presenters`: API payload shaping for users, clothing items, outfits, uploads, and detections
 - `app/services/`: OpenRouter detection, metadata suggestion, crop refinement, crop verification, image-cleaning logic, and shared tempfile/image-source helpers
 - `config/routes.rb`: API routes plus HTML fallback routes
-- `db/seeds.rb`: demo admin user and closet seed generation
+- `db/seeds.rb`: demo admin user plus large-scale dev seed (~1k users, ~5k items, ~2k outfits) for pagination/perf testing
 - `test/`: model, integration, and service tests
 
 ## Frontend (`front-end`)

--- a/back-end/Gemfile
+++ b/back-end/Gemfile
@@ -20,6 +20,7 @@ gem "jbuilder"
 
 gem "bcrypt", "~> 3.1.7"
 gem "aws-sdk-s3", require: false
+gem "kaminari"
 gem "omniauth"
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"

--- a/back-end/Gemfile.lock
+++ b/back-end/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
+    bcrypt_pbkdf (1.1.2-arm64-darwin)
+    bcrypt_pbkdf (1.1.2-x86_64-darwin)
     better_html (2.2.0)
       actionview (>= 7.0)
       activesupport (>= 7.0)
@@ -201,6 +203,18 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -496,6 +510,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  kaminari
   net-imap (>= 0.6.4)
   omniauth
   omniauth-google-oauth2

--- a/back-end/README.md
+++ b/back-end/README.md
@@ -12,6 +12,7 @@ Rails 8 JSON backend for Curated Closet.
 - `has_secure_password`
 - OmniAuth Google OAuth 2
 - Active Storage for uploaded and generated images
+- Kaminari for paginated index endpoints
 
 ## What The Backend Handles
 
@@ -92,6 +93,7 @@ Notes:
 - `/` resolves to `clothing_items#index` inside the JSON scope.
 - HTML browser requests for SPA routes fall back to the frontend shell.
 - `ApplicationController` returns `404` JSON for missing records and `422` JSON for validation failures.
+- `GET /users` is paginated via Kaminari. It accepts `page` and `per_page` query params (default 24, max 100) and returns `{ users: [...], meta: { page, per_page, total_pages, total_count } }`. The index payload omits each user's `clothing_items` array and only includes a `clothing_items_count` field; per-user `GET /users/:id` still returns the full items array.
 
 ## Important Internal Files
 
@@ -207,16 +209,23 @@ See [back-end/.env.example](./.env.example) for expected variables.
 
 ## Seeds
 
-`db/seeds.rb` currently creates:
+`db/seeds.rb` builds a development-scale dataset so pagination and large-list performance are visible locally:
 
-- one Google-backed admin user: `annabel_goldman`
-- email `annabelgoldman2025@u.northwestern.edu`
-- a 20-item demo closet with realistic wardrobe tags
+- preset Google-backed admin user `annabel_goldman` (email `annabelgoldman2025@u.northwestern.edu`) with a 20-item demo closet and a few sample outfits
+- ~1,050 additional generated users (provider `"seed"`, shared password `password`) with realistic names and preferred styles
+- ~5,200 total clothing items distributed across users using a long-tail distribution (some users empty, most with a handful, a few with many)
+- ~2,100 total outfits, each linked to 2–5 of its owner's items
 
 Load seeds with:
 
 ```bash
 bin/rails db:seed
+```
+
+To reset and reseed:
+
+```bash
+bin/rails db:reset
 ```
 
 ## Tests And Quality Checks

--- a/back-end/app/controllers/users_controller.rb
+++ b/back-end/app/controllers/users_controller.rb
@@ -3,8 +3,22 @@ class UsersController < ApplicationController
   before_action :require_admin, only: %i[index show]
   before_action :set_user, only: %i[ show update destroy ]
 
+  DEFAULT_PER_PAGE = 24
+  MAX_PER_PAGE = 100
+
   def index
-    render json: User.order(:username).map { |user| payloads.user(user) }
+    scope = User.order(:username)
+    page = scope.page(params[:page]).per(resolved_per_page)
+
+    render json: {
+      users: page.map { |user| payloads.user(user, include_items: false) },
+      meta: {
+        page: page.current_page,
+        per_page: page.limit_value,
+        total_pages: page.total_pages,
+        total_count: page.total_count
+      }
+    }
   end
 
   def show
@@ -42,5 +56,12 @@ class UsersController < ApplicationController
     else
       permitted
     end
+  end
+
+  def resolved_per_page
+    raw = params[:per_page].presence&.to_i
+    return DEFAULT_PER_PAGE if raw.blank? || raw <= 0
+
+    [ raw, MAX_PER_PAGE ].min
   end
 end

--- a/back-end/app/presenters/api_payloads.rb
+++ b/back-end/app/presenters/api_payloads.rb
@@ -8,6 +8,8 @@ class ApiPayloads
       only: %i[id username preferred_style email avatar_url admin created_at updated_at]
     )
 
+    payload["clothing_items_count"] = user.clothing_items.size
+
     if include_items
       payload["clothing_items"] = user.clothing_items.order(:name).map do |item|
         clothing_item(item, include_user: false)

--- a/back-end/db/seeds.rb
+++ b/back-end/db/seeds.rb
@@ -1,9 +1,13 @@
 require "date"
 
-srand(20260425)
+srand(20260517)
 
-ClothingItem.destroy_all
-User.destroy_all
+ActiveRecord::Base.transaction do
+  OutfitItem.delete_all
+  Outfit.delete_all
+  ClothingItem.delete_all
+  User.delete_all
+end
 
 WARDROBE_LIBRARY = {
   smart_casual: [
@@ -59,7 +63,38 @@ SIZE_PROFILES = {
   relaxed: %i[medium large large xl]
 }.freeze
 
-seed_users = [
+OUTFIT_NAME_TEMPLATES = [
+  "Monday Morning",
+  "Coffee Run",
+  "Office Day",
+  "Date Night",
+  "Weekend Brunch",
+  "Studio Session",
+  "Evening Out",
+  "Travel Day",
+  "Quiet Saturday",
+  "Errand Loop",
+  "Gallery Opening",
+  "Cabin Weekend",
+  "Sunday Reset",
+  "Friday Drinks"
+].freeze
+
+FIRST_NAMES = %w[
+  alex avery bailey blair cameron casey charlie dakota drew elliot emery finley
+  hayden harper hunter jamie jordan kai kendall kennedy logan morgan parker
+  payton peyton quinn reese riley rowan sage skyler sloan taylor teagan tristan
+  remi ari ellis sutton ezra june theo aspen ridley remy linden
+].freeze
+
+LAST_NAMES = %w[
+  abel albright bishop blakely carrington cole dove ellsworth fairbanks gallagher
+  hartley ivory james kingsley lockhart monroe nash orchard pemberton quarry
+  reyes sutherland tanaka underwood valencia winters xie yamamoto zane
+  ashford brennan calder davenport everett fernsby greer huxley iverson kellerman
+].freeze
+
+PRESET_USERS = [
   {
     username: "annabel_goldman",
     email: "annabelgoldman2025@u.northwestern.edu",
@@ -68,9 +103,18 @@ seed_users = [
     password: "password",
     admin: true,
     preferred_style: "polished",
-    item_count: 20
+    item_count: 20,
+    outfit_count: 4,
+    size_profile: :standard
   }
-]
+].freeze
+
+STYLE_KEYS = WARDROBE_LIBRARY.keys.map(&:to_s).freeze
+SIZE_KEYS = SIZE_PROFILES.keys.freeze
+
+TARGET_TOTAL_USERS = 1_050
+TARGET_TOTAL_ITEMS = 5_200
+TARGET_TOTAL_OUTFITS = 2_100
 
 def random_purchase_date
   Date.today - rand(20..540)
@@ -80,9 +124,44 @@ def build_item_name(base_name)
   "#{ADJECTIVES.sample} #{base_name}"
 end
 
-created_items_count = 0
+def build_clothing_item_attrs(user_id, style_key, size_pool)
+  base_name, base_tags = WARDROBE_LIBRARY.fetch(style_key.to_sym).sample
+  now = Time.current
 
-seed_users.each do |user_data|
+  {
+    name: build_item_name(base_name),
+    size: ClothingItem.sizes.fetch(size_pool.sample.to_s),
+    date: random_purchase_date,
+    user_id: user_id,
+    tags: base_tags + [ style_key.to_s.tr("_", " ") ],
+    clean_image_status: 0,
+    created_at: now,
+    updated_at: now
+  }
+end
+
+def unique_username(seen, base)
+  candidate = base
+  suffix = 2
+  while seen.include?(candidate)
+    candidate = "#{base}_#{suffix}"
+    suffix += 1
+  end
+  seen << candidate
+  candidate
+end
+
+def make_random_username(seen)
+  base = "#{FIRST_NAMES.sample}_#{LAST_NAMES.sample}#{rand(10..9999)}"
+  unique_username(seen, base)
+end
+
+puts "Creating preset users..."
+
+seen_usernames = Set.new
+preset_user_records = []
+
+PRESET_USERS.each do |user_data|
   user = User.create!(
     username: user_data[:username],
     email: user_data[:email],
@@ -92,36 +171,171 @@ seed_users.each do |user_data|
     admin: user_data.fetch(:admin, false),
     preferred_style: user_data[:preferred_style]
   )
+  seen_usernames << user.username
+  preset_user_records << [ user, user_data ]
+end
 
-  if user_data[:items].present?
-    user_data[:items].each do |item_data|
-      ClothingItem.create!(
-        name: item_data[:name],
-        size: item_data[:size],
-        date: item_data[:date],
-        user: user,
-        tags: item_data[:tags]
-      )
-      created_items_count += 1
-    end
-    next
-  end
+remaining_users = TARGET_TOTAL_USERS - preset_user_records.size
+puts "Generating #{remaining_users} additional users (target: #{TARGET_TOTAL_USERS} total)..."
 
-  style_pool = WARDROBE_LIBRARY.fetch(user.preferred_style.to_sym)
+generated_user_rows = []
+remaining_users.times do
+  username = make_random_username(seen_usernames)
+  preferred_style = STYLE_KEYS.sample
+  now = Time.current
+  generated_user_rows << {
+    username: username,
+    email: "#{username}@example.com",
+    provider: "seed",
+    uid: "seed-#{username}",
+    password_digest: BCrypt::Password.create("password", cost: BCrypt::Engine::MIN_COST),
+    admin: false,
+    preferred_style: preferred_style,
+    created_at: now,
+    updated_at: now
+  }
+end
+
+User.insert_all(generated_user_rows) if generated_user_rows.any?
+
+all_users = User.order(:id).to_a
+puts "User count: #{all_users.size}"
+
+preset_user_ids = preset_user_records.map { |user, _| user.id }
+generated_users = all_users.reject { |user| preset_user_ids.include?(user.id) }
+
+puts "Building preset clothing items and outfits..."
+
+preset_item_rows = []
+preset_user_records.each do |user, user_data|
   size_pool = SIZE_PROFILES.fetch(user_data.fetch(:size_profile, :standard))
-
   user_data.fetch(:item_count, 0).times do
-    base_name, base_tags = style_pool.sample
-
-    ClothingItem.create!(
-      name: build_item_name(base_name),
-      size: size_pool.sample,
-      date: random_purchase_date,
-      user: user,
-      tags: base_tags + [ user.preferred_style.to_s.tr("_", " ") ]
-    )
-    created_items_count += 1
+    preset_item_rows << build_clothing_item_attrs(user.id, user.preferred_style, size_pool)
   end
 end
 
-puts "Seeded #{User.count} users and #{created_items_count} clothing items"
+ClothingItem.insert_all(preset_item_rows) if preset_item_rows.any?
+
+# Distribute generated items across non-preset users.
+preset_item_total = preset_item_rows.size
+remaining_items = [ TARGET_TOTAL_ITEMS - preset_item_total, 0 ].max
+
+puts "Generating #{remaining_items} additional clothing items..."
+
+# Use a weighted distribution so most users have a few items, some have many.
+# Weights chosen to produce a realistic long-tail distribution.
+def sample_item_count_for_user
+  roll = rand
+  case roll
+  when 0.0...0.15 then 0                # ~15% have no items
+  when 0.15...0.55 then rand(1..3)      # ~40% have 1-3
+  when 0.55...0.85 then rand(4..8)      # ~30% have 4-8
+  when 0.85...0.97 then rand(9..15)     # ~12% have 9-15
+  else rand(16..40)                     # ~3% have 16-40
+  end
+end
+
+generated_item_rows = []
+generated_users.each do |user|
+  count = sample_item_count_for_user
+  size_pool = SIZE_PROFILES.fetch(SIZE_KEYS.sample)
+  count.times do
+    generated_item_rows << build_clothing_item_attrs(user.id, user.preferred_style, size_pool)
+    break if generated_item_rows.size >= remaining_items
+  end
+  break if generated_item_rows.size >= remaining_items
+end
+
+# Top up if we still haven't reached the target.
+while generated_item_rows.size < remaining_items
+  user = generated_users.sample
+  size_pool = SIZE_PROFILES.fetch(SIZE_KEYS.sample)
+  generated_item_rows << build_clothing_item_attrs(user.id, user.preferred_style, size_pool)
+end
+
+# Insert in batches to keep memory bounded.
+generated_item_rows.each_slice(1_000) { |batch| ClothingItem.insert_all(batch) }
+
+items_by_user = ClothingItem.pluck(:user_id, :id).group_by(&:first).transform_values { |rows| rows.map(&:last) }
+
+puts "Total clothing items: #{ClothingItem.count}"
+
+puts "Building outfits..."
+
+preset_outfit_rows = []
+preset_outfit_user_records = []
+preset_user_records.each do |user, user_data|
+  user_data.fetch(:outfit_count, 0).times do |i|
+    now = Time.current
+    preset_outfit_rows << {
+      user_id: user.id,
+      name: "#{OUTFIT_NAME_TEMPLATES.sample} #{i + 1}",
+      tags: [ user.preferred_style ],
+      notes: nil,
+      created_at: now,
+      updated_at: now
+    }
+    preset_outfit_user_records << user
+  end
+end
+
+remaining_outfits = [ TARGET_TOTAL_OUTFITS - preset_outfit_rows.size, 0 ].max
+puts "Generating #{remaining_outfits} additional outfits..."
+
+# Outfit attachments: skip users with no items.
+candidate_users = generated_users.select { |user| items_by_user[user.id]&.any? }
+generated_outfit_rows = []
+generated_outfit_user_ids = []
+
+remaining_outfits.times do
+  user = candidate_users.sample
+  next unless user
+
+  now = Time.current
+  generated_outfit_rows << {
+    user_id: user.id,
+    name: "#{OUTFIT_NAME_TEMPLATES.sample} #{rand(1..99)}",
+    tags: [ user.preferred_style, OUTFIT_NAME_TEMPLATES.sample.downcase ].uniq,
+    notes: nil,
+    created_at: now,
+    updated_at: now
+  }
+  generated_outfit_user_ids << user.id
+end
+
+all_outfit_rows = preset_outfit_rows + generated_outfit_rows
+all_outfit_rows.each_slice(1_000) { |batch| Outfit.insert_all(batch) }
+
+puts "Total outfits: #{Outfit.count}"
+
+puts "Linking outfit items..."
+
+outfit_id_iter = Outfit.order(:id).pluck(:id).each
+outfit_user_ids = preset_outfit_user_records.map(&:id) + generated_outfit_user_ids
+
+outfit_item_rows = []
+outfit_user_ids.each do |user_id|
+  outfit_id = outfit_id_iter.next
+  item_ids = items_by_user[user_id] || []
+  next if item_ids.empty?
+
+  pick_count = [ rand(2..5), item_ids.size ].min
+  chosen_ids = item_ids.sample(pick_count)
+  now = Time.current
+  chosen_ids.each do |item_id|
+    outfit_item_rows << {
+      outfit_id: outfit_id,
+      clothing_item_id: item_id,
+      created_at: now,
+      updated_at: now
+    }
+  end
+end
+
+outfit_item_rows.each_slice(2_000) { |batch| OutfitItem.insert_all(batch) }
+
+puts "Seed complete:"
+puts "  Users: #{User.count}"
+puts "  Clothing items: #{ClothingItem.count}"
+puts "  Outfits: #{Outfit.count}"
+puts "  Outfit-item links: #{OutfitItem.count}"

--- a/back-end/test/integration/users_flow_test.rb
+++ b/back-end/test/integration/users_flow_test.rb
@@ -10,7 +10,19 @@ class UsersFlowTest < ActionDispatch::IntegrationTest
     get users_url, headers: auth_headers(@admin), as: :json
 
     assert_response :success
-    assert_equal [ @user.username, @admin.username ].sort, response_json.map { |user| user["username"] }
+    usernames = response_json["users"].map { |user| user["username"] }.sort
+    assert_equal [ @user.username, @admin.username ].sort, usernames
+    assert_equal 2, response_json.dig("meta", "total_count")
+    assert_equal 1, response_json.dig("meta", "page")
+  end
+
+  test "users index paginates with page and per_page" do
+    get users_url(page: 1, per_page: 1), headers: auth_headers(@admin), as: :json
+
+    assert_response :success
+    assert_equal 1, response_json["users"].size
+    assert_equal 2, response_json.dig("meta", "total_count")
+    assert_equal 2, response_json.dig("meta", "total_pages")
   end
 
   test "browser html request for users index falls back to the frontend app" do

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -74,6 +74,7 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
 
 - The app loads the signed-in user through `GET /me`.
 - Non-admin users are blocked from `/users` and `/users/:id` in both backend authorization and frontend navigation.
+- The admin users directory at `/users` is paginated (24 per page) and uses a `clothing_items_count` field per user instead of shipping each user's full items array.
 - Closet filtering and sorting are handled through focused helpers in `src/app/lib/closetFilters.ts`.
 - Item create and edit flows send multipart form data so photos can be uploaded, cropped, removed, or sourced from detected outfit-photo regions.
 - The item editor can request AI metadata suggestions for type, name, brand, and tags, and can request cleaned item imagery for catalog-style presentation.

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -90,9 +90,15 @@ function removeUserItem(user: User | null, itemId: number) {
     return user;
   }
 
+  const nextItems = user.clothing_items.filter((item) => item.id !== itemId);
+  const removed = nextItems.length !== user.clothing_items.length;
+
   return {
     ...user,
-    clothing_items: user.clothing_items.filter((item) => item.id !== itemId),
+    clothing_items: nextItems,
+    clothing_items_count: removed
+      ? Math.max(0, user.clothing_items_count - 1)
+      : user.clothing_items_count,
   };
 }
 
@@ -475,6 +481,7 @@ export default function App() {
               clothing_items: [...current.clothing_items, ...nextItems].sort((left, right) =>
                 left.name.localeCompare(right.name),
               ),
+              clothing_items_count: current.clothing_items_count + nextItems.length,
             };
           });
 

--- a/front-end/src/app/components/UsersDirectoryPage.tsx
+++ b/front-end/src/app/components/UsersDirectoryPage.tsx
@@ -1,10 +1,26 @@
+import { useState } from "react";
 import { motion } from "motion/react";
 import { ChevronRight, Users } from "lucide-react";
-import { fetchUsers, formatPossessive, formatPreferredStyle, titleize, User } from "../lib/closet";
+import {
+  fetchUsers,
+  formatPossessive,
+  formatPreferredStyle,
+  titleize,
+  UsersPage,
+} from "../lib/closet";
 import { usePageData } from "../lib/usePageData";
 import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 import { AccessRestrictedState } from "./shared/AccessRestrictedState";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "./ui/pagination";
 
 interface UsersDirectoryPageProps {
   onBack: () => void;
@@ -12,17 +28,50 @@ interface UsersDirectoryPageProps {
 }
 
 const MotionPrimitiveButton = motion.create(PrimitiveButton);
+const PER_PAGE = 24;
+
+const EMPTY_PAGE: UsersPage = {
+  users: [],
+  meta: { page: 1, per_page: PER_PAGE, total_pages: 0, total_count: 0 },
+};
+
+function pageNumbersToShow(currentPage: number, totalPages: number): Array<number | "ellipsis"> {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const pages: Array<number | "ellipsis"> = [1];
+  const windowStart = Math.max(2, currentPage - 1);
+  const windowEnd = Math.min(totalPages - 1, currentPage + 1);
+
+  if (windowStart > 2) {
+    pages.push("ellipsis");
+  }
+
+  for (let page = windowStart; page <= windowEnd; page += 1) {
+    pages.push(page);
+  }
+
+  if (windowEnd < totalPages - 1) {
+    pages.push("ellipsis");
+  }
+
+  pages.push(totalPages);
+  return pages;
+}
 
 export function UsersDirectoryPage({ onBack, onSelectUser }: UsersDirectoryPageProps) {
+  const [page, setPage] = useState(1);
+
   const {
-    data: users,
+    data: { users, meta },
     errorMessage,
     isLoading,
-  } = usePageData<User[]>({
-    deps: [],
+  } = usePageData<UsersPage>({
+    deps: [page],
     getErrorMessage: (error) => (error instanceof Error ? error.message : "Unable to load users."),
-    initialData: [],
-    load: (signal) => fetchUsers(signal),
+    initialData: EMPTY_PAGE,
+    load: (signal) => fetchUsers({ page, perPage: PER_PAGE }, signal),
   });
   const isForbidden = /not authorized/i.test(errorMessage);
 
@@ -35,6 +84,22 @@ export function UsersDirectoryPage({ onBack, onSelectUser }: UsersDirectoryPageP
       />
     );
   }
+
+  const totalCount = meta.total_count;
+  const totalPages = Math.max(meta.total_pages, 1);
+  const startIndex = totalCount === 0 ? 0 : (meta.page - 1) * meta.per_page + 1;
+  const endIndex = totalCount === 0 ? 0 : Math.min(meta.page * meta.per_page, totalCount);
+  const shouldShowPagination = totalPages > 1;
+
+  const goToPage = (nextPage: number) => {
+    const clamped = Math.min(Math.max(1, nextPage), totalPages);
+    if (clamped !== page) {
+      setPage(clamped);
+    }
+  };
+
+  const isFirstPage = meta.page <= 1;
+  const isLastPage = meta.page >= totalPages;
 
   return (
     <div className="min-h-screen bg-background">
@@ -62,7 +127,7 @@ export function UsersDirectoryPage({ onBack, onSelectUser }: UsersDirectoryPageP
           <div className="hidden sm:flex items-center gap-3 px-5 py-3 border border-border bg-card">
             <Users className="w-4 h-4" />
             <PrimitiveText as="span" variant="bodySm">
-              {users.length} users
+              {totalCount.toLocaleString()} {totalCount === 1 ? "user" : "users"}
             </PrimitiveText>
           </div>
         </div>
@@ -86,57 +151,127 @@ export function UsersDirectoryPage({ onBack, onSelectUser }: UsersDirectoryPageP
               </div>
             ))}
           </div>
-        ) : (
-          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            {users.map((user, index) => {
-              const preferredStyle = formatPreferredStyle(user.preferred_style);
-              return (
-                <MotionPrimitiveButton
-                  key={user.id}
-                  initial={{ opacity: 0, y: 18 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.45, delay: index * 0.04 }}
-                  onClick={() => onSelectUser(user.id)}
-                  variant="outline"
-                  className="h-auto justify-start bg-card p-6 text-left hover:border-foreground"
-                >
-                  <PrimitiveText as="p" variant="overline" tone="muted" className="mb-4">
-                    Closet Owner
-                  </PrimitiveText>
-                  <PrimitiveText as="h2" variant="title" font="serif" className="mb-2">
-                    {titleize(user.username)}
-                  </PrimitiveText>
-                  <PrimitiveText as="p" tone="muted" className="mb-6">
-                    {formatPossessive(titleize(user.username))}
-                  </PrimitiveText>
-                  <div className="grid grid-cols-2 gap-4 text-sm mb-6">
-                    <div className="border border-border p-4">
-                      <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-1">
-                        Items
-                      </PrimitiveText>
-                      <PrimitiveText as="p" variant="stat" font="serif">
-                        {user.clothing_items.length}
-                      </PrimitiveText>
-                    </div>
-                    <div className="border border-border p-4">
-                      <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-1">
-                        Style
-                      </PrimitiveText>
-                      <PrimitiveText as="p" variant="stat" font="serif">
-                        {preferredStyle ?? "N/A"}
-                      </PrimitiveText>
-                    </div>
-                  </div>
-                  <div className="flex items-center justify-between text-sm">
-                    <PrimitiveText as="span" variant="bodySm">
-                      Open details
-                    </PrimitiveText>
-                    <ChevronRight className="w-4 h-4" />
-                  </div>
-                </MotionPrimitiveButton>
-              );
-            })}
+        ) : users.length === 0 ? (
+          <div className="border border-dashed border-border p-12 text-center">
+            <PrimitiveText as="p" variant="display" font="serif" className="mb-2">
+              No users yet
+            </PrimitiveText>
+            <PrimitiveText as="p" tone="muted">
+              Once people sign in, they will show up here.
+            </PrimitiveText>
           </div>
+        ) : (
+          <>
+            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+              {users.map((user, index) => {
+                const preferredStyle = formatPreferredStyle(user.preferred_style);
+                return (
+                  <MotionPrimitiveButton
+                    key={user.id}
+                    initial={{ opacity: 0, y: 18 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.45, delay: index * 0.02 }}
+                    onClick={() => onSelectUser(user.id)}
+                    variant="outline"
+                    className="h-auto justify-start bg-card p-6 text-left hover:border-foreground"
+                  >
+                    <PrimitiveText as="p" variant="overline" tone="muted" className="mb-4">
+                      Closet Owner
+                    </PrimitiveText>
+                    <PrimitiveText as="h2" variant="title" font="serif" className="mb-2">
+                      {titleize(user.username)}
+                    </PrimitiveText>
+                    <PrimitiveText as="p" tone="muted" className="mb-6">
+                      {formatPossessive(titleize(user.username))}
+                    </PrimitiveText>
+                    <div className="grid grid-cols-2 gap-4 text-sm mb-6">
+                      <div className="border border-border p-4">
+                        <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-1">
+                          Items
+                        </PrimitiveText>
+                        <PrimitiveText as="p" variant="stat" font="serif">
+                          {user.clothing_items_count.toLocaleString()}
+                        </PrimitiveText>
+                      </div>
+                      <div className="border border-border p-4">
+                        <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-1">
+                          Style
+                        </PrimitiveText>
+                        <PrimitiveText as="p" variant="stat" font="serif">
+                          {preferredStyle ?? "N/A"}
+                        </PrimitiveText>
+                      </div>
+                    </div>
+                    <div className="flex items-center justify-between text-sm">
+                      <PrimitiveText as="span" variant="bodySm">
+                        Open details
+                      </PrimitiveText>
+                      <ChevronRight className="w-4 h-4" />
+                    </div>
+                  </MotionPrimitiveButton>
+                );
+              })}
+            </div>
+
+            {shouldShowPagination && (
+              <div className="mt-10 flex flex-col items-center gap-3">
+                <PrimitiveText as="p" variant="bodySm" tone="muted">
+                  Showing {startIndex.toLocaleString()}–{endIndex.toLocaleString()} of{" "}
+                  {totalCount.toLocaleString()}
+                </PrimitiveText>
+                <Pagination>
+                  <PaginationContent>
+                    <PaginationItem>
+                      <PaginationPrevious
+                        href="#"
+                        aria-disabled={isFirstPage}
+                        className={isFirstPage ? "pointer-events-none opacity-50" : ""}
+                        onClick={(event) => {
+                          event.preventDefault();
+                          if (!isFirstPage) {
+                            goToPage(meta.page - 1);
+                          }
+                        }}
+                      />
+                    </PaginationItem>
+                    {pageNumbersToShow(meta.page, totalPages).map((entry, index) =>
+                      entry === "ellipsis" ? (
+                        <PaginationItem key={`ellipsis-${index}`}>
+                          <PaginationEllipsis />
+                        </PaginationItem>
+                      ) : (
+                        <PaginationItem key={entry}>
+                          <PaginationLink
+                            href="#"
+                            isActive={entry === meta.page}
+                            onClick={(event) => {
+                              event.preventDefault();
+                              goToPage(entry);
+                            }}
+                          >
+                            {entry}
+                          </PaginationLink>
+                        </PaginationItem>
+                      ),
+                    )}
+                    <PaginationItem>
+                      <PaginationNext
+                        href="#"
+                        aria-disabled={isLastPage}
+                        className={isLastPage ? "pointer-events-none opacity-50" : ""}
+                        onClick={(event) => {
+                          event.preventDefault();
+                          if (!isLastPage) {
+                            goToPage(meta.page + 1);
+                          }
+                        }}
+                      />
+                    </PaginationItem>
+                  </PaginationContent>
+                </Pagination>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/front-end/src/app/components/UsersDirectoryPage.tsx
+++ b/front-end/src/app/components/UsersDirectoryPage.tsx
@@ -173,40 +173,51 @@ export function UsersDirectoryPage({ onBack, onSelectUser }: UsersDirectoryPageP
                     transition={{ duration: 0.45, delay: index * 0.02 }}
                     onClick={() => onSelectUser(user.id)}
                     variant="outline"
-                    className="h-auto justify-start bg-card p-6 text-left hover:border-foreground"
+                    className="h-auto w-full whitespace-normal items-stretch justify-start gap-0 bg-card p-6 text-left hover:border-foreground"
                   >
-                    <PrimitiveText as="p" variant="overline" tone="muted" className="mb-4">
-                      Closet Owner
-                    </PrimitiveText>
-                    <PrimitiveText as="h2" variant="title" font="serif" className="mb-2">
-                      {titleize(user.username)}
-                    </PrimitiveText>
-                    <PrimitiveText as="p" tone="muted" className="mb-6">
-                      {formatPossessive(titleize(user.username))}
-                    </PrimitiveText>
-                    <div className="grid grid-cols-2 gap-4 text-sm mb-6">
-                      <div className="border border-border p-4">
-                        <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-1">
-                          Items
-                        </PrimitiveText>
-                        <PrimitiveText as="p" variant="stat" font="serif">
-                          {user.clothing_items_count.toLocaleString()}
-                        </PrimitiveText>
-                      </div>
-                      <div className="border border-border p-4">
-                        <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-1">
-                          Style
-                        </PrimitiveText>
-                        <PrimitiveText as="p" variant="stat" font="serif">
-                          {preferredStyle ?? "N/A"}
-                        </PrimitiveText>
-                      </div>
-                    </div>
-                    <div className="flex items-center justify-between text-sm">
-                      <PrimitiveText as="span" variant="bodySm">
-                        Open details
+                    <div className="flex w-full flex-col items-start text-left">
+                      <PrimitiveText as="p" variant="overline" tone="muted" className="mb-4">
+                        Closet Owner
                       </PrimitiveText>
-                      <ChevronRight className="w-4 h-4" />
+                      <PrimitiveText
+                        as="h2"
+                        variant="title"
+                        font="serif"
+                        className="mb-2 w-full break-words"
+                      >
+                        {titleize(user.username)}
+                      </PrimitiveText>
+                      <PrimitiveText
+                        as="p"
+                        tone="muted"
+                        className="mb-6 w-full break-words"
+                      >
+                        {formatPossessive(titleize(user.username))}
+                      </PrimitiveText>
+                      <div className="mb-6 grid w-full grid-cols-2 gap-4 text-sm">
+                        <div className="border border-border p-4">
+                          <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-1">
+                            Items
+                          </PrimitiveText>
+                          <PrimitiveText as="p" variant="stat" font="serif">
+                            {user.clothing_items_count.toLocaleString()}
+                          </PrimitiveText>
+                        </div>
+                        <div className="border border-border p-4">
+                          <PrimitiveText as="p" variant="bodySm" tone="muted" className="mb-1">
+                            Style
+                          </PrimitiveText>
+                          <PrimitiveText as="p" variant="stat" font="serif">
+                            {preferredStyle ?? "N/A"}
+                          </PrimitiveText>
+                        </div>
+                      </div>
+                      <div className="flex w-full items-center justify-between text-sm">
+                        <PrimitiveText as="span" variant="bodySm">
+                          Open details
+                        </PrimitiveText>
+                        <ChevronRight className="h-4 w-4" />
+                      </div>
                     </div>
                   </MotionPrimitiveButton>
                 );

--- a/front-end/src/app/lib/closet.ts
+++ b/front-end/src/app/lib/closet.ts
@@ -58,6 +58,19 @@ export interface ClothingItem {
 
 export interface User extends UserSummary {
   clothing_items: ClothingItem[];
+  clothing_items_count: number;
+}
+
+export interface PaginationMeta {
+  page: number;
+  per_page: number;
+  total_pages: number;
+  total_count: number;
+}
+
+export interface UsersPage {
+  users: User[];
+  meta: PaginationMeta;
 }
 
 export interface OutfitDetection {
@@ -400,9 +413,31 @@ export async function logoutSession() {
   });
 }
 
-export async function fetchUsers(signal?: AbortSignal) {
-  const users = await requestJson<User[]>(`${API_BASE_URL}/users`, { signal });
-  return users.map(normalizeUserPayload);
+export interface FetchUsersParams {
+  page?: number;
+  perPage?: number;
+}
+
+export async function fetchUsers(
+  params: FetchUsersParams = {},
+  signal?: AbortSignal,
+): Promise<UsersPage> {
+  const query = new URLSearchParams();
+  if (params.page) {
+    query.set("page", String(params.page));
+  }
+  if (params.perPage) {
+    query.set("per_page", String(params.perPage));
+  }
+
+  const querystring = query.toString();
+  const url = `${API_BASE_URL}/users${querystring ? `?${querystring}` : ""}`;
+  const response = await requestJson<UsersPage>(url, { signal });
+
+  return {
+    users: response.users.map(normalizeUserPayload),
+    meta: response.meta,
+  };
 }
 
 export async function fetchUser(id: number, signal?: AbortSignal) {
@@ -675,9 +710,17 @@ function normalizeMetadataSuggestionPayload(
 }
 
 function normalizeUserPayload(user: User): User {
+  const clothing_items = (user.clothing_items ?? []).map(normalizeClothingItemPayload);
+  const rawCount = (user as User & { clothing_items_count?: unknown }).clothing_items_count;
+  const clothing_items_count =
+    typeof rawCount === "number" && Number.isFinite(rawCount)
+      ? rawCount
+      : clothing_items.length;
+
   return {
     ...user,
-    clothing_items: (user.clothing_items ?? []).map(normalizeClothingItemPayload),
+    clothing_items,
+    clothing_items_count,
   };
 }
 


### PR DESCRIPTION
## Summary
- Added Kaminari-backed pagination to `GET /users` (24/page, max 100) returning a `{ users, meta }` envelope. The index payload now ships a `clothing_items_count` field instead of each user's full `clothing_items` array; per-user `GET /users/:id` still includes the full array.
- Wired the existing shadcn `Pagination` primitive into the admin users directory with Prev/Next/numbered controls, a "Showing X–Y of N" footer, and a polished empty-state when there are no users.
- Fixed user-card layout (was inheriting `PrimitiveButton`'s `inline-flex items-center whitespace-nowrap` and overflowing horizontally) — content now stacks vertically with wrapping titles.
- Expanded `db/seeds.rb` to a development-scale dataset (~1,050 users, ~5,200 clothing items, ~2,100 outfits with linked items) using bulk `insert_all` so pagination and large-list perf are visible locally.
- Docs: updated `CHANGELOG.md` (Unreleased), `back-end/README.md` (Kaminari + pagination contract + new seed shape), `front-end/README.md`, and `PROJECT_INDEX.md`.

Addresses the rubric item: _"Application is designed for sustained use with large datasets (1000+ users, 1000+ records)… Pagination is implemented where needed."_

## Test plan
- [ ] `cd back-end && bin/rails db:reset` — should print `Users: 1050 / Clothing items: 5200 / Outfits: 2100`.
- [ ] `./start.sh` from repo root and sign in as an admin.
- [ ] Visit `/users`:
  - [ ] Header shows total count (e.g. "1,051 users").
  - [ ] 24 user cards render per page, each card stacks vertically (overline, name, possessive, Items/Style stats, "Open details ›").
  - [ ] Footer shows "Showing X–Y of N".
  - [ ] Pagination bar shows `Prev 1 2 3 … 44 Next`.
  - [ ] Clicking page numbers loads the next slice instantly; URL is unchanged (state is local).
  - [ ] `Previous` on page 1 and `Next` on the last page are greyed out and inert.
  - [ ] Clicking a card opens the user's detail page.
- [ ] `cd back-end && bin/rails test test/integration/users_flow_test.rb` — all 10 tests green (includes the new pagination assertion).
- [ ] Non-admin user hitting `/users` still gets the access-restricted state (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)