### PR TITLE
Add legal disclaimers and privacy pages (#54)

### DIFF
--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -28,6 +28,10 @@ import {
   PrimitiveSelectValue,
 } from "./components/primitives/PrimitiveSelect";
 import { PrimitiveText } from "./components/primitives/PrimitiveText";
+import { AboutPage } from "./components/info/AboutPage";
+import { HomeFooterLinks } from "./components/info/HomeFooterLinks";
+import { PrivacyPage } from "./components/info/PrivacyPage";
+import { TermsPage } from "./components/info/TermsPage";
 import { AccessRestrictedState } from "./components/shared/AccessRestrictedState";
 import { Input } from "./components/ui/input";
 import {
@@ -408,9 +412,16 @@ export default function App() {
               <PrimitiveText as="p" variant="bodySm">{homeMessage.text}</PrimitiveText>
             </div>
           ) : null}
+          <HomeFooterLinks className="mt-12" />
         </motion.div>
       </section>
     );
+  } else if (route.kind === "about") {
+    pageContent = <AboutPage />;
+  } else if (route.kind === "privacy") {
+    pageContent = <PrivacyPage />;
+  } else if (route.kind === "terms") {
+    pageContent = <TermsPage />;
   } else if (route.kind === "not-found") {
     pageContent = (
       <div className="max-w-3xl mx-auto px-6 py-16">
@@ -814,11 +825,11 @@ export default function App() {
       ) : null}
 
       <footer className="mt-12 border-t border-border">
-        <div className="mx-auto flex max-w-7xl flex-col gap-2 px-6 py-5 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-          <PrimitiveText as="p" variant="bodySm">
+        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+          <PrimitiveText as="p" variant="bodySm" tone="muted">
             Curating closets and serving looks, one hanger at a time.
           </PrimitiveText>
-          <PrimitiveText as="p" variant="bodySm">Pressed, polished, and ready for the runway.</PrimitiveText>
+          <HomeFooterLinks />
         </div>
       </footer>
     </div>

--- a/front-end/src/app/components/info/AboutPage.tsx
+++ b/front-end/src/app/components/info/AboutPage.tsx
@@ -1,0 +1,44 @@
+import { PrimitiveText } from "../primitives/PrimitiveText";
+import { InfoPageLayout } from "./InfoPageLayout";
+import { InfoSection } from "./InfoSection";
+import { PROJECT_NAME, REPOSITORY_URL, TEAM_MEMBERS } from "../../lib/siteContent";
+
+export function AboutPage() {
+  return (
+    <InfoPageLayout title="About us">
+      <InfoSection heading="What is Curated Closet?">
+        <PrimitiveText as="p" tone="muted">
+          {PROJECT_NAME} helps you catalog clothing, build outfits, and use AI-assisted tools to
+          organize photos and metadata. It is a course project built for Northwestern&apos;s CS
+          Software Studio.
+        </PrimitiveText>
+      </InfoSection>
+
+      <InfoSection heading="Team">
+        <ul className="list-disc space-y-2 pl-5">
+          {TEAM_MEMBERS.map((name) => (
+            <li key={name}>
+              <PrimitiveText as="span" tone="muted">
+                {name}
+              </PrimitiveText>
+            </li>
+          ))}
+        </ul>
+      </InfoSection>
+
+      <InfoSection heading="Source code">
+        <PrimitiveText as="p" tone="muted">
+          The project repository is available on GitHub:{" "}
+          <a
+            href={REPOSITORY_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground underline underline-offset-4 hover:text-foreground/80"
+          >
+            {REPOSITORY_URL.replace("https://github.com/", "")}
+          </a>
+        </PrimitiveText>
+      </InfoSection>
+    </InfoPageLayout>
+  );
+}

--- a/front-end/src/app/components/info/HomeFooterLinks.tsx
+++ b/front-end/src/app/components/info/HomeFooterLinks.tsx
@@ -1,0 +1,66 @@
+import { PrimitiveText } from "../primitives/PrimitiveText";
+import { REPOSITORY_URL } from "../../lib/siteContent";
+import { navigateTo } from "../../lib/routes";
+
+interface HomeFooterLinksProps {
+  className?: string;
+}
+
+function FooterLink({
+  children,
+  onClick,
+  href,
+  external,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  href?: string;
+  external?: boolean;
+}) {
+  const className =
+    "text-muted-foreground underline-offset-4 hover:text-foreground hover:underline transition-colors";
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target={external ? "_blank" : undefined}
+        rel={external ? "noopener noreferrer" : undefined}
+        className={className}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <button type="button" onClick={onClick} className={className}>
+      {children}
+    </button>
+  );
+}
+
+export function HomeFooterLinks({ className = "" }: HomeFooterLinksProps) {
+  return (
+    <nav
+      aria-label="Legal and project links"
+      className={`flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm ${className}`}
+    >
+      <FooterLink onClick={() => navigateTo("/about")}>About us</FooterLink>
+      <PrimitiveText as="span" variant="bodySm" tone="muted" aria-hidden>
+        ·
+      </PrimitiveText>
+      <FooterLink onClick={() => navigateTo("/privacy")}>Privacy</FooterLink>
+      <PrimitiveText as="span" variant="bodySm" tone="muted" aria-hidden>
+        ·
+      </PrimitiveText>
+      <FooterLink onClick={() => navigateTo("/terms")}>Terms</FooterLink>
+      <PrimitiveText as="span" variant="bodySm" tone="muted" aria-hidden>
+        ·
+      </PrimitiveText>
+      <FooterLink href={REPOSITORY_URL} external>
+        Repository
+      </FooterLink>
+    </nav>
+  );
+}

--- a/front-end/src/app/components/info/InfoPageLayout.tsx
+++ b/front-end/src/app/components/info/InfoPageLayout.tsx
@@ -1,0 +1,31 @@
+import { ArrowLeft } from "lucide-react";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
+import { PrimitiveText } from "../primitives/PrimitiveText";
+import { navigateTo } from "../../lib/routes";
+
+interface InfoPageLayoutProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export function InfoPageLayout({ title, children }: InfoPageLayoutProps) {
+  return (
+    <article className="mx-auto max-w-3xl px-6 py-12">
+      <PrimitiveButton
+        onClick={() => navigateTo("/")}
+        variant="ghost"
+        size="sm"
+        className="mb-8 -ml-2"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back home
+      </PrimitiveButton>
+
+      <PrimitiveText as="h1" variant="display" font="serif" className="mb-8">
+        {title}
+      </PrimitiveText>
+
+      <div className="space-y-6">{children}</div>
+    </article>
+  );
+}

--- a/front-end/src/app/components/info/InfoSection.tsx
+++ b/front-end/src/app/components/info/InfoSection.tsx
@@ -1,0 +1,17 @@
+import { PrimitiveText } from "../primitives/PrimitiveText";
+
+interface InfoSectionProps {
+  heading: string;
+  children: React.ReactNode;
+}
+
+export function InfoSection({ heading, children }: InfoSectionProps) {
+  return (
+    <section className="space-y-3">
+      <PrimitiveText as="h2" variant="title" font="serif">
+        {heading}
+      </PrimitiveText>
+      <div className="space-y-3">{children}</div>
+    </section>
+  );
+}

--- a/front-end/src/app/components/info/PrivacyPage.tsx
+++ b/front-end/src/app/components/info/PrivacyPage.tsx
@@ -1,0 +1,68 @@
+import { PrimitiveText } from "../primitives/PrimitiveText";
+import { DELETION_CONTACT, PROJECT_NAME, REPOSITORY_URL } from "../../lib/siteContent";
+import { InfoPageLayout } from "./InfoPageLayout";
+import { InfoSection } from "./InfoSection";
+
+export function PrivacyPage() {
+  return (
+    <InfoPageLayout title="Privacy">
+      <PrimitiveText as="p" tone="muted" className="mb-2">
+        Last updated: May 2026. This summary describes how {PROJECT_NAME} handles information
+        beyond what Google provides for sign-in.
+      </PrimitiveText>
+
+      <InfoSection heading="What we collect">
+        <PrimitiveText as="p" tone="muted">
+          When you sign in with Google, we store your Google account identifier, email address,
+          display name, profile image URL, and an internal username. We also store a session cookie
+          so you stay signed in.
+        </PrimitiveText>
+        <PrimitiveText as="p" tone="muted">
+          When you use the closet, we store clothing item details you enter or generate (such as
+          name, size, brand, tags, and dates), photos you upload, AI-cleaned versions of those
+          photos, and saved outfits (names, notes, tags, and links to your items).
+        </PrimitiveText>
+        <PrimitiveText as="p" tone="muted">
+          If you use outfit-photo import, we store the uploaded photo, detection results, and related
+          AI metadata. Image and text processing may be sent to third-party AI providers configured
+          for the deployment (for example OpenRouter).
+        </PrimitiveText>
+      </InfoSection>
+
+      <InfoSection heading="How we use it">
+        <PrimitiveText as="p" tone="muted">
+          We use this information to operate the app: authenticate you, display and search your
+          closet, save outfits, run optional AI features, and administer the service. We do not sell
+          your personal data.
+        </PrimitiveText>
+      </InfoSection>
+
+      <InfoSection heading="Where it is stored">
+        <PrimitiveText as="p" tone="muted">
+          Data is stored in the application database and, for uploaded images, in file storage used
+          by the hosting environment (local disk in development; cloud storage in production when
+          configured).
+        </PrimitiveText>
+      </InfoSection>
+
+      <InfoSection heading="How to request deletion">
+        <PrimitiveText as="p" tone="muted">
+          You may delete individual clothing items and outfits in the app. To remove your entire
+          account and associated data, {DELETION_CONTACT} Include the email address tied to your
+          Google sign-in so we can locate your account.
+        </PrimitiveText>
+        <PrimitiveText as="p" tone="muted">
+          Repository for requests:{" "}
+          <a
+            href={REPOSITORY_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground underline underline-offset-4 hover:text-foreground/80"
+          >
+            GitHub project
+          </a>
+        </PrimitiveText>
+      </InfoSection>
+    </InfoPageLayout>
+  );
+}

--- a/front-end/src/app/components/info/TermsPage.tsx
+++ b/front-end/src/app/components/info/TermsPage.tsx
@@ -1,0 +1,50 @@
+import { PrimitiveText } from "../primitives/PrimitiveText";
+import { PROJECT_NAME } from "../../lib/siteContent";
+import { InfoPageLayout } from "./InfoPageLayout";
+import { InfoSection } from "./InfoSection";
+
+export function TermsPage() {
+  return (
+    <InfoPageLayout title="Terms & disclaimers">
+      <InfoSection heading="Educational use">
+        <PrimitiveText as="p" tone="muted">
+          {PROJECT_NAME} is provided as a student software-studio project for learning and
+          demonstration. It is not a commercial product and may change or be taken offline without
+          notice.
+        </PrimitiveText>
+      </InfoSection>
+
+      <InfoSection heading="No warranty">
+        <PrimitiveText as="p" tone="muted">
+          The app is provided &quot;as is&quot; without warranties of any kind. We do not guarantee
+          uninterrupted service, accuracy of AI-generated labels or images, or fitness for any
+          particular purpose.
+        </PrimitiveText>
+      </InfoSection>
+
+      <InfoSection heading="Your content">
+        <PrimitiveText as="p" tone="muted">
+          You are responsible for photos and information you upload. Do not upload content you do
+          not have rights to use. If you export listing text for third-party marketplaces, you are
+          responsible for complying with those platforms&apos; policies and applicable laws.
+        </PrimitiveText>
+      </InfoSection>
+
+      <InfoSection heading="Third-party services">
+        <PrimitiveText as="p" tone="muted">
+          Sign-in is handled by Google. Optional AI and hosting services are subject to their own
+          terms. Use of those features implies acceptance of their respective policies where
+          applicable.
+        </PrimitiveText>
+      </InfoSection>
+
+      <InfoSection heading="Limitation of liability">
+        <PrimitiveText as="p" tone="muted">
+          To the fullest extent permitted by law, the project team is not liable for any damages
+          arising from use of this application, including loss of data, incorrect AI output, or
+          issues with external resale or social platforms.
+        </PrimitiveText>
+      </InfoSection>
+    </InfoPageLayout>
+  );
+}

--- a/front-end/src/app/lib/routes.ts
+++ b/front-end/src/app/lib/routes.ts
@@ -36,6 +36,18 @@ interface NotFoundRouteState {
   kind: "not-found";
 }
 
+interface AboutRouteState {
+  kind: "about";
+}
+
+interface PrivacyRouteState {
+  kind: "privacy";
+}
+
+interface TermsRouteState {
+  kind: "terms";
+}
+
 export type AppRoute =
   | HomeRouteState
   | ClosetRouteState
@@ -44,7 +56,14 @@ export type AppRoute =
   | UserRouteState
   | NewItemRouteState
   | OutfitsRouteState
+  | AboutRouteState
+  | PrivacyRouteState
+  | TermsRouteState
   | NotFoundRouteState;
+
+export function isPublicInfoRoute(route: AppRoute) {
+  return route.kind === "about" || route.kind === "privacy" || route.kind === "terms";
+}
 
 export function isClosetRoute(route: AppRoute) {
   return route.kind === "closet" || route.kind === "item" || route.kind === "new-item";
@@ -59,7 +78,7 @@ export function isUsersRoute(route: AppRoute) {
 }
 
 export function isProtectedRoute(route: AppRoute) {
-  return route.kind !== "home" && route.kind !== "not-found";
+  return route.kind !== "home" && route.kind !== "not-found" && !isPublicInfoRoute(route);
 }
 
 export function authErrorMessage(code: string | null) {
@@ -116,6 +135,18 @@ export function getRouteFromLocation(
 
   if (itemMatch) {
     return { kind: "item", itemId: Number(itemMatch[1]) };
+  }
+
+  if (normalizedPath === "/about") {
+    return { kind: "about" };
+  }
+
+  if (normalizedPath === "/privacy") {
+    return { kind: "privacy" };
+  }
+
+  if (normalizedPath === "/terms") {
+    return { kind: "terms" };
   }
 
   if (normalizedPath === "/") {

--- a/front-end/src/app/lib/siteContent.ts
+++ b/front-end/src/app/lib/siteContent.ts
@@ -1,0 +1,16 @@
+export const REPOSITORY_URL =
+  import.meta.env.VITE_REPOSITORY_URL ??
+  "https://github.com/NU-CS-Software-Studio-Spring-26/project-closet-organizer";
+
+export const PROJECT_NAME = "Curated Closet";
+
+export const TEAM_MEMBERS = [
+  "Annabel Goldman",
+  "Adedamola Adejumobi",
+  "David Gerchik",
+  "Kailyn Mohammed",
+  "Reem Khalid",
+] as const;
+
+export const DELETION_CONTACT =
+  "Open an issue on our GitHub repository or contact a project maintainer listed on the About page.";


### PR DESCRIPTION
## Summary
- Adds public **About**, **Privacy**, and **Terms** pages
- Adds home-page and site-footer links: About us, Privacy, Terms, Repository
- Privacy page describes what we collect beyond Google sign-in, how it is used, and how to request deletion

Closes #54

## Test plan
- [ ] Open http://127.0.0.1:5173 and confirm links appear below sign-in
- [ ] Visit `/about`, `/privacy`, and `/terms` while logged out
- [ ] Confirm **Repository** opens the GitHub repo in a new tab
- [ ] Sign in and confirm closet still works

Made with [Cursor](https://cursor.com)