### PR TITLE
UI polish and AI loading states

### DIFF
--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useDeferredValue, useEffect, useState } from "react";
 import { motion } from "motion/react";
-import { ArrowLeft, ArrowRight, Search, Users } from "lucide-react";
+import { Search } from "lucide-react";
 import { AddItemMenu } from "./components/AddItemMenu";
 import { ClothingCard } from "./components/ClothingCard";
 import { CreateItemPage } from "./components/CreateItemPage";
@@ -29,9 +29,13 @@ import {
 } from "./components/primitives/PrimitiveSelect";
 import { PrimitiveText } from "./components/primitives/PrimitiveText";
 import { AccessRestrictedState } from "./components/shared/AccessRestrictedState";
+import { ClosetEmptyState } from "./components/shared/ClosetEmptyState";
+import { HomeLanding } from "./components/shared/HomeLanding";
+import { NotFoundPage } from "./components/shared/NotFoundPage";
+import { SiteFooter } from "./components/shared/SiteFooter";
+import { SiteHeader } from "./components/shared/SiteHeader";
 import { Input } from "./components/ui/input";
 import {
-  beginGoogleSignIn,
   ClothingItem,
   fetchCurrentUser,
   formatPossessive,
@@ -326,24 +330,6 @@ export default function App() {
     navigateTo("/");
   }
 
-  const globalAction = user ? (
-    <PrimitiveButton
-      onClick={() => void handleLogout()}
-      variant="outline"
-    >
-      <Users className="h-4 w-4" />
-      Sign Out
-    </PrimitiveButton>
-  ) : (
-    <PrimitiveButton
-      onClick={() => beginGoogleSignIn()}
-      variant="outline"
-    >
-      Sign In
-      <ArrowRight className="h-4 w-4" />
-    </PrimitiveButton>
-  );
-
   const shouldRenderStandaloneAuthPage = !user && (route.kind === "home" || isLoggedOutProtectedRoute);
 
   let pageContent;
@@ -353,86 +339,9 @@ export default function App() {
   }
 
   if ((!user && route.kind === "home") || (isLoggedOutProtectedRoute && !isLoading)) {
-    pageContent = (
-      <section className="flex flex-1 items-center justify-center px-6 py-16">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          className="max-w-2xl text-center"
-        >
-          <img
-            src="/brand-mark.png"
-            alt="Curated Closet logo"
-            className="mx-auto mb-8 h-32 w-auto object-contain sm:h-40"
-          />
-          <PrimitiveText
-            as="h1"
-            variant="display"
-            font="serif"
-            className="mb-6"
-            style={{
-              fontSize: "clamp(3rem, 8vw, 5.5rem)",
-              lineHeight: "0.95",
-            }}
-          >
-            Curated Closet
-          </PrimitiveText>
-          <PrimitiveText
-            as="p"
-            variant="title"
-            tone="muted"
-            className="mb-10"
-            style={{ lineHeight: "1.7" }}
-          >
-            Find your fit, faster.
-          </PrimitiveText>
-          <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
-            <PrimitiveButton
-              onClick={() => beginGoogleSignIn()}
-              variant="outline"
-              className="h-auto px-6 py-3"
-            >
-              Sign in with Google
-              <ArrowRight className="h-4 w-4" />
-            </PrimitiveButton>
-          </div>
-          {homeMessage ? (
-            <div
-              className={`mt-6 px-4 py-3 text-sm ${
-                homeMessage.kind === "success"
-                  ? "border border-emerald-300/40 bg-emerald-50 text-emerald-900"
-                  : "border border-destructive/30 bg-destructive/10 text-destructive"
-              }`}
-            >
-              <PrimitiveText as="p" variant="bodySm">{homeMessage.text}</PrimitiveText>
-            </div>
-          ) : null}
-        </motion.div>
-      </section>
-    );
+    pageContent = <HomeLanding homeMessage={homeMessage} />;
   } else if (route.kind === "not-found") {
-    pageContent = (
-      <div className="max-w-3xl mx-auto px-6 py-16">
-        <div className="border border-border bg-card p-8">
-          <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
-            Page Not Found
-          </PrimitiveText>
-          <PrimitiveText as="h1" variant="display" font="serif" className="mb-3">
-            We couldn&apos;t find that page.
-          </PrimitiveText>
-          <PrimitiveText as="p" tone="muted" className="mb-6">
-            The link may be out of date, or the page may have been moved.
-          </PrimitiveText>
-          <PrimitiveButton
-            onClick={() => navigateTo(user ? "/closet" : "/")}
-            variant="outline"
-          >
-            {user ? "Back to closet" : "Back home"}
-          </PrimitiveButton>
-        </div>
-      </div>
-    );
+    pageContent = <NotFoundPage signedIn={Boolean(user)} />;
   } else if (isUnauthorizedAdminRoute) {
     pageContent = (
       <AccessRestrictedState
@@ -714,19 +623,22 @@ export default function App() {
                   />
                 ))}
               </div>
+            ) : user ? (
+              <ClosetEmptyState
+                hasActiveFilters={hasActiveFilters}
+                onSelectImage={
+                  hasActiveFilters
+                    ? undefined
+                    : () => navigateTo(`/items/new?userId=${user.id}&mode=image`)
+                }
+                onSelectManual={
+                  hasActiveFilters
+                    ? undefined
+                    : () => navigateTo(`/items/new?userId=${user.id}&mode=manual`)
+                }
+              />
             ) : (
-              <div className="border border-dashed border-border p-10 text-center">
-                <PrimitiveText as="p" variant="display" font="serif" className="mb-3">
-                  {user ? "No matching items found" : "No closet data found"}
-                </PrimitiveText>
-                <PrimitiveText as="p" tone="muted">
-                  {user
-                    ? hasActiveFilters
-                      ? "Try a different tag, search phrase, or sort."
-                      : "Add a new item to start building out this closet."
-                    : "Sign in with Google to load your closet."}
-                </PrimitiveText>
-              </div>
+              <ClosetEmptyState hasActiveFilters={false} />
             )}
           </>
         )}
@@ -735,7 +647,20 @@ export default function App() {
   }
 
   if (shouldRenderStandaloneAuthPage) {
-    return <div className="flex min-h-screen flex-col bg-background">{pageContent}</div>;
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:border focus:border-foreground focus:bg-background focus:px-4 focus:py-2"
+        >
+          Skip to main content
+        </a>
+        <main id="main-content" className="flex flex-1 flex-col">
+          {pageContent}
+        </main>
+        <SiteFooter />
+      </div>
+    );
   }
 
   return (
@@ -747,53 +672,7 @@ export default function App() {
         Skip to main content
       </a>
 
-      <header className="border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85">
-        <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-6 py-5">
-          <PrimitiveButton
-            onClick={() => navigateTo(user ? "/closet" : "/")}
-            variant="outline"
-            className={`${
-              user && isClosetRoute(route)
-                ? "border-foreground bg-foreground text-background"
-                : "border-border hover:border-foreground"
-            }`}
-          >
-            {user ? "Closet" : "Home"}
-          </PrimitiveButton>
-
-          <div className="flex items-center gap-3">
-            {user ? (
-              <nav className="flex items-center gap-2">
-                <PrimitiveButton
-                  onClick={() => navigateTo("/outfits")}
-                  variant="outline"
-                  className={`${
-                    isOutfitRoute(route)
-                      ? "border-foreground bg-foreground text-background"
-                      : "border-border text-foreground hover:border-foreground"
-                  }`}
-                >
-                  My Outfits
-                </PrimitiveButton>
-                {user.admin ? (
-                  <PrimitiveButton
-                    onClick={() => navigateTo("/users")}
-                    variant="outline"
-                    className={`${
-                      isUsersRoute(route)
-                        ? "border-foreground bg-foreground text-background"
-                        : "border-border text-foreground hover:border-foreground"
-                    }`}
-                  >
-                    Users
-                  </PrimitiveButton>
-                ) : null}
-              </nav>
-            ) : null}
-            {globalAction}
-          </div>
-        </div>
-      </header>
+      <SiteHeader route={route} user={user} onSignOut={() => void handleLogout()} />
 
       <main id="main-content" className={`flex-1 ${route.kind === "home" ? "flex" : ""}`}>
         {pageContent}
@@ -813,14 +692,7 @@ export default function App() {
         </motion.div>
       ) : null}
 
-      <footer className="mt-12 border-t border-border">
-        <div className="mx-auto flex max-w-7xl flex-col gap-2 px-6 py-5 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-          <PrimitiveText as="p" variant="bodySm">
-            Curating closets and serving looks, one hanger at a time.
-          </PrimitiveText>
-          <PrimitiveText as="p" variant="bodySm">Pressed, polished, and ready for the runway.</PrimitiveText>
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/front-end/src/app/components/AiCleanImageButton.tsx
+++ b/front-end/src/app/components/AiCleanImageButton.tsx
@@ -1,4 +1,4 @@
-import { Sparkles } from "lucide-react";
+import { LoaderCircle, Sparkles } from "lucide-react";
 import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
@@ -19,24 +19,31 @@ export function AiCleanImageButton({
   label = "AI clean PNG",
   onClick,
 }: AiCleanImageButtonProps) {
-  const buttonLabel = isLoading ? "Cleaning..." : label;
+  const buttonLabel = label;
   const isDisabled = disabled || isLoading;
+  const Icon = isLoading ? LoaderCircle : Sparkles;
+
+  const button = (
+    <PrimitiveButton
+      type="button"
+      onClick={onClick}
+      disabled={isDisabled}
+      variant="outline"
+      className={className}
+      aria-busy={isLoading}
+      aria-label={buttonLabel}
+    >
+      <Icon className={`h-4 w-4 shrink-0 ${isLoading ? "animate-spin" : ""}`} />
+      {!iconOnly ? buttonLabel : null}
+    </PrimitiveButton>
+  );
 
   if (iconOnly) {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
           <span className={`inline-flex ${isDisabled ? "cursor-default" : "cursor-pointer"}`}>
-            <PrimitiveButton
-              type="button"
-              onClick={onClick}
-              disabled={isDisabled}
-              variant="outline"
-              className={className}
-              aria-label={buttonLabel}
-            >
-              <Sparkles className="w-4 h-4" />
-            </PrimitiveButton>
+            {button}
           </span>
         </TooltipTrigger>
         <TooltipContent sideOffset={8}>{buttonLabel}</TooltipContent>
@@ -44,16 +51,5 @@ export function AiCleanImageButton({
     );
   }
 
-  return (
-    <PrimitiveButton
-      type="button"
-      onClick={onClick}
-      disabled={isDisabled}
-      variant="outline"
-      className={className}
-    >
-      <Sparkles className="w-4 h-4" />
-      {buttonLabel}
-    </PrimitiveButton>
-  );
+  return button;
 }

--- a/front-end/src/app/components/AiMetadataAutofillButton.tsx
+++ b/front-end/src/app/components/AiMetadataAutofillButton.tsx
@@ -1,4 +1,4 @@
-import { Sparkles } from "lucide-react";
+import { LoaderCircle, Sparkles } from "lucide-react";
 import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
@@ -17,8 +17,9 @@ export function AiMetadataAutofillButton({
   label = "AI autofill item details",
   onClick,
 }: AiMetadataAutofillButtonProps) {
-  const buttonLabel = isLoading ? "Autofilling..." : label;
+  const buttonLabel = isLoading ? "Autofilling details..." : label;
   const isDisabled = disabled || isLoading;
+  const Icon = isLoading ? LoaderCircle : Sparkles;
 
   return (
     <Tooltip>
@@ -30,13 +31,14 @@ export function AiMetadataAutofillButton({
             disabled={isDisabled}
             variant="outline"
             className={className}
+            aria-busy={isLoading}
             aria-label={buttonLabel}
           >
-            <Sparkles className="w-4 h-4" />
+            <Icon className={`h-4 w-4 shrink-0 ${isLoading ? "animate-spin" : ""}`} />
           </PrimitiveButton>
         </span>
       </TooltipTrigger>
-      <TooltipContent sideOffset={8}>{label}</TooltipContent>
+      <TooltipContent sideOffset={8}>{buttonLabel}</TooltipContent>
     </Tooltip>
   );
 }

--- a/front-end/src/app/components/CreateItemPage.tsx
+++ b/front-end/src/app/components/CreateItemPage.tsx
@@ -570,6 +570,7 @@ export function CreateItemPage({
           strokeWidth={1.1}
         />
       }
+      isPreviewProcessing={isCleaningUploadedPhoto}
       previewTopAction={
         <AiCleanImageButton
           className="size-11 border border-white/75 shadow-sm bg-white/70 p-0 backdrop-blur-sm hover:bg-white/85"
@@ -625,6 +626,7 @@ export function CreateItemPage({
       >
         <div className="grid gap-5 sm:grid-cols-2">
           <ItemMetadataFields
+            isAutofilling={isAutofillingMetadata}
             onChange={setFormValues}
             showAutofillButton={false}
             values={formValues}

--- a/front-end/src/app/components/ItemDetailPage.tsx
+++ b/front-end/src/app/components/ItemDetailPage.tsx
@@ -286,6 +286,7 @@ export function ItemDetailPage({
           strokeWidth={1.1}
         />
       }
+      isPreviewProcessing={isCleaningImage}
       previewTopAction={
         <AiCleanImageButton
           className="size-11 border border-white/75 shadow-sm bg-white/70 p-0 backdrop-blur-sm hover:bg-white/85"
@@ -351,6 +352,7 @@ export function ItemDetailPage({
       >
         <div className="grid gap-5 sm:grid-cols-2">
           <ItemMetadataFields
+            isAutofilling={isAutofillingMetadata}
             onChange={setFormValues}
             showAutofillButton={false}
             values={formValues}

--- a/front-end/src/app/components/ItemEditorWorkspace.tsx
+++ b/front-end/src/app/components/ItemEditorWorkspace.tsx
@@ -19,6 +19,7 @@ interface ItemEditorWorkspaceProps {
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   previewAriaLabel?: string;
   previewBackgroundDecoration?: ReactNode;
+  isPreviewProcessing?: boolean;
   previewLabel: string;
   previewPrimaryDetail: string;
   previewSecondaryDetail?: string | null;
@@ -40,6 +41,7 @@ export function ItemEditorWorkspace({
   onSubmit,
   previewAriaLabel,
   previewBackgroundDecoration,
+  isPreviewProcessing,
   previewLabel,
   previewPrimaryDetail,
   previewSecondaryDetail,
@@ -86,6 +88,7 @@ export function ItemEditorWorkspace({
           onPreviewEdit={onPreviewEdit}
           previewAriaLabel={previewAriaLabel}
           previewBackgroundDecoration={previewBackgroundDecoration}
+          isPreviewProcessing={isPreviewProcessing}
           previewTopAction={previewTopAction}
           previewLabel={previewLabel}
           previewPrimaryDetail={previewPrimaryDetail}

--- a/front-end/src/app/components/ItemHeroPreview.tsx
+++ b/front-end/src/app/components/ItemHeroPreview.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useState } from "react";
 import { motion } from "motion/react";
-import { Trash2, Upload } from "lucide-react";
+import { LoaderCircle, Trash2, Upload } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -22,6 +22,7 @@ interface ItemHeroPreviewProps {
   previewAriaLabel?: string;
   previewBackgroundDecoration?: ReactNode;
   previewMedia?: ReactNode;
+  isPreviewProcessing?: boolean;
   previewTopAction?: ReactNode;
   secondaryDetail?: string | null;
   title: string;
@@ -39,6 +40,7 @@ export function ItemHeroPreview({
   previewAriaLabel,
   previewBackgroundDecoration,
   previewMedia,
+  isPreviewProcessing = false,
   previewTopAction,
   secondaryDetail,
   title,
@@ -100,6 +102,18 @@ export function ItemHeroPreview({
             onKeyDown={(event) => event.stopPropagation()}
           >
             {previewTopAction}
+          </div>
+        ) : null}
+
+        {isPreviewProcessing ? (
+          <div
+            className="absolute inset-0 z-40 flex items-center justify-center bg-neutral-950/55 backdrop-blur-[2px]"
+            role="status"
+            aria-live="polite"
+            aria-busy="true"
+            aria-label="Cleaning image"
+          >
+            <LoaderCircle className="h-8 w-8 animate-spin text-white" />
           </div>
         ) : null}
 

--- a/front-end/src/app/components/ItemMetadataFields.tsx
+++ b/front-end/src/app/components/ItemMetadataFields.tsx
@@ -7,6 +7,7 @@ import {
   parseTagInput,
 } from "../lib/closet";
 import { AiMetadataAutofillButton } from "./AiMetadataAutofillButton";
+import { AiActionLoadingNotice } from "./shared/AiActionLoadingNotice";
 import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 
@@ -100,6 +101,13 @@ export function ItemMetadataFields({
             onClick={onRequestAutofill}
           />
         </div>
+      ) : null}
+
+      {isAutofilling ? (
+        <AiActionLoadingNotice
+          className="sm:col-span-2"
+          message="Autofilling type, name, brand, and tags..."
+        />
       ) : null}
 
       <label className="space-y-2 sm:col-span-2">

--- a/front-end/src/app/components/UploadWorkspace.tsx
+++ b/front-end/src/app/components/UploadWorkspace.tsx
@@ -12,6 +12,7 @@ interface UploadWorkspaceProps {
   previewAriaLabel?: string;
   previewBackgroundDecoration?: ReactNode;
   previewMedia?: ReactNode;
+  isPreviewProcessing?: boolean;
   previewTopAction?: ReactNode;
   previewLabel: string;
   previewPrimaryDetail: string;
@@ -29,6 +30,7 @@ export function UploadWorkspace({
   previewAriaLabel,
   previewBackgroundDecoration,
   previewMedia,
+  isPreviewProcessing,
   previewTopAction,
   previewLabel,
   previewPrimaryDetail,
@@ -48,6 +50,7 @@ export function UploadWorkspace({
           previewAriaLabel={previewAriaLabel}
           previewBackgroundDecoration={previewBackgroundDecoration}
           previewMedia={previewMedia}
+          isPreviewProcessing={isPreviewProcessing}
           previewTopAction={previewTopAction}
           primaryDetail={previewPrimaryDetail}
           secondaryDetail={previewSecondaryDetail}

--- a/front-end/src/app/components/create-item/CreateItemImageMode.tsx
+++ b/front-end/src/app/components/create-item/CreateItemImageMode.tsx
@@ -17,6 +17,7 @@ import { ItemMetadataFields } from "../ItemMetadataFields";
 import { ItemMetadataPanel } from "../ItemMetadataPanel";
 import { PrimitiveButton } from "../primitives/PrimitiveButton";
 import { PrimitiveConfirmationDialog } from "../primitives/PrimitiveConfirmationDialog";
+import { AiActionLoadingNotice } from "../shared/AiActionLoadingNotice";
 import { UploadWorkspace } from "../UploadWorkspace";
 import { DetectionPreviewImage } from "./DetectionPreview";
 import { DetectionThumbnailStrip } from "./DetectionThumbnailStrip";
@@ -207,6 +208,7 @@ export function CreateItemImageMode({
       <UploadWorkspace
         expandedPreview={expandedPreview}
         imageUrl={previewDetection?.cleaned_image_url ?? (isSourceFocused ? sourceImageUrl : null)}
+        isPreviewProcessing={focusedIsCleaning}
         onPreviewClick={() => inputRef.current?.click()}
         onPreviewClear={selectedFileName ? onClearImageSelection : undefined}
         onPreviewEdit={selectedFileName ? () => inputRef.current?.click() : undefined}
@@ -342,15 +344,7 @@ export function CreateItemImageMode({
 
         {shouldShowMetadataLoadingState && (!detailsDetection || !detailsDraftReady) ? (
           <div className="border border-border bg-card p-5">
-            <div className="flex items-start gap-3">
-              <LoaderCircle className="mt-0.5 h-5 w-5 animate-spin text-muted-foreground" />
-              <div className="space-y-1">
-                <p className="font-medium">Preparing detected item details...</p>
-                <p className="text-sm text-muted-foreground">
-                  We&apos;re filling in the detected type, name, brand, and tags now.
-                </p>
-              </div>
-            </div>
+            <AiActionLoadingNotice message="Preparing detected item details. Type, name, brand, and tags may update in a moment." />
           </div>
         ) : null}
 
@@ -368,16 +362,8 @@ export function CreateItemImageMode({
             category={focusedDraft.category || detailsDetection.category}
             title={focusedSuggestedName}
           >
-            {shouldShowMetadataLoadingState ? (
-              <div className="flex items-start gap-3 border border-border/70 bg-muted/35 px-3 py-3 text-sm">
-                <LoaderCircle className="mt-0.5 h-4 w-4 animate-spin text-muted-foreground" />
-                <div className="space-y-0.5">
-                  <p className="font-medium">Preparing detected item details...</p>
-                  <p className="text-muted-foreground">
-                    Type, name, brand, and tags may update in a moment.
-                  </p>
-                </div>
-              </div>
+            {isPreparingDetectedMetadata ? (
+              <AiActionLoadingNotice message="Preparing detected item details. Type, name, brand, and tags may update in a moment." />
             ) : null}
 
             {focusedCleanError && (

--- a/front-end/src/app/components/shared/AccessRestrictedState.tsx
+++ b/front-end/src/app/components/shared/AccessRestrictedState.tsx
@@ -1,6 +1,6 @@
-import { ArrowLeft } from "lucide-react";
+import { ShieldAlert } from "lucide-react";
 import { PrimitiveButton } from "../primitives/PrimitiveButton";
-import { PrimitiveText } from "../primitives/PrimitiveText";
+import { VisualStatePanel } from "./VisualStatePanel";
 
 interface AccessRestrictedStateProps {
   backLabel: string;
@@ -14,34 +14,18 @@ export function AccessRestrictedState({
   onBack,
 }: AccessRestrictedStateProps) {
   return (
-    <div className="min-h-screen bg-background">
-      <div className="max-w-3xl mx-auto px-6 py-16">
-        <PrimitiveButton
-          onClick={onBack}
-          variant="ghost"
-          className="mb-8 h-auto px-0 py-0 text-muted-foreground"
-        >
-          <ArrowLeft className="w-4 h-4" />
+    <div className="mx-auto max-w-4xl px-6 py-16">
+      <VisualStatePanel
+        icon={ShieldAlert}
+        tone="destructive"
+        overline="403"
+        title="You are not authorized to view this page."
+        description={message}
+      >
+        <PrimitiveButton onClick={onBack} variant="outline">
           {backLabel}
         </PrimitiveButton>
-
-        <div className="border border-destructive/20 bg-destructive/5 p-8">
-          <PrimitiveText
-            as="p"
-            variant="overline"
-            tone="destructiveSoft"
-            className="mb-3"
-          >
-            Access Restricted
-          </PrimitiveText>
-          <PrimitiveText as="h1" variant="display" font="serif" className="mb-3">
-            You are not authorized to view this page.
-          </PrimitiveText>
-          <PrimitiveText as="p" tone="muted">
-            {message}
-          </PrimitiveText>
-        </div>
-      </div>
+      </VisualStatePanel>
     </div>
   );
 }

--- a/front-end/src/app/components/shared/AiActionLoadingNotice.tsx
+++ b/front-end/src/app/components/shared/AiActionLoadingNotice.tsx
@@ -1,0 +1,23 @@
+import { LoaderCircle } from "lucide-react";
+import { PrimitiveText } from "../primitives/PrimitiveText";
+
+interface AiActionLoadingNoticeProps {
+  message: string;
+  className?: string;
+}
+
+export function AiActionLoadingNotice({ message, className = "" }: AiActionLoadingNoticeProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      className={`flex items-start gap-3 border border-border/70 bg-muted/35 px-3 py-3 ${className}`}
+    >
+      <LoaderCircle className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+      <PrimitiveText as="p" variant="bodySm">
+        {message}
+      </PrimitiveText>
+    </div>
+  );
+}

--- a/front-end/src/app/components/shared/ClosetEmptyState.tsx
+++ b/front-end/src/app/components/shared/ClosetEmptyState.tsx
@@ -1,0 +1,39 @@
+import { SearchX, Shirt } from "lucide-react";
+import { AddItemMenu } from "../AddItemMenu";
+import { VisualStatePanel } from "./VisualStatePanel";
+
+interface ClosetEmptyStateProps {
+  hasActiveFilters: boolean;
+  onSelectImage?: () => void;
+  onSelectManual?: () => void;
+}
+
+export function ClosetEmptyState({
+  hasActiveFilters,
+  onSelectImage,
+  onSelectManual,
+}: ClosetEmptyStateProps) {
+  if (hasActiveFilters) {
+    return (
+      <VisualStatePanel
+        icon={SearchX}
+        overline="No results"
+        title="No matching items found"
+        description="Try a different tag, search phrase, or sort—or clear your filters to see the full closet."
+      />
+    );
+  }
+
+  return (
+    <VisualStatePanel
+      icon={Shirt}
+      overline="Your closet"
+      title="Start with your first piece"
+      description="Add a photo or enter details manually to build a closet you can search, filter, and turn into outfits."
+    >
+      {onSelectImage && onSelectManual ? (
+        <AddItemMenu onSelectImage={onSelectImage} onSelectManual={onSelectManual} />
+      ) : null}
+    </VisualStatePanel>
+  );
+}

--- a/front-end/src/app/components/shared/HomeLanding.tsx
+++ b/front-end/src/app/components/shared/HomeLanding.tsx
@@ -1,0 +1,71 @@
+import { motion } from "motion/react";
+import { ArrowRight } from "lucide-react";
+import { beginGoogleSignIn } from "../../lib/closet";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
+import { PrimitiveText } from "../primitives/PrimitiveText";
+
+interface HomeLandingProps {
+  homeMessage: { kind: "error" | "success"; text: string } | null;
+}
+
+export function HomeLanding({ homeMessage }: HomeLandingProps) {
+  return (
+    <section className="flex flex-1 items-center justify-center px-6 py-16">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className="max-w-2xl text-center"
+      >
+        <img
+          src="/brand-mark.png"
+          alt="Curated Closet logo"
+          className="mx-auto mb-8 h-32 w-auto object-contain sm:h-40"
+        />
+        <PrimitiveText
+          as="h1"
+          variant="display"
+          font="serif"
+          className="mb-6"
+          style={{
+            fontSize: "clamp(3rem, 8vw, 5.5rem)",
+            lineHeight: "0.95",
+          }}
+        >
+          Curated Closet
+        </PrimitiveText>
+        <PrimitiveText
+          as="p"
+          variant="title"
+          tone="muted"
+          className="mb-10"
+          style={{ lineHeight: "1.7" }}
+        >
+          Find your fit, faster.
+        </PrimitiveText>
+        <PrimitiveButton
+          onClick={() => beginGoogleSignIn()}
+          variant="outline"
+          className="h-auto px-6 py-3"
+        >
+          Sign in with Google
+          <ArrowRight className="h-4 w-4" />
+        </PrimitiveButton>
+
+        {homeMessage ? (
+          <motion.div
+            className={`mt-6 px-4 py-3 text-sm ${
+              homeMessage.kind === "success"
+                ? "border border-emerald-300/40 bg-emerald-50 text-emerald-900"
+                : "border border-destructive/30 bg-destructive/10 text-destructive"
+            }`}
+          >
+            <PrimitiveText as="p" variant="bodySm">
+              {homeMessage.text}
+            </PrimitiveText>
+          </motion.div>
+        ) : null}
+      </motion.div>
+    </section>
+  );
+}

--- a/front-end/src/app/components/shared/NotFoundPage.tsx
+++ b/front-end/src/app/components/shared/NotFoundPage.tsx
@@ -1,0 +1,28 @@
+import { MapPinOff } from "lucide-react";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
+import { navigateTo } from "../../lib/routes";
+import { VisualStatePanel } from "./VisualStatePanel";
+
+interface NotFoundPageProps {
+  signedIn: boolean;
+}
+
+export function NotFoundPage({ signedIn }: NotFoundPageProps) {
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-16">
+      <VisualStatePanel
+        icon={MapPinOff}
+        overline="404"
+        title="We couldn't find that page."
+        description="The link may be out of date, or the page may have been moved. Use the button below to return to a known page."
+      >
+        <PrimitiveButton
+          onClick={() => navigateTo(signedIn ? "/closet" : "/")}
+          variant="outline"
+        >
+          {signedIn ? "Back to closet" : "Back home"}
+        </PrimitiveButton>
+      </VisualStatePanel>
+    </div>
+  );
+}

--- a/front-end/src/app/components/shared/SiteFooter.tsx
+++ b/front-end/src/app/components/shared/SiteFooter.tsx
@@ -1,0 +1,13 @@
+import { PrimitiveText } from "../primitives/PrimitiveText";
+
+export function SiteFooter() {
+  return (
+    <footer className="mt-auto border-t border-border">
+      <div className="mx-auto max-w-7xl px-6 py-5">
+        <PrimitiveText as="p" variant="bodySm" tone="muted">
+          Curating closets and serving looks, one hanger at a time.
+        </PrimitiveText>
+      </div>
+    </footer>
+  );
+}

--- a/front-end/src/app/components/shared/SiteHeader.tsx
+++ b/front-end/src/app/components/shared/SiteHeader.tsx
@@ -1,0 +1,79 @@
+import { ArrowRight, Users } from "lucide-react";
+import type { AppRoute } from "../../lib/routes";
+import { isClosetRoute, isOutfitRoute, isUsersRoute, navigateTo } from "../../lib/routes";
+import type { User } from "../../lib/closet";
+import { beginGoogleSignIn } from "../../lib/closet";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
+
+interface SiteHeaderProps {
+  route: AppRoute;
+  user: User | null;
+  onSignOut: () => void;
+}
+
+export function SiteHeader({ route, user, onSignOut }: SiteHeaderProps) {
+  const globalAction = user ? (
+    <PrimitiveButton onClick={onSignOut} variant="outline">
+      <Users className="h-4 w-4" />
+      Sign Out
+    </PrimitiveButton>
+  ) : (
+    <PrimitiveButton onClick={() => beginGoogleSignIn()} variant="outline">
+      Sign In
+      <ArrowRight className="h-4 w-4" />
+    </PrimitiveButton>
+  );
+
+  return (
+    <header className="border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-6 py-5">
+        <div className="flex items-center gap-4">
+          <PrimitiveButton
+            onClick={() => navigateTo(user ? "/closet" : "/")}
+            variant="outline"
+            className={
+              user && isClosetRoute(route)
+                ? "border-foreground bg-foreground text-background"
+                : "border-border hover:border-foreground"
+            }
+          >
+            {user ? "Closet" : "Home"}
+          </PrimitiveButton>
+          <img src="/brand-mark.png" alt="" className="hidden h-9 w-auto opacity-90 sm:block" aria-hidden />
+        </div>
+
+        <div className="flex items-center gap-3">
+          {user ? (
+            <nav className="flex items-center gap-2" aria-label="Main">
+              <PrimitiveButton
+                onClick={() => navigateTo("/outfits")}
+                variant="outline"
+                className={
+                  isOutfitRoute(route)
+                    ? "border-foreground bg-foreground text-background"
+                    : "border-border text-foreground hover:border-foreground"
+                }
+              >
+                My Outfits
+              </PrimitiveButton>
+              {user.admin ? (
+                <PrimitiveButton
+                  onClick={() => navigateTo("/users")}
+                  variant="outline"
+                  className={
+                    isUsersRoute(route)
+                      ? "border-foreground bg-foreground text-background"
+                      : "border-border text-foreground hover:border-foreground"
+                  }
+                >
+                  Users
+                </PrimitiveButton>
+              ) : null}
+            </nav>
+          ) : null}
+          {globalAction}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/front-end/src/app/components/shared/VisualStatePanel.tsx
+++ b/front-end/src/app/components/shared/VisualStatePanel.tsx
@@ -1,0 +1,66 @@
+import type { LucideIcon } from "lucide-react";
+import { motion } from "motion/react";
+import { PrimitiveText } from "../primitives/PrimitiveText";
+
+interface VisualStatePanelProps {
+  overline: string;
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  tone?: "default" | "destructive";
+  children?: React.ReactNode;
+}
+
+export function VisualStatePanel({
+  overline,
+  title,
+  description,
+  icon: Icon,
+  tone = "default",
+  children,
+}: VisualStatePanelProps) {
+  const isDestructive = tone === "destructive";
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.45 }}
+      className={`overflow-hidden border bg-card ${
+        isDestructive ? "border-destructive/25" : "border-border"
+      }`}
+    >
+      <div className="grid md:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)]">
+        <div
+          className={`flex min-h-[10rem] items-center justify-center ${
+            isDestructive ? "bg-destructive/5" : "bg-muted/40"
+          }`}
+        >
+          <Icon
+            className={`h-16 w-16 ${isDestructive ? "text-destructive/70" : "text-muted-foreground"}`}
+            strokeWidth={1.25}
+            aria-hidden
+          />
+        </div>
+
+        <div className={`p-8 md:p-10 ${isDestructive ? "bg-destructive/5" : ""}`}>
+          <PrimitiveText
+            as="p"
+            variant="overline"
+            tone={isDestructive ? "destructiveSoft" : "muted"}
+            className="mb-3"
+          >
+            {overline}
+          </PrimitiveText>
+          <PrimitiveText as="h1" variant="display" font="serif" className="mb-3">
+            {title}
+          </PrimitiveText>
+          <PrimitiveText as="p" tone="muted" className="mb-6 max-w-prose">
+            {description}
+          </PrimitiveText>
+          {children ? <div className="flex flex-wrap gap-3">{children}</div> : null}
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/wiki.md
+++ b/wiki.md
@@ -13,3 +13,21 @@ Closet information is often spread across memory, notes, screenshots, and shoppi
 - manage closet photos and cleaner presentation images
 - reuse closet items in saved outfits
 - extract visible pieces from an outfit photo and convert them into closet records
+
+## Image and visual sources
+
+When the team adds stock photography, use royalty-free sources such as:
+
+- [Unsplash](https://unsplash.com/)
+- [Pixabay](https://pixabay.com/)
+- [RGBStock](https://www.rgbstock.com/images/)
+
+Record the file path, photographer, and source URL in this section.
+
+Icons use [Lucide](https://lucide.dev/) (MIT). The app logo is `front-end/public/brand-mark.png`. UI primitives include [shadcn/ui](https://ui.shadcn.com/) (MIT); see `front-end/ATTRIBUTIONS.md`.
+
+## Visual improvements (Kailyn Mohammed)
+
+1. **Custom error and empty states** — shared `VisualStatePanel` with Lucide icons for 404, 403 (access restricted), and closet empty states. For **new users with an empty closet** (no items and no active filters), the closet page now shows **“Start with your first piece”** with an **Add Item** menu (detect from image or add manually). Previously, an empty closet used the same **“No matching items found”** copy as a filtered search with no results. **“No matching items found”** is reserved for when filters or search are active but nothing matches.
+2. **Shared header and footer** — `SiteHeader` and `SiteFooter` components used across authenticated pages and the signed-out landing flow.
+3. **Home landing** — refactored signed-out home into `HomeLanding` (brand mark, sign-in, consistent layout).


### PR DESCRIPTION
## Summary

- Add shared site chrome (`SiteHeader`, `SiteFooter`, `HomeLanding`) and consistent empty/error states (`ClosetEmptyState`, `NotFoundPage`, `AccessRestrictedState`, `VisualStatePanel`).
- Improve empty-closet copy and wire the empty state to the same add-item actions as the header.
- Add loading feedback for AI clean (preview overlay + button spinners) and AI autofill (shared `AiActionLoadingNotice` and button spinners) across edit item, manual add item, and outfit detection flows.

## Test plan

- [ ] Open an empty closet and verify empty state copy and add-item actions work.
- [ ] Edit an item: trigger AI clean PNG and confirm spinner overlay on preview; trigger AI autofill and confirm loading notice.
- [ ] Add item (manual): same AI clean/autofill loading checks.
- [ ] Add item from outfit photo: select a detection, run AI clean and autofill, confirm loading states on preview and metadata form.

Made with [Cursor](https://cursor.com)