### PR TITLE
Feat/outfit flatlay builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y imagemagick libvips
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Rebuilt the saved-outfit collage editor on `react-moveable`, replacing the custom drag/resize/rotate control math with library-backed corner handles, top rotation control, and a cleaner DOM-target interaction model.
+- Simplified the edit-modal layers panel into a slim left-side thumbnail strip so the collage preview keeps more vertical room and better matches the outfit canvas proportions.
+- Corrected the outfit edit collage editor so the resize outline now follows the actual visible photo bounds with corner-only resize controls, and fixed the edit modal's breakpoint width cap so the preview workspace can expand properly on larger screens.
+- Added persisted outfit-collage layout data on `outfit_items` so saved looks can store per-piece position, size, rotation, and layer order for edit-modal collage editing.
+- Expanded the outfit edit modal so the collage preview now appears at full size in the left panel while editing saved looks.
+- Removed the outfit cart footer helper copy so the selected-items tray has more room to show outfit pieces before creation.
+- Redesigned the closet-to-outfit flow into a cart-style builder: adding an item now updates a closet-page cart button with a notification badge, the cart opens a right-side review tray with inline outfit name, tag, and notes fields, and creating an outfit from that tray now ends with a success popup that links back to Closet or into My Outfits.
+- Removed the standalone create-outfit form from the `/outfits` page so new outfits now enter the system through the closet cart, while `/outfits` stays focused on browsing and editing saved looks.
+- Refreshed the `/outfits` gallery into larger, photo-led saved-look cards so outfit pieces are previewed visually first instead of appearing primarily as text rows.
+- Replaced the inline `/outfits` edit section with a focused edit modal that keeps the outfit preview visible on the left while title, tags, and notes are edited on the right.
 - Added project-wide text input length limits enforced at every layer: a shared `InputLengthPolicy` module (Rails) with model validations on `User`, `ClothingItem`, and `Outfit`; a new migration that mirrors the caps as database `limit:` constraints and marks load-bearing identifier columns (`users.username`, `users.provider`, `users.uid`, `clothing_items.name`, `outfits.name`) as `null: false` with backfill for legacy blank rows; and a matching `inputLengthPolicy.ts` on the frontend that exposes `maxLength` on the item, outfit name, notes, and tag inputs.
 - Documented the SQL injection posture: every query uses ActiveRecord's parameterized API or strong params; the only raw SQL fragment (`where("lower(email) = ?", ...)`) uses bound placeholders so user-supplied values are never interpolated into SQL.
 - Added Kaminari-backed pagination to the admin users index (`GET /users?page=&per_page=`) returning a `{ users, meta }` envelope, surfaced a paginated grid with Previous/Next/page controls on the admin users directory, and switched the directory cards to a `clothing_items_count` field so per-user item arrays no longer ship with the index payload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,15 @@
 ## Unreleased
 
 - Added a configurable post-removal sharpen step to AI-cleaned transparent PNG outputs so item edges render a bit crisper after background removal.
+- Added automated saved-outfit collage contract coverage for backend round-trips and frontend layout math so saved cards, the editor preview, and resize-ratio fallback stay aligned.
 - Routed local Active Storage image URLs through the Vite dev server so outfit collage previews can measure image bounds without cross-origin console errors while developing at `127.0.0.1:5173`.
 - Slimmed the `/outfits` saved-look cards so the collage stage reads closer to the editor preview proportions instead of feeling visually too wide.
 - Updated the `/outfits` gallery to use three saved-look cards per row on larger screens so the slimmer cards fill the page more naturally.
 - Reworked the mobile Edit Outfit modal so the collage preview stays dominant, with the layers strip pinned to the left of the canvas instead of stacking above it.
 - Changed the mobile Edit Outfit modal to scroll as a single vertical flow, with the outfit editor taking the first screen and the detail form living below it.
 - Fixed the `/outfits` collage renderer so local Active Storage images load again from the Rails origin without tripping browser CORS enforcement on the visible `<img>` elements.
-- Added more visible outfit-collage debug logging around image-bounds measurement, layout normalization, editor-open state, and save-time layout payloads so renderer drift between the editor and saved view is easier to trace locally.
-- Switched outfit collage rendering to measure each image's visible alpha bounds and use those same content bounds in both the saved view and editor, plus dev-only logging for source-vs-rendered layout drift.
-- Unified the saved-look and edit-modal outfit previews onto the same normalized renderer path in `OutfitCollageCanvas`, and added dev-only mismatch logging so any future drift between edited and saved composition is easier to catch.
+- Switched outfit collage rendering to measure each image's visible alpha bounds and use those same content bounds in both the saved view and editor.
+- Unified the saved-look and edit-modal outfit previews onto the same normalized renderer path in `OutfitCollageCanvas` so edited and saved composition stay in lockstep.
 - Moved the saved-look and edit-modal outfit previews back onto a single shared stage-aspect contract in `OutfitCollageCanvas` so saved outfits render the same composition you see while editing.
 - Reduced the saved-look card preview size on `/outfits` and capped the edit-modal collage preview by viewport height so the full outfit stays visible without preview-pane scrolling.
 - Relaxed the outfit collage editor bounds so pieces can now sit partially off-canvas, allowing looks where up to half of an item extends beyond the white outfit stage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added a configurable post-removal sharpen step to AI-cleaned transparent PNG outputs so item edges render a bit crisper after background removal.
 - Added automated saved-outfit collage contract coverage for backend round-trips and frontend layout math so saved cards, the editor preview, and resize-ratio fallback stay aligned.
+- Updated CI to install ImageMagick alongside `libvips` so the MiniMagick-backed clean-image background removal path and its tests run in GitHub Actions.
 - Routed local Active Storage image URLs through the Vite dev server so outfit collage previews can measure image bounds without cross-origin console errors while developing at `127.0.0.1:5173`.
 - Slimmed the `/outfits` saved-look cards so the collage stage reads closer to the editor preview proportions instead of feeling visually too wide.
 - Updated the `/outfits` gallery to use three saved-look cards per row on larger screens so the slimmer cards fill the page more naturally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- Added a configurable post-removal sharpen step to AI-cleaned transparent PNG outputs so item edges render a bit crisper after background removal.
+- Routed local Active Storage image URLs through the Vite dev server so outfit collage previews can measure image bounds without cross-origin console errors while developing at `127.0.0.1:5173`.
+- Slimmed the `/outfits` saved-look cards so the collage stage reads closer to the editor preview proportions instead of feeling visually too wide.
+- Updated the `/outfits` gallery to use three saved-look cards per row on larger screens so the slimmer cards fill the page more naturally.
+- Reworked the mobile Edit Outfit modal so the collage preview stays dominant, with the layers strip pinned to the left of the canvas instead of stacking above it.
+- Changed the mobile Edit Outfit modal to scroll as a single vertical flow, with the outfit editor taking the first screen and the detail form living below it.
+- Fixed the `/outfits` collage renderer so local Active Storage images load again from the Rails origin without tripping browser CORS enforcement on the visible `<img>` elements.
+- Added more visible outfit-collage debug logging around image-bounds measurement, layout normalization, editor-open state, and save-time layout payloads so renderer drift between the editor and saved view is easier to trace locally.
+- Switched outfit collage rendering to measure each image's visible alpha bounds and use those same content bounds in both the saved view and editor, plus dev-only logging for source-vs-rendered layout drift.
+- Unified the saved-look and edit-modal outfit previews onto the same normalized renderer path in `OutfitCollageCanvas`, and added dev-only mismatch logging so any future drift between edited and saved composition is easier to catch.
+- Moved the saved-look and edit-modal outfit previews back onto a single shared stage-aspect contract in `OutfitCollageCanvas` so saved outfits render the same composition you see while editing.
+- Reduced the saved-look card preview size on `/outfits` and capped the edit-modal collage preview by viewport height so the full outfit stays visible without preview-pane scrolling.
+- Relaxed the outfit collage editor bounds so pieces can now sit partially off-canvas, allowing looks where up to half of an item extends beyond the white outfit stage.
+- Added a background-removal post-process to the AI clean-image pipeline so generated item photos are attached as transparent PNG cutouts instead of keeping the white studio backdrop.
 - Rebuilt the saved-outfit collage editor on `react-moveable`, replacing the custom drag/resize/rotate control math with library-backed corner handles, top rotation control, and a cleaner DOM-target interaction model.
 - Simplified the edit-modal layers panel into a slim left-side thumbnail strip so the collage preview keeps more vertical room and better matches the outfit canvas proportions.
 - Corrected the outfit edit collage editor so the resize outline now follows the actual visible photo bounds with corner-only resize controls, and fixed the edit modal's breakpoint width cap so the preview workspace can expand properly on larger screens.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,8 +100,6 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
-    bcrypt_pbkdf (1.1.2-arm64-darwin)
-    bcrypt_pbkdf (1.1.2-x86_64-darwin)
     better_html (2.2.0)
       actionview (>= 7.0)
       activesupport (>= 7.0)

--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -1,6 +1,6 @@
 # Project Structure Index
 
-Last updated: 2026-05-17
+Last updated: 2026-05-21
 
 This file is intentionally concise and focused on repository structure.
 For the product purpose and problem statement, see `wiki.md`.
@@ -25,8 +25,8 @@ project-closet-organizer/
 ## Backend (`back-end`)
 
 - `app/models`: `user`, `clothing_item`, `outfit`, `outfit_item`, `outfit_upload`, and `outfit_detection`
-- `app/controllers`: auth/session handling, JSON CRUD controllers, upload flows, AI helper endpoints, and SPA fallback
-- `app/presenters`: API payload shaping for users, clothing items, outfits, uploads, and detections
+- `app/controllers`: auth/session handling, JSON CRUD controllers, outfit collage/layout-aware outfit updates, upload flows, AI helper endpoints, and SPA fallback
+- `app/presenters`: API payload shaping for users, clothing items, outfits, uploads, and detections, including saved outfit collage layout data
 - `app/services/`: OpenRouter detection, metadata suggestion, crop refinement, crop verification, image-cleaning logic, and shared tempfile/image-source helpers
 - `config/routes.rb`: API routes plus HTML fallback routes
 - `db/seeds.rb`: demo admin user plus large-scale dev seed (~1k users, ~5k items, ~2k outfits) for pagination/perf testing
@@ -36,10 +36,12 @@ project-closet-organizer/
 
 - `src/app/App.tsx`: route handling, auth-aware layout, and top-level page composition
 - `src/app/components/primitives/`: shared button, select, dropdown, and typography primitives that frontend work should reuse first
-- `src/app/components/`: routed pages, item editor flows, extracted create-item/restricted-state components, and supporting UI
+- `src/app/components/`: routed pages, the closet outfit-cart tray, item editor flows, extracted create-item/restricted-state components, and supporting UI
+- `src/app/components/OutfitCollageCanvas.tsx`: saved-outfit collage renderer plus the `react-moveable`-backed edit-modal move/resize/rotate/layers interactions and image content-bounds viewport handling
 - `src/app/lib/routes.ts`: route parsing, navigation helpers, and route guards
 - `src/app/lib/api.ts`: shared request/error helpers for frontend API calls
 - `src/app/lib/closet.ts`: shared types, formatting helpers, and feature-specific API helpers, including AI preview and metadata-suggestion requests
+- `src/app/lib/outfitCollage.ts`: shared default-layout and layer-order helpers for saved outfit collages
 - `src/app/lib/closetFilters.ts`: closet search, filter, and sort helpers
 - `src/app/lib/useItemPhotoState.ts`: shared photo upload and preview state management
 - `src/app/lib/usePageData.ts`: shared async page-loading hook

--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -1,6 +1,6 @@
 # Project Structure Index
 
-Last updated: 2026-05-21
+Last updated: 2026-05-22
 
 This file is intentionally concise and focused on repository structure.
 For the product purpose and problem statement, see `wiki.md`.
@@ -27,7 +27,7 @@ project-closet-organizer/
 - `app/models`: `user`, `clothing_item`, `outfit`, `outfit_item`, `outfit_upload`, and `outfit_detection`
 - `app/controllers`: auth/session handling, JSON CRUD controllers, outfit collage/layout-aware outfit updates, upload flows, AI helper endpoints, and SPA fallback
 - `app/presenters`: API payload shaping for users, clothing items, outfits, uploads, and detections, including saved outfit collage layout data
-- `app/services/`: OpenRouter detection, metadata suggestion, crop refinement, crop verification, image-cleaning logic, and shared tempfile/image-source helpers
+- `app/services/`: OpenRouter detection, metadata suggestion, crop refinement, crop verification, image-cleaning and background-removal logic, and shared tempfile/image-source helpers
 - `config/routes.rb`: API routes plus HTML fallback routes
 - `db/seeds.rb`: demo admin user plus large-scale dev seed (~1k users, ~5k items, ~2k outfits) for pagination/perf testing
 - `test/`: model, integration, and service tests
@@ -37,11 +37,13 @@ project-closet-organizer/
 - `src/app/App.tsx`: route handling, auth-aware layout, and top-level page composition
 - `src/app/components/primitives/`: shared button, select, dropdown, and typography primitives that frontend work should reuse first
 - `src/app/components/`: routed pages, the closet outfit-cart tray, item editor flows, extracted create-item/restricted-state components, and supporting UI
-- `src/app/components/OutfitCollageCanvas.tsx`: saved-outfit collage renderer plus the `react-moveable`-backed edit-modal move/resize/rotate/layers interactions and image content-bounds viewport handling
+- `src/app/components/OutfitCollageCanvas.tsx`: saved-outfit collage renderer plus the `react-moveable`-backed edit-modal move/resize/rotate interactions and the shared normalized-layout/stage-aspect contract used by both saved and editable outfit previews
+- `src/app/components/OutfitCollageLayersPanel.tsx`: focused layers sidebar for thumbnail selection plus pointer and keyboard-accessible layer reordering
 - `src/app/lib/routes.ts`: route parsing, navigation helpers, and route guards
 - `src/app/lib/api.ts`: shared request/error helpers for frontend API calls
 - `src/app/lib/closet.ts`: shared types, formatting helpers, and feature-specific API helpers, including AI preview and metadata-suggestion requests
 - `src/app/lib/outfitCollage.ts`: shared default-layout and layer-order helpers for saved outfit collages
+- `src/app/lib/outfitImageBounds.ts`: cached image-content-bounds measurement helpers for saved-outfit collage rendering and editing
 - `src/app/lib/closetFilters.ts`: closet search, filter, and sort helpers
 - `src/app/lib/useItemPhotoState.ts`: shared photo upload and preview state management
 - `src/app/lib/usePageData.ts`: shared async page-loading hook

--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -1,6 +1,6 @@
 # Project Structure Index
 
-Last updated: 2026-05-22
+Last updated: 2026-05-23
 
 This file is intentionally concise and focused on repository structure.
 For the product purpose and problem statement, see `wiki.md`.
@@ -43,11 +43,13 @@ project-closet-organizer/
 - `src/app/lib/api.ts`: shared request/error helpers for frontend API calls
 - `src/app/lib/closet.ts`: shared types, formatting helpers, and feature-specific API helpers, including AI preview and metadata-suggestion requests
 - `src/app/lib/outfitCollage.ts`: shared default-layout and layer-order helpers for saved outfit collages
+- `src/app/lib/outfitCollageRenderMath.ts`: shared stage-aspect normalization and resize-aspect helpers that keep saved cards and the editor preview on the same rendering contract
 - `src/app/lib/outfitImageBounds.ts`: cached image-content-bounds measurement helpers for saved-outfit collage rendering and editing
 - `src/app/lib/closetFilters.ts`: closet search, filter, and sort helpers
 - `src/app/lib/useItemPhotoState.ts`: shared photo upload and preview state management
 - `src/app/lib/usePageData.ts`: shared async page-loading hook
 - `src/app/lib/useOutfitDraftState.ts`: persisted outfit draft state management
+- `tests/`: frontend contract tests run with Node's built-in test runner
 - `src/styles/`: fonts, theme, and global styling
 
 ## CI

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Curated Closet is a monorepo with a Rails JSON API in `back-end/` and a React + 
 - Create, edit, delete, and photo-manage clothing items
 - Generate AI metadata suggestions for item type, name, brand, and tags
 - Generate cleaned catalog-style item images
-- Save outfits from owned closet items at `/outfits`
+- Build outfits from the closet cart and browse/edit saved outfits at `/outfits`
 - Upload an outfit photo, review detections, and convert detections into closet items
 - Restrict `/users` and `/users/:id` to admin users only
 - Show frontend not-found and unauthorized states instead of raw backend responses
@@ -53,6 +53,7 @@ Heroku deployment link:
 ## Current Code Organization
 
 - Frontend route parsing, closet filtering, shared API helpers, page-loading hooks, and outfit-draft persistence are split into focused modules under `front-end/src/app/lib/`.
+- Saved-outfit collage rendering and resize math are shared between the `/outfits` gallery and edit modal so the editor preview and saved card composition stay on the same contract.
 - Shared frontend control patterns live under `front-end/src/app/components/primitives/` and should be reused before introducing custom button, dropdown, select-trigger, or typography markup.
 - The add/edit item workflow is centered on `ItemEditorWorkspace.tsx`, `CreateItemPage.tsx`, `ItemDetailPage.tsx`, and extracted review components under `front-end/src/app/components/create-item/`.
 - Backend JSON response shaping lives in `back-end/app/presenters/api_payloads.rb`.
@@ -131,9 +132,11 @@ npm run dev
 ## Testing And CI
 
 - Rails tests run in GitHub Actions through `.github/workflows/ci.yml`
+- Frontend contract tests run through `cd front-end && npm test`
 - CI also runs `brakeman`, `bundler-audit`, and `rubocop`
 - Recent local verification:
   `npm run build`
+  `cd front-end && npm test`
   `bundle exec rails test`
   `bundle exec rubocop`
 

--- a/back-end/Gemfile.lock
+++ b/back-end/Gemfile.lock
@@ -100,8 +100,6 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
-    bcrypt_pbkdf (1.1.2-arm64-darwin)
-    bcrypt_pbkdf (1.1.2-x86_64-darwin)
     better_html (2.2.0)
       actionview (>= 7.0)
       activesupport (>= 7.0)

--- a/back-end/README.md
+++ b/back-end/README.md
@@ -22,7 +22,7 @@ Rails 8 JSON backend for Curated Closet.
 - admin-only user directory access
 - saved outfit CRUD with owned-item validation
 - outfit photo upload, detection persistence, crop refinement, and review support
-- AI-assisted image cleanup and metadata suggestion flows for clothing items and outfit detections
+- AI-assisted image cleanup and metadata suggestion flows for clothing items and outfit detections, including transparent-background post-processing on generated clean images
 - HTML fallback routes for the SPA frontend
 
 ## Local Setup
@@ -109,6 +109,8 @@ Notes:
   Handles temporary AI preview generation and metadata suggestions for uploaded but unsaved images
 - `app/services/openrouter_image_cleaner.rb`
   Calls OpenRouter image generation for cleaned item imagery
+- `app/services/clean_image_background_remover.rb`
+  Removes the white studio backdrop from generated clean images and produces the final transparent PNG attachment
 - `app/services/openrouter_metadata_suggester.rb`
   Calls OpenRouter structured vision responses for item metadata suggestions
 - `app/services/outfit_upload_analyzer.rb`
@@ -217,6 +219,8 @@ See [back-end/.env.example](./.env.example) for expected variables.
 - `OPENROUTER_API_KEY` is required for outfit detection, metadata suggestion, and image-cleaning features.
 - `OPENROUTER_MODEL` defaults to `openai/gpt-4.1-mini`.
 - `OPENROUTER_METADATA_MODEL` can override the metadata suggestion model independently.
+- `AI_CLEAN_BACKGROUND_FUZZ` optionally tunes how aggressively the clean-image post-process removes near-white edge background pixels. It defaults to `12%`.
+- `AI_CLEAN_SHARPEN` optionally adds a light sharpen pass after background removal to recover edge crispness in the final transparent PNG. It defaults to `0x0.8`.
 - `OUTFIT_CROP_CYCLE_LIMIT` controls refinement and verification retries.
 - Active Storage can be configured for S3-style storage through the provided AWS variables.
 

--- a/back-end/README.md
+++ b/back-end/README.md
@@ -95,6 +95,7 @@ Notes:
 - `ApplicationController` returns `404` JSON for missing records and `422` JSON for validation failures.
 - Text input length is capped at every layer: `app/models/concerns/input_length_policy.rb` exposes the limits (username 60, email 254, item name 120, brand 80, category 60, outfit name 120, notes 2_000, tag 40 chars × 30 per record); the `User`/`ClothingItem`/`Outfit` models validate against the same constants and surface friendly errors; the `AddInputLengthConstraints` migration enforces matching `limit:` and `null: false` constraints at the database. SQL injection is mitigated by ActiveRecord's parameterized queries — the only raw SQL fragment in the app (`where("lower(email) = ?", ...)` in `User`) uses bound placeholders.
 - `GET /users` is paginated via Kaminari. It accepts `page` and `per_page` query params (default 24, max 100) and returns `{ users: [...], meta: { page, per_page, total_pages, total_count } }`. The index payload omits each user's `clothing_items` array and only includes a `clothing_items_count` field; per-user `GET /users/:id` still returns the full items array.
+- Outfit payloads now preserve per-piece collage presentation through `outfit_items`: each embedded outfit item can include `outfit_item_id`, `layer_order`, and `collage_layout` (`x`, `y`, `width`, `height`, `rotation`) so the frontend can reopen and edit saved collages faithfully.
 
 ## Important Internal Files
 
@@ -165,6 +166,17 @@ Supported `size` enum values:
 - `notes`
 - `has_many :outfit_items`
 - `has_many :clothing_items, through: :outfit_items`
+
+### `OutfitItem`
+
+- `outfit_id`
+- `clothing_item_id`
+- `layer_order`
+- `collage_x`
+- `collage_y`
+- `collage_width`
+- `collage_height`
+- `collage_rotation`
 
 ### `OutfitUpload`
 

--- a/back-end/README.md
+++ b/back-end/README.md
@@ -95,7 +95,7 @@ Notes:
 - `ApplicationController` returns `404` JSON for missing records and `422` JSON for validation failures.
 - Text input length is capped at every layer: `app/models/concerns/input_length_policy.rb` exposes the limits (username 60, email 254, item name 120, brand 80, category 60, outfit name 120, notes 2_000, tag 40 chars × 30 per record); the `User`/`ClothingItem`/`Outfit` models validate against the same constants and surface friendly errors; the `AddInputLengthConstraints` migration enforces matching `limit:` and `null: false` constraints at the database. SQL injection is mitigated by ActiveRecord's parameterized queries — the only raw SQL fragment in the app (`where("lower(email) = ?", ...)` in `User`) uses bound placeholders.
 - `GET /users` is paginated via Kaminari. It accepts `page` and `per_page` query params (default 24, max 100) and returns `{ users: [...], meta: { page, per_page, total_pages, total_count } }`. The index payload omits each user's `clothing_items` array and only includes a `clothing_items_count` field; per-user `GET /users/:id` still returns the full items array.
-- Outfit payloads now preserve per-piece collage presentation through `outfit_items`: each embedded outfit item can include `outfit_item_id`, `layer_order`, and `collage_layout` (`x`, `y`, `width`, `height`, `rotation`) so the frontend can reopen and edit saved collages faithfully.
+- Outfit payloads now preserve per-piece collage presentation through `outfit_items`: each embedded outfit item can include `outfit_item_id`, `layer_order`, and `collage_layout` (`x`, `y`, `width`, `height`, `rotation`) so the frontend can reopen and edit saved collages faithfully. The outfit integration suite also covers the round-trip contract that the collage layout returned by `PATCH /outfits/:id` matches the subsequent `GET /outfits/:id` payload used by the saved gallery.
 
 ## Important Internal Files
 
@@ -218,6 +218,8 @@ See [back-end/.env.example](./.env.example) for expected variables.
 - `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` enable Google sign-in.
 - `OPENROUTER_API_KEY` is required for outfit detection, metadata suggestion, and image-cleaning features.
 - `OPENROUTER_MODEL` defaults to `openai/gpt-4.1-mini`.
+- `AI_CLEAN_BACKGROUND_FUZZ` optionally adjusts how aggressively edge-connected near-white pixels are removed from AI-cleaned images.
+- `AI_CLEAN_SHARPEN` optionally adjusts the sharpen pass that restores edge definition on the final transparent PNG.
 - `OPENROUTER_METADATA_MODEL` can override the metadata suggestion model independently.
 - `AI_CLEAN_BACKGROUND_FUZZ` optionally tunes how aggressively the clean-image post-process removes near-white edge background pixels. It defaults to `12%`.
 - `AI_CLEAN_SHARPEN` optionally adds a light sharpen pass after background removal to recover edge crispness in the final transparent PNG. It defaults to `0x0.8`.

--- a/back-end/README.md
+++ b/back-end/README.md
@@ -33,6 +33,8 @@ bin/rails db:prepare db:seed
 bin/dev
 ```
 
+Local image-cleaning flows and related tests also expect the ImageMagick CLI to be installed, because the transparent-background cleanup step currently runs through MiniMagick.
+
 Default local backend URL:
 
 ```text

--- a/back-end/app/controllers/outfits_controller.rb
+++ b/back-end/app/controllers/outfits_controller.rb
@@ -3,7 +3,7 @@ class OutfitsController < ApplicationController
   before_action :set_outfit, only: %i[ show update destroy ]
 
   def index
-    outfits = current_user.outfits.includes(:clothing_items).order(created_at: :desc)
+    outfits = current_user.outfits.includes(outfit_items: :clothing_item).order(created_at: :desc)
     render json: outfits.map { |outfit| payloads.outfit(outfit) }
   end
 
@@ -28,11 +28,17 @@ class OutfitsController < ApplicationController
   private
 
   def set_outfit
-    @outfit = current_user.outfits.includes(:clothing_items).find(params[:id])
+    @outfit = current_user.outfits.includes(outfit_items: :clothing_item).find(params[:id])
   end
 
   def outfit_params
-    params.require(:outfit).permit(:name, :notes, tags: [], item_ids: [])
+    params.require(:outfit).permit(
+      :name,
+      :notes,
+      tags: [],
+      item_ids: [],
+      item_layouts: %i[item_id x y width height rotation layer_order]
+    )
   end
 
   def outfit_attributes
@@ -42,6 +48,7 @@ class OutfitsController < ApplicationController
   def persist_outfit(outfit, status: :ok)
     outfit.assign_attributes(outfit_attributes)
     assign_items(outfit)
+    assign_item_layouts(outfit)
 
     if outfit.errors.empty? && outfit.save
       render json: payloads.outfit(outfit), status: status
@@ -62,5 +69,60 @@ class OutfitsController < ApplicationController
     end
 
     outfit.clothing_items = items
+    outfit.outfit_items.each do |outfit_item|
+      next unless (index = item_ids.index(outfit_item.clothing_item_id))
+
+      outfit_item.layer_order = index
+    end
+  end
+
+  def assign_item_layouts(outfit)
+    return unless outfit_params.key?(:item_layouts)
+
+    layouts = normalized_item_layouts
+    return if outfit.errors.any?
+
+    outfit_items_by_item_id = outfit.outfit_items.index_by(&:clothing_item_id)
+    item_ids_in_outfit = outfit_items_by_item_id.keys.sort
+    layout_item_ids = layouts.map { |layout| layout[:item_id] }.sort
+
+    if layout_item_ids != item_ids_in_outfit
+      outfit.errors.add(:item_layouts, "must match the outfit items")
+      return
+    end
+
+    layer_orders = layouts.map { |layout| layout[:layer_order] }
+    if layer_orders.uniq.length != layer_orders.length
+      outfit.errors.add(:item_layouts, "must use unique layer positions")
+      return
+    end
+
+    layouts.each do |layout|
+      outfit_item = outfit_items_by_item_id[layout[:item_id]]
+      outfit_item.assign_attributes(
+        collage_x: layout[:x],
+        collage_y: layout[:y],
+        collage_width: layout[:width],
+        collage_height: layout[:height],
+        collage_rotation: layout[:rotation],
+        layer_order: layout[:layer_order]
+      )
+    end
+  rescue ArgumentError, TypeError
+    outfit.errors.add(:item_layouts, "are invalid")
+  end
+
+  def normalized_item_layouts
+    Array(outfit_params[:item_layouts]).map do |layout|
+      {
+        item_id: Integer(layout[:item_id]),
+        x: Float(layout[:x]),
+        y: Float(layout[:y]),
+        width: Float(layout[:width]),
+        height: Float(layout[:height]),
+        rotation: Float(layout[:rotation] || 0),
+        layer_order: Integer(layout[:layer_order])
+      }
+    end
   end
 end

--- a/back-end/app/models/outfit.rb
+++ b/back-end/app/models/outfit.rb
@@ -1,6 +1,6 @@
 class Outfit < ApplicationRecord
   belongs_to :user
-  has_many :outfit_items, dependent: :destroy
+  has_many :outfit_items, -> { order(:layer_order, :id) }, dependent: :destroy
   has_many :clothing_items, through: :outfit_items
 
   validates :name, presence: true, length: { maximum: InputLengthPolicy::MAX_OUTFIT_NAME }

--- a/back-end/app/models/outfit.rb
+++ b/back-end/app/models/outfit.rb
@@ -1,6 +1,6 @@
 class Outfit < ApplicationRecord
   belongs_to :user
-  has_many :outfit_items, -> { order(:layer_order, :id) }, dependent: :destroy
+  has_many :outfit_items, -> { order(:layer_order, :id) }, dependent: :destroy, autosave: true
   has_many :clothing_items, through: :outfit_items
 
   validates :name, presence: true, length: { maximum: InputLengthPolicy::MAX_OUTFIT_NAME }

--- a/back-end/app/models/outfit_item.rb
+++ b/back-end/app/models/outfit_item.rb
@@ -1,4 +1,6 @@
 class OutfitItem < ApplicationRecord
+  MAX_OFF_CANVAS_VISIBLE_FRACTION = 0.5
+
   belongs_to :outfit
   belongs_to :clothing_item
 
@@ -45,16 +47,20 @@ class OutfitItem < ApplicationRecord
     return unless collage_layout_present?
     return if [ collage_x, collage_y, collage_width, collage_height ].any?(&:nil?)
 
-    unless collage_x.between?(0.0, 100.0) && collage_y.between?(0.0, 100.0)
-      errors.add(:base, "Collage layout origin must stay within the canvas")
-    end
-
     unless collage_width.positive? && collage_width <= 100.0 && collage_height.positive? && collage_height <= 100.0
       errors.add(:base, "Collage layout size must stay within the canvas")
+      return
     end
 
-    if collage_x + collage_width > 100.0 || collage_y + collage_height > 100.0
-      errors.add(:base, "Collage layout must stay within the canvas")
+    min_visible_width = collage_width * MAX_OFF_CANVAS_VISIBLE_FRACTION
+    min_visible_height = collage_height * MAX_OFF_CANVAS_VISIBLE_FRACTION
+    min_x = min_visible_width - collage_width
+    max_x = 100.0 - min_visible_width
+    min_y = min_visible_height - collage_height
+    max_y = 100.0 - min_visible_height
+
+    unless collage_x.between?(min_x, max_x) && collage_y.between?(min_y, max_y)
+      errors.add(:base, "At least half of each collage item must stay within the canvas")
     end
   end
 end

--- a/back-end/app/models/outfit_item.rb
+++ b/back-end/app/models/outfit_item.rb
@@ -3,7 +3,27 @@ class OutfitItem < ApplicationRecord
   belongs_to :clothing_item
 
   validates :clothing_item_id, uniqueness: { scope: :outfit_id }
+  validates :layer_order, numericality: { greater_than_or_equal_to: 0, only_integer: true }
   validate :clothing_item_must_belong_to_outfit_user
+  validate :collage_layout_must_be_complete
+  validate :collage_layout_must_be_in_bounds
+
+  def collage_layout_payload
+    return nil unless collage_layout_present?
+
+    {
+      x: collage_x,
+      y: collage_y,
+      width: collage_width,
+      height: collage_height,
+      rotation: collage_rotation,
+      layer_order: layer_order
+    }
+  end
+
+  def collage_layout_present?
+    [ collage_x, collage_y, collage_width, collage_height ].any?(&:present?)
+  end
 
   private
 
@@ -12,5 +32,29 @@ class OutfitItem < ApplicationRecord
     return if outfit.user_id == clothing_item.user_id
 
     errors.add(:clothing_item_id, "must belong to the same user as the outfit")
+  end
+
+  def collage_layout_must_be_complete
+    values = [ collage_x, collage_y, collage_width, collage_height ]
+    return if values.all?(&:nil?) || values.none?(&:nil?)
+
+    errors.add(:base, "Collage layout is incomplete")
+  end
+
+  def collage_layout_must_be_in_bounds
+    return unless collage_layout_present?
+    return if [ collage_x, collage_y, collage_width, collage_height ].any?(&:nil?)
+
+    unless collage_x.between?(0.0, 100.0) && collage_y.between?(0.0, 100.0)
+      errors.add(:base, "Collage layout origin must stay within the canvas")
+    end
+
+    unless collage_width.positive? && collage_width <= 100.0 && collage_height.positive? && collage_height <= 100.0
+      errors.add(:base, "Collage layout size must stay within the canvas")
+    end
+
+    if collage_x + collage_width > 100.0 || collage_y + collage_height > 100.0
+      errors.add(:base, "Collage layout must stay within the canvas")
+    end
   end
 end

--- a/back-end/app/presenters/api_payloads.rb
+++ b/back-end/app/presenters/api_payloads.rb
@@ -109,9 +109,15 @@ class ApiPayloads
       ]
     )
 
-    payload["item_ids"] = outfit.clothing_items.map(&:id)
-    payload["items"] = outfit.clothing_items.order(:name).map do |item|
-      clothing_item(item, include_user: false)
+    ordered_outfit_items = outfit.outfit_items.sort_by { |outfit_item| [ outfit_item.layer_order, outfit_item.id ] }
+
+    payload["item_ids"] = ordered_outfit_items.map(&:clothing_item_id)
+    payload["items"] = ordered_outfit_items.map do |outfit_item|
+      clothing_item(outfit_item.clothing_item, include_user: false).merge(
+        "outfit_item_id" => outfit_item.id,
+        "layer_order" => outfit_item.layer_order,
+        "collage_layout" => outfit_item.collage_layout_payload
+      )
     end
     payload
   end

--- a/back-end/app/services/clean_image_attachment_generator.rb
+++ b/back-end/app/services/clean_image_attachment_generator.rb
@@ -32,11 +32,18 @@ class CleanImageAttachmentGenerator
       metadata_context: metadata_context
     )
     generated_tempfile = temporary_files.track(generated.fetch(:tempfile))
+    filename_root = File.basename(generated.fetch(:filename).to_s, ".*").presence || "item-clean"
+    processed = CleanImageBackgroundRemover.call(
+      generated_tempfile,
+      filename_root: filename_root,
+      temporary_files: temporary_files
+    )
+    processed_tempfile = temporary_files.track(processed.fetch(:tempfile))
 
     record.cleaned_photo.attach(
-      io: generated_tempfile,
-      filename: generated.fetch(:filename),
-      content_type: generated.fetch(:content_type)
+      io: processed_tempfile,
+      filename: processed.fetch(:filename),
+      content_type: processed.fetch(:content_type)
     )
     record.update!(
       clean_image_status: :succeeded,

--- a/back-end/app/services/clean_image_background_remover.rb
+++ b/back-end/app/services/clean_image_background_remover.rb
@@ -20,9 +20,8 @@ class CleanImageBackgroundRemover
     output_file = temporary_files.track(Tempfile.new([ "#{filename_root}-no-background", ".png" ]))
     output_file.binmode
 
-    image = MiniMagick::Image.open(source_file.path)
-    image.format("png")
-    image.combine_options do |command|
+    MiniMagick.convert do |command|
+      command << source_file.path
       # Flood-filling from the added corner border removes only edge-connected
       # near-white pixels, which preserves white details that belong to the item.
       command.alpha "set"
@@ -35,8 +34,8 @@ class CleanImageBackgroundRemover
       # A light sharpen pass restores some edge definition after the AI clean
       # image generation and transparent-background conversion steps.
       command.sharpen configured_sharpen_amount
+      command << output_file.path
     end
-    image.write(output_file.path)
     output_file.rewind
 
     {

--- a/back-end/app/services/clean_image_background_remover.rb
+++ b/back-end/app/services/clean_image_background_remover.rb
@@ -29,7 +29,7 @@ class CleanImageBackgroundRemover
       command.border "1x1"
       command.fuzz configured_background_fuzz
       command.fill "none"
-      command.draw "alpha 0,0 floodfill"
+      command.draw "color 0,0 floodfill"
       command.shave "1x1"
       # A light sharpen pass restores some edge definition after the AI clean
       # image generation and transparent-background conversion steps.

--- a/back-end/app/services/clean_image_background_remover.rb
+++ b/back-end/app/services/clean_image_background_remover.rb
@@ -20,7 +20,7 @@ class CleanImageBackgroundRemover
     output_file = temporary_files.track(Tempfile.new([ "#{filename_root}-no-background", ".png" ]))
     output_file.binmode
 
-    MiniMagick.convert do |command|
+    MiniMagick::Tool.new(image_magick_command_name) do |command|
       command << source_file.path
       # Flood-filling from the added corner border removes only edge-connected
       # near-white pixels, which preserves white details that belong to the item.
@@ -55,6 +55,10 @@ class CleanImageBackgroundRemover
 
   def configured_sharpen_amount
     ENV.fetch("AI_CLEAN_SHARPEN", DEFAULT_SHARPEN_AMOUNT)
+  end
+
+  def image_magick_command_name
+    MiniMagick.imagemagick7? ? "magick" : "convert"
   end
 
   def prepared_source_file

--- a/back-end/app/services/clean_image_background_remover.rb
+++ b/back-end/app/services/clean_image_background_remover.rb
@@ -1,0 +1,71 @@
+require "mini_magick"
+require "tempfile"
+
+class CleanImageBackgroundRemover
+  DEFAULT_BACKGROUND_FUZZ = "12%".freeze
+  DEFAULT_SHARPEN_AMOUNT = "0x0.8".freeze
+
+  def self.call(image_source, filename_root:, temporary_files: [])
+    new(image_source, filename_root: filename_root, temporary_files: temporary_files).call
+  end
+
+  def initialize(image_source, filename_root:, temporary_files: [])
+    @image_source = image_source
+    @filename_root = filename_root
+    @temporary_files = ManagedTempfiles.wrap(temporary_files)
+  end
+
+  def call
+    source_file = prepared_source_file
+    output_file = temporary_files.track(Tempfile.new([ "#{filename_root}-no-background", ".png" ]))
+    output_file.binmode
+
+    image = MiniMagick::Image.open(source_file.path)
+    image.format("png")
+    image.combine_options do |command|
+      # Flood-filling from the added corner border removes only edge-connected
+      # near-white pixels, which preserves white details that belong to the item.
+      command.alpha "set"
+      command.bordercolor "white"
+      command.border "1x1"
+      command.fuzz configured_background_fuzz
+      command.fill "none"
+      command.draw "alpha 0,0 floodfill"
+      command.shave "1x1"
+      # A light sharpen pass restores some edge definition after the AI clean
+      # image generation and transparent-background conversion steps.
+      command.sharpen configured_sharpen_amount
+    end
+    image.write(output_file.path)
+    output_file.rewind
+
+    {
+      tempfile: output_file,
+      filename: "#{filename_root}-clean.png",
+      content_type: "image/png"
+    }
+  end
+
+  private
+
+  attr_reader :filename_root, :image_source, :temporary_files
+
+  def configured_background_fuzz
+    ENV.fetch("AI_CLEAN_BACKGROUND_FUZZ", DEFAULT_BACKGROUND_FUZZ)
+  end
+
+  def configured_sharpen_amount
+    ENV.fetch("AI_CLEAN_SHARPEN", DEFAULT_SHARPEN_AMOUNT)
+  end
+
+  def prepared_source_file
+    return image_source if image_source.respond_to?(:path)
+
+    tempfile = temporary_files.track(Tempfile.new([ filename_root, ".png" ]))
+    tempfile.binmode
+    image_source.rewind if image_source.respond_to?(:rewind)
+    IO.copy_stream(image_source, tempfile)
+    tempfile.rewind
+    tempfile
+  end
+end

--- a/back-end/db/migrate/20260521165312_add_collage_layout_to_outfit_items.rb
+++ b/back-end/db/migrate/20260521165312_add_collage_layout_to_outfit_items.rb
@@ -12,7 +12,7 @@ class AddCollageLayoutToOutfitItems < ActiveRecord::Migration[8.1]
     OutfitItem.reset_column_information
 
     OutfitItem.all.group_by(&:outfit_id).each_value do |outfit_items|
-      outfit_items.sort_by { |outfit_item| [outfit_item.created_at, outfit_item.id] }.each_with_index do |outfit_item, index|
+      outfit_items.sort_by { |outfit_item| [ outfit_item.created_at, outfit_item.id ] }.each_with_index do |outfit_item, index|
         outfit_item.update_columns(layer_order: index)
       end
     end

--- a/back-end/db/migrate/20260521165312_add_collage_layout_to_outfit_items.rb
+++ b/back-end/db/migrate/20260521165312_add_collage_layout_to_outfit_items.rb
@@ -1,0 +1,29 @@
+class AddCollageLayoutToOutfitItems < ActiveRecord::Migration[8.1]
+  def up
+    add_column :outfit_items, :collage_x, :float unless column_exists?(:outfit_items, :collage_x)
+    add_column :outfit_items, :collage_y, :float unless column_exists?(:outfit_items, :collage_y)
+    add_column :outfit_items, :collage_width, :float unless column_exists?(:outfit_items, :collage_width)
+    add_column :outfit_items, :collage_height, :float unless column_exists?(:outfit_items, :collage_height)
+    unless column_exists?(:outfit_items, :collage_rotation)
+      add_column :outfit_items, :collage_rotation, :float, null: false, default: 0.0
+    end
+    add_column :outfit_items, :layer_order, :integer, null: false, default: 0 unless column_exists?(:outfit_items, :layer_order)
+
+    OutfitItem.reset_column_information
+
+    OutfitItem.all.group_by(&:outfit_id).each_value do |outfit_items|
+      outfit_items.sort_by { |outfit_item| [outfit_item.created_at, outfit_item.id] }.each_with_index do |outfit_item, index|
+        outfit_item.update_columns(layer_order: index)
+      end
+    end
+  end
+
+  def down
+    remove_column :outfit_items, :layer_order if column_exists?(:outfit_items, :layer_order)
+    remove_column :outfit_items, :collage_rotation if column_exists?(:outfit_items, :collage_rotation)
+    remove_column :outfit_items, :collage_height if column_exists?(:outfit_items, :collage_height)
+    remove_column :outfit_items, :collage_width if column_exists?(:outfit_items, :collage_width)
+    remove_column :outfit_items, :collage_y if column_exists?(:outfit_items, :collage_y)
+    remove_column :outfit_items, :collage_x if column_exists?(:outfit_items, :collage_x)
+  end
+end

--- a/back-end/db/schema.rb
+++ b/back-end/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_17_220000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_21_165312) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -101,7 +101,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_17_220000) do
 
   create_table "outfit_items", force: :cascade do |t|
     t.integer "clothing_item_id", null: false
+    t.float "collage_height"
+    t.float "collage_rotation", default: 0.0, null: false
+    t.float "collage_width"
+    t.float "collage_x"
+    t.float "collage_y"
     t.datetime "created_at", null: false
+    t.integer "layer_order", default: 0, null: false
     t.integer "outfit_id", null: false
     t.datetime "updated_at", null: false
     t.index ["clothing_item_id"], name: "index_outfit_items_on_clothing_item_id"

--- a/back-end/test/integration/outfits_flow_test.rb
+++ b/back-end/test/integration/outfits_flow_test.rb
@@ -119,6 +119,16 @@ class OutfitsFlowTest < ActionDispatch::IntegrationTest
     assert_equal 18.0, response_json["items"].first["collage_layout"]["x"]
     assert_equal(-8.0, response_json["items"].first["collage_layout"]["rotation"])
     assert_equal 1, response_json["items"].second["layer_order"]
+
+    @outfit.reload
+    ordered_outfit_items = @outfit.outfit_items.order(:layer_order, :id)
+    assert_equal [ extra_item.id, @user_item.id ], ordered_outfit_items.map(&:clothing_item_id)
+    assert_equal 18.0, ordered_outfit_items.first.collage_x
+    assert_equal 44.0, ordered_outfit_items.first.collage_width
+    assert_equal(-8.0, ordered_outfit_items.first.collage_rotation)
+    assert_equal 36.0, ordered_outfit_items.second.collage_x
+    assert_equal 42.0, ordered_outfit_items.second.collage_height
+    assert_equal 6.0, ordered_outfit_items.second.collage_rotation
   end
 
   test "can delete an outfit" do

--- a/back-end/test/integration/outfits_flow_test.rb
+++ b/back-end/test/integration/outfits_flow_test.rb
@@ -131,6 +131,59 @@ class OutfitsFlowTest < ActionDispatch::IntegrationTest
     assert_equal 6.0, ordered_outfit_items.second.collage_rotation
   end
 
+  test "outfit show returns the same saved collage layout after editing" do
+    extra_item = ClothingItem.create!(
+      user: @user,
+      name: "Layered Coat",
+      size: :large,
+      tags: [ "outerwear" ]
+    )
+    @outfit.clothing_items << extra_item
+
+    patch outfit_url(@outfit), params: {
+      outfit: {
+        name: @outfit.name,
+        item_ids: [ extra_item.id, @user_item.id ],
+        item_layouts: [
+          {
+            item_id: extra_item.id,
+            x: 18,
+            y: 10,
+            width: 44,
+            height: 48,
+            rotation: -8,
+            layer_order: 0
+          },
+          {
+            item_id: @user_item.id,
+            x: 36,
+            y: 32,
+            width: 40,
+            height: 42,
+            rotation: 6,
+            layer_order: 1
+          }
+        ]
+      }
+    }, headers: auth_headers(@user), as: :json
+
+    assert_response :success
+    updated_items = response_json.fetch("items").map do |item|
+      [
+        item.fetch("id"),
+        item.fetch("layer_order"),
+        item.fetch("collage_layout")
+      ]
+    end
+    updated_item_ids = response_json.fetch("item_ids")
+
+    get outfit_url(@outfit), headers: auth_headers(@user), as: :json
+
+    assert_response :success
+    assert_equal updated_item_ids, response_json.fetch("item_ids")
+    assert_equal updated_items, response_json.fetch("items").map { |item| [ item.fetch("id"), item.fetch("layer_order"), item.fetch("collage_layout") ] }
+  end
+
   test "can update outfit collage layout with an item partially off canvas" do
     patch outfit_url(@outfit), params: {
       outfit: {

--- a/back-end/test/integration/outfits_flow_test.rb
+++ b/back-end/test/integration/outfits_flow_test.rb
@@ -131,6 +131,32 @@ class OutfitsFlowTest < ActionDispatch::IntegrationTest
     assert_equal 6.0, ordered_outfit_items.second.collage_rotation
   end
 
+  test "can update outfit collage layout with an item partially off canvas" do
+    patch outfit_url(@outfit), params: {
+      outfit: {
+        name: @outfit.name,
+        item_ids: [ @user_item.id ],
+        item_layouts: [
+          {
+            item_id: @user_item.id,
+            x: -20,
+            y: 12,
+            width: 40,
+            height: 48,
+            rotation: 0,
+            layer_order: 0
+          }
+        ]
+      }
+    }, headers: auth_headers(@user), as: :json
+
+    assert_response :success
+    assert_equal(-20.0, response_json["items"].first["collage_layout"]["x"])
+
+    @outfit.reload
+    assert_equal(-20.0, @outfit.outfit_items.first.collage_x)
+  end
+
   test "can delete an outfit" do
     assert_difference("Outfit.count", -1) do
       delete outfit_url(@outfit), headers: auth_headers(@user), as: :json

--- a/back-end/test/integration/outfits_flow_test.rb
+++ b/back-end/test/integration/outfits_flow_test.rb
@@ -43,6 +43,7 @@ class OutfitsFlowTest < ActionDispatch::IntegrationTest
     assert_equal @user.id, created_outfit.user_id
     assert_equal [ @user_item.id ], created_outfit.clothing_item_ids
     assert_equal [ "rain", "casual" ], response_json["tags"]
+    assert_equal [ @user_item.id ], response_json["item_ids"]
   end
 
   test "cannot create an outfit using another user's item" do
@@ -74,6 +75,50 @@ class OutfitsFlowTest < ActionDispatch::IntegrationTest
     assert_equal "Weekend Capsule Updated", @outfit.name
     assert_equal "Updated note", @outfit.notes
     assert_empty @outfit.clothing_item_ids
+  end
+
+  test "can update outfit collage layout and layer order" do
+    extra_item = ClothingItem.create!(
+      user: @user,
+      name: "Layered Coat",
+      size: :large,
+      tags: [ "outerwear" ]
+    )
+    @outfit.clothing_items << extra_item
+
+    patch outfit_url(@outfit), params: {
+      outfit: {
+        name: @outfit.name,
+        item_ids: [ extra_item.id, @user_item.id ],
+        item_layouts: [
+          {
+            item_id: extra_item.id,
+            x: 18,
+            y: 10,
+            width: 44,
+            height: 48,
+            rotation: -8,
+            layer_order: 0
+          },
+          {
+            item_id: @user_item.id,
+            x: 36,
+            y: 32,
+            width: 40,
+            height: 42,
+            rotation: 6,
+            layer_order: 1
+          }
+        ]
+      }
+    }, headers: auth_headers(@user), as: :json
+
+    assert_response :success
+    assert_equal [ extra_item.id, @user_item.id ], response_json["item_ids"]
+    assert_equal extra_item.id, response_json["items"].first["id"]
+    assert_equal 18.0, response_json["items"].first["collage_layout"]["x"]
+    assert_equal(-8.0, response_json["items"].first["collage_layout"]["rotation"])
+    assert_equal 1, response_json["items"].second["layer_order"]
   end
 
   test "can delete an outfit" do

--- a/back-end/test/models/outfit_item_test.rb
+++ b/back-end/test/models/outfit_item_test.rb
@@ -31,17 +31,36 @@ class OutfitItemTest < ActiveSupport::TestCase
     assert_includes invalid.errors[:base], "Collage layout is incomplete"
   end
 
-  test "collage layout must stay within bounds" do
+  test "collage layout can sit partially outside the canvas" do
+    fresh_item = ClothingItem.create!(
+      user: outfits(:one).user,
+      name: "Partial Canvas Tee",
+      size: :medium,
+      tags: [ "test" ]
+    )
+    valid = OutfitItem.new(
+      outfit: outfits(:one),
+      clothing_item: fresh_item,
+      collage_x: -20,
+      collage_y: 10,
+      collage_width: 40,
+      collage_height: 30
+    )
+
+    assert valid.valid?
+  end
+
+  test "collage layout must keep at least half visible" do
     invalid = OutfitItem.new(
       outfit: outfits(:one),
       clothing_item: clothing_items(:one),
-      collage_x: 70,
+      collage_x: -25,
       collage_y: 10,
       collage_width: 40,
       collage_height: 30
     )
 
     assert_not invalid.valid?
-    assert_includes invalid.errors[:base], "Collage layout must stay within the canvas"
+    assert_includes invalid.errors[:base], "At least half of each collage item must stay within the canvas"
   end
 end

--- a/back-end/test/models/outfit_item_test.rb
+++ b/back-end/test/models/outfit_item_test.rb
@@ -18,4 +18,30 @@ class OutfitItemTest < ActiveSupport::TestCase
     assert_not invalid.valid?
     assert_includes invalid.errors[:clothing_item_id], "must belong to the same user as the outfit"
   end
+
+  test "collage layout must be complete" do
+    invalid = OutfitItem.new(
+      outfit: outfits(:one),
+      clothing_item: clothing_items(:one),
+      collage_x: 10,
+      collage_y: 12
+    )
+
+    assert_not invalid.valid?
+    assert_includes invalid.errors[:base], "Collage layout is incomplete"
+  end
+
+  test "collage layout must stay within bounds" do
+    invalid = OutfitItem.new(
+      outfit: outfits(:one),
+      clothing_item: clothing_items(:one),
+      collage_x: 70,
+      collage_y: 10,
+      collage_width: 40,
+      collage_height: 30
+    )
+
+    assert_not invalid.valid?
+    assert_includes invalid.errors[:base], "Collage layout must stay within the canvas"
+  end
 end

--- a/back-end/test/services/clean_image_background_remover_test.rb
+++ b/back-end/test/services/clean_image_background_remover_test.rb
@@ -7,14 +7,14 @@ class CleanImageBackgroundRemoverTest < ActiveSupport::TestCase
     source = Tempfile.new([ "background-removal-source", ".png" ])
     source.binmode
 
-    MiniMagick.convert do |convert|
-      convert.size "40x40"
-      convert.xc "white"
-      convert.fill "black"
-      convert.draw "rectangle 8,8 31,31"
-      convert.fill "white"
-      convert.draw "rectangle 16,16 23,23"
-      convert << source.path
+    MiniMagick::Tool.new(image_magick_command_name) do |command|
+      command.size "40x40"
+      command.xc "white"
+      command.fill "black"
+      command.draw "rectangle 8,8 31,31"
+      command.fill "white"
+      command.draw "rectangle 16,16 23,23"
+      command << source.path
     end
     source.rewind
 
@@ -29,5 +29,11 @@ class CleanImageBackgroundRemoverTest < ActiveSupport::TestCase
   ensure
     source&.close!
     result&.dig(:tempfile)&.close!
+  end
+
+  private
+
+  def image_magick_command_name
+    MiniMagick.imagemagick7? ? "magick" : "convert"
   end
 end

--- a/back-end/test/services/clean_image_background_remover_test.rb
+++ b/back-end/test/services/clean_image_background_remover_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+require "mini_magick"
+require "tempfile"
+
+class CleanImageBackgroundRemoverTest < ActiveSupport::TestCase
+  test "removes only the edge-connected white background" do
+    source = Tempfile.new([ "background-removal-source", ".png" ])
+    source.binmode
+
+    MiniMagick.convert do |convert|
+      convert.size "40x40"
+      convert.xc "white"
+      convert.fill "black"
+      convert.draw "rectangle 8,8 31,31"
+      convert.fill "white"
+      convert.draw "rectangle 16,16 23,23"
+      convert << source.path
+    end
+    source.rewind
+
+    result = CleanImageBackgroundRemover.call(source, filename_root: "synthetic-item")
+    output = MiniMagick::Image.open(result.fetch(:tempfile).path)
+
+    assert_equal "image/png", result.fetch(:content_type)
+    assert_equal "synthetic-item-clean.png", result.fetch(:filename)
+    assert_equal "graya(0,0)", output["%[pixel:p{0,0}]"]
+    assert_equal "graya(0,1)", output["%[pixel:p{12,12}]"]
+    assert_equal "graya(255,1)", output["%[pixel:p{20,20}]"]
+  ensure
+    source&.close!
+    result&.dig(:tempfile)&.close!
+  end
+end

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -62,7 +62,7 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
 
 - `/` logged-out landing page
 - `/closet` signed-in closet home with search, filters, and sorting
-- `/outfits` saved outfit builder and editor
+- `/outfits` saved outfit gallery and editor
 - `/users` admin-only users directory
 - `/users/:id` admin-only user detail page
 - `/items/:id` clothing item detail editor
@@ -77,6 +77,7 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
 - The admin users directory at `/users` is paginated (24 per page) and uses a `clothing_items_count` field per user instead of shipping each user's full items array.
 - The closet page now treats outfit selection like a cart: `Add to Outfit` updates a cart button in the closet action row beside `Add Item`, the selected pieces can be reviewed in a right-side tray, and the tray can capture outfit name, tags, and notes before creating the outfit. The `/outfits` page now focuses on browsing, editing, and deleting saved outfits, and editing opens a modal with the outfit preview on the left, direct collage editing controls (move, resize, rotate, and layer reordering), and editable metadata on the right.
 - The saved-outfit collage editor is library-backed: `react-moveable` owns the move/resize/rotate controls, while `OutfitCollageCanvas` keeps the rendered image viewport and persisted collage layout data in sync.
+- The saved card and edit modal intentionally share the same collage-layout math: the editor seeds its layouts from the saved API payload, and both views normalize those layouts through the same render-math helpers so the saved preview matches what the editor shows after save.
 - Item and outfit text inputs are length-capped through `src/app/lib/inputLengthPolicy.ts`, which mirrors the backend `InputLengthPolicy` constants and applies them as `maxLength` on the relevant `<input>` and `<textarea>` controls.
 - Closet filtering and sorting are handled through focused helpers in `src/app/lib/closetFilters.ts`.
 - Item create and edit flows send multipart form data so photos can be uploaded, cropped, removed, or sourced from detected outfit-photo regions.
@@ -96,8 +97,12 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
   Shared types plus frontend-facing API helpers for clothing items, outfits, uploads, clean-image flows, and metadata suggestions
 - `src/app/lib/outfitCollage.ts`
   Shared default-layout, layer-order, and layout-normalization helpers for saved outfit collages
+- `src/app/lib/outfitCollageRenderMath.ts`
+  Shared stage-aspect normalization and resize-aspect helpers that keep saved cards and the editor preview on the same rendering contract
 - `src/app/lib/outfitImageBounds.ts`
   Cached image-content-bounds measurement helpers for saved-outfit collage rendering and editing
+- `tests/outfit-collage-contracts.test.ts`
+  Node-based frontend contract tests covering saved-view/editor layout parity and the resize-aspect fallback that prevents reselection drift
 - `src/app/lib/closetFilters.ts`
   Closet search, filter, and sort helpers
 - `src/app/lib/usePageData.ts`
@@ -145,4 +150,10 @@ Create a production build:
 
 ```bash
 npm run build
+```
+
+Run the frontend contract tests:
+
+```bash
+npm test
 ```

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -75,6 +75,8 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
 - The app loads the signed-in user through `GET /me`.
 - Non-admin users are blocked from `/users` and `/users/:id` in both backend authorization and frontend navigation.
 - The admin users directory at `/users` is paginated (24 per page) and uses a `clothing_items_count` field per user instead of shipping each user's full items array.
+- The closet page now treats outfit selection like a cart: `Add to Outfit` updates a cart button in the closet action row beside `Add Item`, the selected pieces can be reviewed in a right-side tray, and the tray can capture outfit name, tags, and notes before creating the outfit. The `/outfits` page now focuses on browsing, editing, and deleting saved outfits, and editing opens a modal with the outfit preview on the left, direct collage editing controls (move, resize, rotate, and layer reordering), and editable metadata on the right.
+- The saved-outfit collage editor is library-backed: `react-moveable` owns the move/resize/rotate controls, while `OutfitCollageCanvas` keeps the rendered image viewport and persisted collage layout data in sync.
 - Item and outfit text inputs are length-capped through `src/app/lib/inputLengthPolicy.ts`, which mirrors the backend `InputLengthPolicy` constants and applies them as `maxLength` on the relevant `<input>` and `<textarea>` controls.
 - Closet filtering and sorting are handled through focused helpers in `src/app/lib/closetFilters.ts`.
 - Item create and edit flows send multipart form data so photos can be uploaded, cropped, removed, or sourced from detected outfit-photo regions.
@@ -92,6 +94,8 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
   Shared fetch helpers and API error formatting
 - `src/app/lib/closet.ts`
   Shared types plus frontend-facing API helpers for clothing items, outfits, uploads, clean-image flows, and metadata suggestions
+- `src/app/lib/outfitCollage.ts`
+  Shared default-layout, layer-order, and layout-normalization helpers for saved outfit collages
 - `src/app/lib/closetFilters.ts`
   Closet search, filter, and sort helpers
 - `src/app/lib/usePageData.ts`
@@ -106,6 +110,10 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
   Manual item creation plus orchestration for the image-based create flow
 - `src/app/components/ItemDetailPage.tsx`
   Edit and delete flow for an existing clothing item
+- `src/app/components/OutfitCartSheet.tsx`
+  Cart-style right-side tray for reviewing selected closet items and creating an outfit directly from the closet page
+- `src/app/components/OutfitCollageCanvas.tsx`
+  Shared saved-outfit collage renderer plus the edit-modal `react-moveable` interaction layer and content-bounds-aware image viewport
 - `src/app/components/ItemMetadataFields.tsx`
   Shared name, size, date, brand, tag, and AI autofill fields
 - `src/app/components/AiMetadataAutofillButton.tsx`

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -80,7 +80,7 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
 - Item and outfit text inputs are length-capped through `src/app/lib/inputLengthPolicy.ts`, which mirrors the backend `InputLengthPolicy` constants and applies them as `maxLength` on the relevant `<input>` and `<textarea>` controls.
 - Closet filtering and sorting are handled through focused helpers in `src/app/lib/closetFilters.ts`.
 - Item create and edit flows send multipart form data so photos can be uploaded, cropped, removed, or sourced from detected outfit-photo regions.
-- The item editor can request AI metadata suggestions for type, name, brand, and tags, and can request cleaned item imagery for catalog-style presentation.
+- The item editor can request AI metadata suggestions for type, name, brand, and tags, and can request cleaned item imagery for catalog-style presentation; the backend now strips the generated white studio background before returning the final cleaned PNG.
 - Image-based item creation submits an outfit photo to `POST /outfit_uploads`, renders detections, and supports promoting a reviewed detection into a closet item.
 - Outfit drafts are stored per user in local storage through `useOutfitDraftState`.
 
@@ -96,6 +96,8 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
   Shared types plus frontend-facing API helpers for clothing items, outfits, uploads, clean-image flows, and metadata suggestions
 - `src/app/lib/outfitCollage.ts`
   Shared default-layout, layer-order, and layout-normalization helpers for saved outfit collages
+- `src/app/lib/outfitImageBounds.ts`
+  Cached image-content-bounds measurement helpers for saved-outfit collage rendering and editing
 - `src/app/lib/closetFilters.ts`
   Closet search, filter, and sort helpers
 - `src/app/lib/usePageData.ts`
@@ -113,7 +115,9 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
 - `src/app/components/OutfitCartSheet.tsx`
   Cart-style right-side tray for reviewing selected closet items and creating an outfit directly from the closet page
 - `src/app/components/OutfitCollageCanvas.tsx`
-  Shared saved-outfit collage renderer plus the edit-modal `react-moveable` interaction layer and content-bounds-aware image viewport
+  Shared saved-outfit collage renderer plus the edit-modal `react-moveable` interaction layer and the shared normalized-layout/stage-aspect contract used by both gallery and editor views
+- `src/app/components/OutfitCollageLayersPanel.tsx`
+  Focused layers sidebar for thumbnail selection plus pointer and keyboard-accessible layer reordering
 - `src/app/components/ItemMetadataFields.tsx`
   Shared name, size, date, brand, tag, and AI autofill fields
 - `src/app/components/AiMetadataAutofillButton.tsx`
@@ -128,7 +132,7 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
 The frontend API layer is split between shared request helpers in `src/app/lib/api.ts` and feature-facing helpers/types in `src/app/lib/closet.ts`.
 
 - `VITE_API_BASE_URL` defaults to `/api`
-- Vite proxies `/api` to the Rails backend in development
+- Vite proxies `/api` and `/rails/active_storage` to the Rails backend in development so API requests and local Active Storage media stay same-origin from the browser's perspective
 - `BACKEND_HOST` and `BACKEND_PORT` control the proxy target during local development
 - authenticated requests use `credentials: "include"`
 

--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -48,6 +48,7 @@
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.5",
         "react-hook-form": "^7.75.0",
+        "react-moveable": "^0.56.0",
         "react-resizable-panels": "^4.11.1",
         "recharts": "^3.8.1",
         "sonner": "^2.0.7",
@@ -59,10 +60,52 @@
       },
       "devDependencies": {}
     },
+    "node_modules/@cfcs/core": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@cfcs/core/-/core-0.0.6.tgz",
+      "integrity": "sha512-FxfJMwoLB8MEMConeXUCqtMGqxdtePQxRBOiGip9ULcYYam3WfCgoY6xdnMaSkYvRvmosp5iuG+TiPofm65+Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/component": "^3.0.2"
+      }
+    },
     "node_modules/@date-fns/tz": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
+    },
+    "node_modules/@daybrush/utils": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@daybrush/utils/-/utils-1.13.0.tgz",
+      "integrity": "sha512-ALK12C6SQNNHw1enXK+UO8bdyQ+jaWNQ1Af7Z3FNxeAwjYhQT7do+TRE4RASAJ3ObaS2+TJ7TXR3oz2Gzbw0PQ==",
+      "license": "MIT"
+    },
+    "node_modules/@egjs/agent": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@egjs/agent/-/agent-2.4.4.tgz",
+      "integrity": "sha512-cvAPSlUILhBBOakn2krdPnOGv5hAZq92f1YHxYcfu0p7uarix2C6Ia3AVizpS1SGRZGiEkIS5E+IVTLg1I2Iog==",
+      "license": "MIT"
+    },
+    "node_modules/@egjs/children-differ": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@egjs/children-differ/-/children-differ-1.0.1.tgz",
+      "integrity": "sha512-DRvyqMf+CPCOzAopQKHtW+X8iN6Hy6SFol+/7zCUiE5y4P/OB8JP8FtU4NxtZwtafvSL4faD5KoQYPj3JHzPFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/list-differ": "^1.0.0"
+      }
+    },
+    "node_modules/@egjs/component": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@egjs/component/-/component-3.0.5.tgz",
+      "integrity": "sha512-cLcGizTrrUNA2EYE3MBmEDt2tQv1joVP1Q3oDisZ5nw0MZDx2kcgEXM+/kZpfa/PAkFvYVhRUZwytIQWoN3V/w==",
+      "license": "MIT"
+    },
+    "node_modules/@egjs/list-differ": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@egjs/list-differ/-/list-differ-1.0.1.tgz",
+      "integrity": "sha512-OTFTDQcWS+1ZREOdCWuk5hCBgYO4OsD30lXcOCyVOAjXMhgL5rBRDnt/otb6Nz8CzU0L/igdcaQBDLWc4t9gvg==",
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
@@ -2099,6 +2142,34 @@
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "license": "MIT"
     },
+    "node_modules/@scena/dragscroll": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scena/dragscroll/-/dragscroll-1.4.0.tgz",
+      "integrity": "sha512-3O8daaZD9VXA9CP3dra6xcgt/qrm0mg0xJCwiX6druCteQ9FFsXffkF8PrqxY4Z4VJ58fFKEa0RlKqbsi/XnRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@daybrush/utils": "^1.6.0",
+        "@scena/event-emitter": "^1.0.2"
+      }
+    },
+    "node_modules/@scena/event-emitter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@scena/event-emitter/-/event-emitter-1.0.5.tgz",
+      "integrity": "sha512-AzY4OTb0+7ynefmWFQ6hxDdk0CySAq/D4efljfhtRHCOP7MBF9zUfhKG3TJiroVjASqVgkRJFdenS8ArZo6Olg==",
+      "license": "MIT",
+      "dependencies": {
+        "@daybrush/utils": "^1.1.1"
+      }
+    },
+    "node_modules/@scena/matrix": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scena/matrix/-/matrix-1.1.1.tgz",
+      "integrity": "sha512-JVKBhN0tm2Srl+Yt+Ywqu0oLgLcdemDQlD1OxmN9jaCTwaFPZ7tY8n6dhVgMEaR9qcR7r+kAlMXnSfNyYdE+Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@daybrush/utils": "^1.4.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2600,6 +2671,25 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/css-styled": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/css-styled/-/css-styled-1.0.8.tgz",
+      "integrity": "sha512-tCpP7kLRI8dI95rCh3Syl7I+v7PP+2JYOzWkl0bUEoSbJM+u8ITbutjlQVf0NC2/g4ULROJPi16sfwDIO8/84g==",
+      "license": "MIT",
+      "dependencies": {
+        "@daybrush/utils": "^1.13.0"
+      }
+    },
+    "node_modules/css-to-mat": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-to-mat/-/css-to-mat-1.1.1.tgz",
+      "integrity": "sha512-kvpxFYZb27jRd2vium35G7q5XZ2WJ9rWjDUMNT36M3Hc41qCrLXFM5iEKMGXcrPsKfXEN+8l/riB4QzwwwiEyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@daybrush/utils": "^1.13.0",
+        "@scena/matrix": "^1.0.0"
+      }
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -2859,6 +2949,12 @@
         }
       }
     },
+    "node_modules/framework-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/framework-utils/-/framework-utils-1.1.0.tgz",
+      "integrity": "sha512-KAfqli5PwpFJ8o3psRNs8svpMGyCSAe8nmGcjQ0zZBWN2H6dZDnq+ABp3N3hdUmFeMrLtjOCTXD4yplUJIWceg==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2871,6 +2967,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gesto": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/gesto/-/gesto-1.19.4.tgz",
+      "integrity": "sha512-hfr/0dWwh0Bnbb88s3QVJd1ZRJeOWcgHPPwmiH6NnafDYvhTsxg+SLYu+q/oPNh9JS3V+nlr6fNs8kvPAtcRDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@daybrush/utils": "^1.13.0",
+        "@scena/event-emitter": "^1.0.2"
       }
     },
     "node_modules/get-nonce": {
@@ -2924,6 +3030,24 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/keycode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
+      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg==",
+      "license": "MIT"
+    },
+    "node_modules/keycon": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keycon/-/keycon-1.4.0.tgz",
+      "integrity": "sha512-p1NAIxiRMH3jYfTeXRs2uWbVJ1WpEjpi8ktzUyBJsX7/wn2qu2VRXktneBLNtKNxJmlUYxRi9gOJt1DuthXR7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfcs/core": "^0.0.6",
+        "@daybrush/utils": "^1.7.1",
+        "@scena/event-emitter": "^1.0.2",
+        "keycode": "^2.2.0"
       }
     },
     "node_modules/lightningcss": {
@@ -3262,6 +3386,15 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/overlap-area": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/overlap-area/-/overlap-area-1.1.0.tgz",
+      "integrity": "sha512-3dlJgJCaVeXH0/eZjYVJvQiLVVrPO4U1ZGqlATtx6QGO3b5eNM6+JgUKa7oStBTdYuGTk7gVoABCW6Tp+dhRdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@daybrush/utils": "^1.7.1"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3315,6 +3448,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-css-styled": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/react-css-styled/-/react-css-styled-1.1.9.tgz",
+      "integrity": "sha512-M7fJZ3IWFaIHcZEkoFOnkjdiUFmwd8d+gTh2bpqMOcnxy/0Gsykw4dsL4QBiKsxcGow6tETUa4NAUcmJF+/nfw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-styled": "~1.0.8",
+        "framework-utils": "^1.1.0"
       }
     },
     "node_modules/react-day-picker": {
@@ -3373,6 +3516,27 @@
       "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-moveable": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.56.0.tgz",
+      "integrity": "sha512-FmJNmIOsOA36mdxbrc/huiE4wuXSRlmon/o+/OrfNhSiYYYL0AV5oObtPluEhb2Yr/7EfYWBHTxF5aWAvjg1SA==",
+      "license": "MIT",
+      "dependencies": {
+        "@daybrush/utils": "^1.13.0",
+        "@egjs/agent": "^2.2.1",
+        "@egjs/children-differ": "^1.0.1",
+        "@egjs/list-differ": "^1.0.0",
+        "@scena/dragscroll": "^1.4.0",
+        "@scena/event-emitter": "^1.0.5",
+        "@scena/matrix": "^1.1.1",
+        "css-to-mat": "^1.1.1",
+        "framework-utils": "^1.1.0",
+        "gesto": "^1.19.3",
+        "overlap-area": "^1.1.0",
+        "react-css-styled": "^1.1.9",
+        "react-selecto": "^1.25.0"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -3452,6 +3616,15 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-selecto": {
+      "version": "1.26.3",
+      "resolved": "https://registry.npmjs.org/react-selecto/-/react-selecto-1.26.3.tgz",
+      "integrity": "sha512-Ubik7kWSnZyQEBNro+1k38hZaI1tJarE+5aD/qsqCOA1uUBSjgKVBy3EWRzGIbdmVex7DcxznFZLec/6KZNvwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "selecto": "~1.26.3"
       }
     },
     "node_modules/react-style-singleton": {
@@ -3571,6 +3744,24 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/selecto": {
+      "version": "1.26.3",
+      "resolved": "https://registry.npmjs.org/selecto/-/selecto-1.26.3.tgz",
+      "integrity": "sha512-gZHgqMy5uyB6/2YDjv3Qqaf7bd2hTDOpPdxXlrez4R3/L0GiEWDCFaUfrflomgqdb3SxHF2IXY0Jw0EamZi7cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@daybrush/utils": "^1.13.0",
+        "@egjs/children-differ": "^1.0.1",
+        "@scena/dragscroll": "^1.4.0",
+        "@scena/event-emitter": "^1.0.5",
+        "css-styled": "^1.0.8",
+        "css-to-mat": "^1.1.1",
+        "framework-utils": "^1.1.0",
+        "gesto": "^1.19.4",
+        "keycon": "^1.2.0",
+        "overlap-area": "^1.1.0"
+      }
     },
     "node_modules/sonner": {
       "version": "2.0.7",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test tests/*.test.ts"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -35,8 +35,6 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "@tailwindcss/vite": "^4.2.4",
-    "@vitejs/plugin-react": "^6.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -58,5 +56,9 @@
     "tw-animate-css": "^1.4.0",
     "vaul": "^1.1.2",
     "vite": "^8.0.13"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.2.4",
+    "@vitejs/plugin-react": "^6.0.1"
   }
 }

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -35,6 +35,8 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tailwindcss/vite": "^4.2.4",
+    "@vitejs/plugin-react": "^6.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -47,6 +49,7 @@
     "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.75.0",
+    "react-moveable": "^0.56.0",
     "react-resizable-panels": "^4.11.1",
     "recharts": "^3.8.1",
     "sonner": "^2.0.7",
@@ -54,10 +57,6 @@
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
     "vaul": "^1.1.2",
-    "@tailwindcss/vite": "^4.2.4",
-    "@vitejs/plugin-react": "^6.0.1",
     "vite": "^8.0.13"
-  },
-  "devDependencies": {
   }
 }

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -1,11 +1,13 @@
 import { Dispatch, SetStateAction, useDeferredValue, useEffect, useState } from "react";
 import { motion } from "motion/react";
-import { Search } from "lucide-react";
+import { Search, ShoppingBag } from "lucide-react";
 import { AddItemMenu } from "./components/AddItemMenu";
 import { ClothingCard } from "./components/ClothingCard";
 import { CreateItemPage } from "./components/CreateItemPage";
 import { ItemDetailPage } from "./components/ItemDetailPage";
 import { MyOutfitsPage } from "./components/MyOutfitsPage";
+import { OutfitCartSheet } from "./components/OutfitCartSheet";
+import { OutfitCreatedDialog } from "./components/OutfitCreatedDialog";
 import { UserDetailPage } from "./components/UserDetailPage";
 import { UsersDirectoryPage } from "./components/UsersDirectoryPage";
 import {
@@ -41,11 +43,13 @@ import { SiteHeader } from "./components/shared/SiteHeader";
 import { Input } from "./components/ui/input";
 import {
   ClothingItem,
+  createOutfit,
   fetchCurrentUser,
   formatPossessive,
   formatPreferredStyle,
   logoutSession,
   OutfitDraft,
+  parseTagInput,
   titleize,
   User,
 } from "./lib/closet";
@@ -71,6 +75,15 @@ import { useOutfitDraftState } from "./lib/useOutfitDraftState";
 interface HomeMessageState {
   kind: "error" | "success";
   text: string;
+}
+
+function buildCartOutfitName(itemCount: number) {
+  const formattedDate = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  }).format(new Date());
+
+  return `Outfit ${formattedDate} · ${itemCount} ${itemCount === 1 ? "piece" : "pieces"}`;
 }
 
 interface ClosetFilterMenuProps {
@@ -177,7 +190,12 @@ export default function App() {
   const [selectedColors, setSelectedColors] = useState<string[]>([]);
   const [selectedOtherTags, setSelectedOtherTags] = useState<string[]>([]);
   const [sortOption, setSortOption] = useState<ClosetSortOption>("name-asc");
-  const [outfitDraftNotice, setOutfitDraftNotice] = useState("");
+  const [isOutfitCartOpen, setIsOutfitCartOpen] = useState(false);
+  const [isOutfitCreatedDialogOpen, setIsOutfitCreatedDialogOpen] = useState(false);
+  const [isCreatingOutfitFromCart, setIsCreatingOutfitFromCart] = useState(false);
+  const [outfitCartErrorMessage, setOutfitCartErrorMessage] = useState("");
+  const [outfitCartName, setOutfitCartName] = useState("");
+  const [outfitCartStatusMessage, setOutfitCartStatusMessage] = useState("");
   const [outfitDraft, setOutfitDraft] = useOutfitDraftState(user);
 
   useEffect(() => {
@@ -247,16 +265,16 @@ export default function App() {
   }, [route.kind]);
 
   useEffect(() => {
-    if (!outfitDraftNotice) {
+    if (!outfitCartStatusMessage) {
       return;
     }
 
     const timeout = window.setTimeout(() => {
-      setOutfitDraftNotice("");
+      setOutfitCartStatusMessage("");
     }, 2400);
 
     return () => window.clearTimeout(timeout);
-  }, [outfitDraftNotice]);
+  }, [outfitCartStatusMessage]);
 
   useEffect(() => {
     if (route.kind === "home" && user) {
@@ -264,7 +282,24 @@ export default function App() {
     }
   }, [route.kind, user]);
 
+  useEffect(() => {
+    if (user) {
+      return;
+    }
+
+    setIsOutfitCartOpen(false);
+    setIsOutfitCreatedDialogOpen(false);
+    setOutfitCartName("");
+    setOutfitCartErrorMessage("");
+    setOutfitCartStatusMessage("");
+  }, [user]);
+
   const clothingItems = user?.clothing_items ?? [];
+  const outfitDraftItems = outfitDraft.itemIds
+    .map((itemId) => clothingItems.find((item) => item.id === itemId))
+    .filter((item): item is ClothingItem => Boolean(item));
+  const outfitCartBadgeLabel =
+    outfitDraftItems.length > 9 ? "9+" : String(outfitDraftItems.length);
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const isLoggedOutProtectedRoute = isProtectedRoute(route) && !user;
   const closetTitle = user ? formatPossessive(titleize(user.username)) : "Your Closet";
@@ -312,7 +347,8 @@ export default function App() {
       return;
     }
 
-    setOutfitDraftNotice("Added to outfit draft.");
+    setOutfitCartStatusMessage("Added to outfit cart.");
+    setOutfitCartErrorMessage("");
     setOutfitDraft((current) => ({
       ...current,
       itemIds: [itemId, ...current.itemIds],
@@ -320,11 +356,59 @@ export default function App() {
   }
 
   function removeItemFromOutfitDraft(itemId: number) {
-    setOutfitDraftNotice("Removed from outfit draft.");
+    setOutfitCartStatusMessage("Removed from outfit cart.");
     setOutfitDraft((current) => ({
       ...current,
       itemIds: current.itemIds.filter((id) => id !== itemId),
     }));
+  }
+
+  async function handleCreateOutfitFromCart() {
+    if (!user || outfitDraft.itemIds.length === 0) {
+      return;
+    }
+
+    setIsCreatingOutfitFromCart(true);
+    setOutfitCartErrorMessage("");
+
+    try {
+      const tags = parseTagInput(outfitDraft.tagInput);
+
+      await createOutfit({
+        userId: user.id,
+        name: outfitCartName.trim() || buildCartOutfitName(outfitDraft.itemIds.length),
+        itemIds: outfitDraft.itemIds,
+        notes: outfitDraft.notes.trim() || undefined,
+        tags: tags.length > 0 ? tags : undefined,
+      });
+
+      setOutfitDraft((current) => ({
+        ...current,
+        itemIds: [],
+        notes: "",
+        tagInput: "",
+      }));
+      setOutfitCartName("");
+      setIsOutfitCartOpen(false);
+      setIsOutfitCreatedDialogOpen(true);
+      setOutfitCartStatusMessage("Outfit created.");
+    } catch (error) {
+      setOutfitCartErrorMessage(
+        error instanceof Error ? error.message : "Unable to create this outfit right now.",
+      );
+    } finally {
+      setIsCreatingOutfitFromCart(false);
+    }
+  }
+
+  function handleBackToClosetFromOutfitDialog() {
+    setIsOutfitCreatedDialogOpen(false);
+    navigateTo("/closet");
+  }
+
+  function handleGoToOutfitsFromDialog() {
+    setIsOutfitCreatedDialogOpen(false);
+    navigateTo("/outfits");
   }
 
   async function handleLogout() {
@@ -444,10 +528,6 @@ export default function App() {
     pageContent = user ? (
       <MyOutfitsPage
         user={user}
-        draft={outfitDraft}
-        onDraftChange={setOutfitDraft}
-        onBrowseCloset={() => navigateTo("/closet")}
-        onOpenItem={(itemId) => navigateTo(`/items/${itemId}`)}
       />
     ) : null;
   } else {
@@ -492,6 +572,7 @@ export default function App() {
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.6 }}
+            className="flex items-center gap-3"
           >
             <AddItemMenu
               disabled={!user}
@@ -510,6 +591,28 @@ export default function App() {
                 navigateTo(`/items/new?userId=${user.id}&mode=manual`);
               }}
             />
+            <PrimitiveButton
+              type="button"
+              variant="outline"
+              onClick={() => setIsOutfitCartOpen(true)}
+              disabled={!user}
+              aria-label={`Open outfit cart with ${outfitDraftItems.length} ${
+                outfitDraftItems.length === 1 ? "item" : "items"
+              }`}
+              className="relative h-auto gap-3 px-5 py-3"
+            >
+              <span className="relative inline-flex">
+                <ShoppingBag className="h-4 w-4" />
+                {outfitDraftItems.length > 0 ? (
+                  <span className="absolute -right-2 -top-2 flex h-4 w-4 items-center justify-center rounded-full bg-foreground text-[9px] font-semibold leading-none text-background">
+                    {outfitCartBadgeLabel}
+                  </span>
+                ) : null}
+              </span>
+              <PrimitiveText as="span" variant="bodySm">
+                Outfit Cart
+              </PrimitiveText>
+            </PrimitiveButton>
           </motion.div>
         </div>
 
@@ -700,19 +803,42 @@ export default function App() {
         {pageContent}
       </main>
 
-      {outfitDraftNotice ? (
-        <motion.div
-          initial={{ opacity: 0, y: 14 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="fixed bottom-6 right-6 z-50 max-w-sm border border-foreground/20 bg-background/95 px-4 py-3 text-sm shadow-lg backdrop-blur"
-          role="status"
-          aria-live="polite"
-          aria-atomic="true"
-        >
-          {outfitDraftNotice} Draft has {outfitDraft.itemIds.length}{" "}
-          {outfitDraft.itemIds.length === 1 ? "item" : "items"}.
-        </motion.div>
-      ) : null}
+      <OutfitCartSheet
+        createErrorMessage={outfitCartErrorMessage}
+        isCreating={isCreatingOutfitFromCart}
+        isOpen={isOutfitCartOpen}
+        items={outfitDraftItems}
+        notes={outfitDraft.notes}
+        onCreateOutfit={() => void handleCreateOutfitFromCart()}
+        onNotesChange={(value) =>
+          setOutfitDraft((current) => ({
+            ...current,
+            notes: value,
+          }))
+        }
+        onOpenChange={setIsOutfitCartOpen}
+        onOutfitNameChange={setOutfitCartName}
+        onRemoveItem={removeItemFromOutfitDraft}
+        onTagInputChange={(value) =>
+          setOutfitDraft((current) => ({
+            ...current,
+            tagInput: value,
+          }))
+        }
+        outfitName={outfitCartName}
+        tagInput={outfitDraft.tagInput}
+      />
+
+      <OutfitCreatedDialog
+        isOpen={isOutfitCreatedDialogOpen}
+        onBackToCloset={handleBackToClosetFromOutfitDialog}
+        onGoToOutfits={handleGoToOutfitsFromDialog}
+        onOpenChange={setIsOutfitCreatedDialogOpen}
+      />
+
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {outfitCartStatusMessage}
+      </div>
 
       <SiteFooter />
     </div>

--- a/front-end/src/app/components/MyOutfitsPage.tsx
+++ b/front-end/src/app/components/MyOutfitsPage.tsx
@@ -1,30 +1,38 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { motion } from "motion/react";
-import { Pencil, Plus, Shirt, Trash2, X } from "lucide-react";
+import { Pencil, Shirt, Trash2 } from "lucide-react";
 import {
-  buildPlaceholderLabel,
   ClothingItem,
-  createOutfit,
   destroyOutfit,
-  emptyOutfitDraft,
   fetchOutfits,
-  formatTagLabel,
   OutfitDraft,
   Outfit,
   parseTagInput,
   updateOutfit,
   User,
 } from "../lib/closet";
+import { OutfitCollageCanvas, OutfitCollageLayersPanel } from "./OutfitCollageCanvas";
+import {
+  OutfitCollageLayout,
+  reorderCollageLayers,
+  resolveOutfitCollageLayouts,
+} from "../lib/outfitCollage";
+import { Input } from "./ui/input";
+import { Textarea } from "./ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
 import { PrimitiveButton } from "./primitives/PrimitiveButton";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 import { MAX_OUTFIT_NAME, MAX_OUTFIT_NOTES } from "../lib/inputLengthPolicy";
 
 interface MyOutfitsPageProps {
   user: User;
-  draft: OutfitDraft;
-  onDraftChange: (draft: OutfitDraft) => void;
-  onBrowseCloset: () => void;
-  onOpenItem: (itemId: number) => void;
 }
 
 interface FlashState {
@@ -43,16 +51,19 @@ function outfitToFormState(outfit: Outfit): OutfitDraft {
 
 export function MyOutfitsPage({
   user,
-  draft,
-  onDraftChange,
-  onBrowseCloset,
-  onOpenItem,
 }: MyOutfitsPageProps) {
   const [outfits, setOutfits] = useState<Outfit[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [flash, setFlash] = useState<FlashState | null>(null);
   const [editingOutfitId, setEditingOutfitId] = useState<number | null>(null);
-  const [formState, setFormState] = useState<OutfitDraft>(draft);
+  const [formState, setFormState] = useState<OutfitDraft>({
+    name: "",
+    notes: "",
+    tagInput: "",
+    itemIds: [],
+  });
+  const [editorLayouts, setEditorLayouts] = useState<Record<number, OutfitCollageLayout>>({});
+  const [selectedCollageItemId, setSelectedCollageItemId] = useState<number | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const formSectionRef = useRef<HTMLElement | null>(null);
 
@@ -66,50 +77,20 @@ export function MyOutfitsPage({
       .map((id) => itemById.get(id))
       .filter((item): item is ClothingItem => Boolean(item));
   }, [formState.itemIds, sortedItems]);
+  const editingOutfit = editingOutfitId
+    ? outfits.find((outfit) => outfit.id === editingOutfitId) ?? null
+    : null;
 
   function showFlash(kind: FlashState["kind"], message: string) {
     setFlash({ kind, message });
   }
 
-  function updateCreateDraft(nextDraft: OutfitDraft) {
-    setFormState(nextDraft);
-    onDraftChange(nextDraft);
-  }
-
-  function updateFormState(updater: (current: OutfitDraft) => OutfitDraft) {
-    setFormState((current) => {
-      const nextDraft = updater(current);
-
-      if (!editingOutfitId) {
-        onDraftChange(nextDraft);
-      }
-
-      return nextDraft;
-    });
-  }
-
   function setFormField<Key extends keyof OutfitDraft>(key: Key, value: OutfitDraft[Key]) {
-    if (editingOutfitId) {
-      setFormState((current) => ({
-        ...current,
-        [key]: value,
-      }));
-      return;
-    }
-
-    updateFormState((current) => ({
+    setFormState((current) => ({
       ...current,
       [key]: value,
     }));
   }
-
-  useEffect(() => {
-    if (editingOutfitId) {
-      return;
-    }
-
-    setFormState(draft);
-  }, [draft, editingOutfitId]);
 
   useEffect(() => {
     if (!flash) {
@@ -165,32 +146,27 @@ export function MyOutfitsPage({
     setIsSaving(true);
 
     try {
-      if (editingOutfitId) {
-        const updatedOutfit = await updateOutfit({
-          id: editingOutfitId,
-          name: trimmedName,
-          itemIds: formState.itemIds,
-          notes: formState.notes.trim() || undefined,
-          tags: tags.length > 0 ? tags : undefined,
-        });
-
-        setOutfits((current) =>
-          current.map((outfit) => (outfit.id === updatedOutfit.id ? updatedOutfit : outfit)),
-        );
-        showFlash("success", "Outfit updated.");
-      } else {
-        const createdOutfit = await createOutfit({
-          userId: user.id,
-          name: trimmedName,
-          itemIds: formState.itemIds,
-          notes: formState.notes.trim() || undefined,
-          tags: tags.length > 0 ? tags : undefined,
-        });
-
-        setOutfits((current) => [createdOutfit, ...current]);
-        updateCreateDraft(emptyOutfitDraft());
-        showFlash("success", "Outfit saved.");
+      if (!editingOutfitId) {
+        showFlash("error", "Create new outfits from the closet cart.");
+        return;
       }
+
+      const updatedOutfit = await updateOutfit({
+        id: editingOutfitId,
+        name: trimmedName,
+        itemIds: formState.itemIds,
+        itemLayouts: formState.itemIds.map((itemId) => ({
+          item_id: itemId,
+          ...editorLayouts[itemId],
+        })),
+        notes: formState.notes.trim() || undefined,
+        tags: tags.length > 0 ? tags : undefined,
+      });
+
+      setOutfits((current) =>
+        current.map((outfit) => (outfit.id === updatedOutfit.id ? updatedOutfit : outfit)),
+      );
+      showFlash("success", "Outfit updated.");
 
       resetForm();
     } catch (error) {
@@ -210,23 +186,25 @@ export function MyOutfitsPage({
     }
   }
 
-  function removeSelectedItem(itemId: number) {
-    updateFormState((current) => ({
-      ...current,
-      itemIds: current.itemIds.filter((id) => id !== itemId),
-    }));
-  }
-
   function startEditing(outfit: Outfit) {
     setEditingOutfitId(outfit.id);
     setFormState(outfitToFormState(outfit));
+    const nextLayouts = resolveOutfitCollageLayouts(outfit.items);
+    setEditorLayouts(nextLayouts);
+    setSelectedCollageItemId(outfit.items[0]?.id ?? null);
     setFlash(null);
-    formSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   }
 
   function resetForm() {
     setEditingOutfitId(null);
-    setFormState(draft);
+    setFormState({
+      name: "",
+      notes: "",
+      tagInput: "",
+      itemIds: [],
+    });
+    setEditorLayouts({});
+    setSelectedCollageItemId(null);
   }
 
   return (
@@ -248,136 +226,6 @@ export function MyOutfitsPage({
         </PrimitiveText>
       </div>
 
-      <section ref={formSectionRef} className="border border-border bg-card p-6">
-        <div className="flex items-center gap-3 mb-5">
-          <Plus className="w-4 h-4" />
-          <h2>{editingOutfitId ? "Edit Outfit" : "Create Outfit"}</h2>
-        </div>
-
-        <form onSubmit={handleSubmit} className="space-y-5">
-          <div className="grid gap-4 md:grid-cols-2">
-            <label className="space-y-2">
-              <PrimitiveText as="span" variant="bodySm" tone="muted">Name</PrimitiveText>
-              <input
-                value={formState.name}
-                onChange={(event) => setFormField("name", event.target.value)}
-                placeholder="Weekend Brunch"
-                className="w-full border border-border bg-background px-3 py-2"
-                maxLength={MAX_OUTFIT_NAME}
-              />
-            </label>
-
-            <label className="space-y-2">
-              <PrimitiveText as="span" variant="bodySm" tone="muted">
-                Tags (comma separated)
-              </PrimitiveText>
-              <input
-                value={formState.tagInput}
-                onChange={(event) => setFormField("tagInput", event.target.value)}
-                placeholder="casual, spring"
-                className="w-full border border-border bg-background px-3 py-2"
-              />
-            </label>
-          </div>
-
-          <label className="space-y-2 block">
-            <PrimitiveText as="span" variant="bodySm" tone="muted">Notes</PrimitiveText>
-            <textarea
-              value={formState.notes}
-              onChange={(event) => setFormField("notes", event.target.value)}
-              placeholder="When and where to wear this look"
-              className="w-full border border-border bg-background px-3 py-2 min-h-24"
-              maxLength={MAX_OUTFIT_NOTES}
-            />
-          </label>
-
-          <div className="space-y-3">
-            <div className="flex items-center justify-between gap-3">
-              <PrimitiveText as="p" variant="bodySm" tone="muted">
-                Items in this outfit
-              </PrimitiveText>
-              <PrimitiveButton
-                type="button"
-                onClick={onBrowseCloset}
-                variant="outline"
-                size="sm"
-              >
-                Add from closet
-              </PrimitiveButton>
-            </div>
-
-            {selectedItems.length === 0 ? (
-              <PrimitiveText
-                as="div"
-                variant="bodySm"
-                tone="muted"
-                className="border border-dashed border-border p-4"
-              >
-                Use “Add to Outfit” on any closet item, then come back here to save.
-              </PrimitiveText>
-            ) : (
-              <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-                {selectedItems.map((item) => (
-                  <div key={item.id} className="border border-border p-2 flex items-center gap-3">
-                    <div className="h-12 w-12 shrink-0 border border-border bg-muted overflow-hidden">
-                      {item.image_url ? (
-                        <img src={item.image_url} alt={item.name} className="h-full w-full object-cover" />
-                      ) : (
-                        <PrimitiveText
-                          as="div"
-                          variant="caption"
-                          className="h-full w-full flex items-center justify-center"
-                        >
-                          {buildPlaceholderLabel(item.name)}
-                        </PrimitiveText>
-                      )}
-                    </div>
-
-                    <div className="min-w-0 flex-1">
-                      <PrimitiveText as="p" className="truncate">{item.name}</PrimitiveText>
-                      <PrimitiveText as="p" variant="caption" tone="muted" className="truncate">
-                        {item.tags.length > 0 ? formatTagLabel(item.tags[0]) : "Unstyled"}
-                      </PrimitiveText>
-                    </div>
-
-                    <PrimitiveButton
-                      type="button"
-                      onClick={() => removeSelectedItem(item.id)}
-                      variant="outline"
-                      size="icon"
-                      className="size-8 p-1.5"
-                      aria-label={`Remove ${item.name}`}
-                    >
-                      <X className="w-3.5 h-3.5" />
-                    </PrimitiveButton>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-
-          <div className="flex items-center gap-2">
-            <PrimitiveButton
-              type="submit"
-              disabled={isSaving}
-              variant="outline"
-            >
-              {editingOutfitId ? "Save Changes" : "Save Outfit"}
-            </PrimitiveButton>
-
-            {editingOutfitId ? (
-              <PrimitiveButton
-                type="button"
-                onClick={resetForm}
-                variant="outline"
-              >
-                Cancel Edit
-              </PrimitiveButton>
-            ) : null}
-          </div>
-        </form>
-      </section>
-
       <section className="space-y-4">
         {isLoading ? (
           <div className="grid gap-4 md:grid-cols-2">
@@ -395,85 +243,70 @@ export function MyOutfitsPage({
               No outfits yet
             </PrimitiveText>
             <PrimitiveText as="p" tone="muted">
-              Build your first look above and it will appear here.
+              Create your first look from the closet cart and it will appear here.
             </PrimitiveText>
           </div>
         ) : (
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-6 md:grid-cols-2">
             {outfits.map((outfit, index) => (
               <motion.article
                 key={outfit.id}
-                initial={{ opacity: 0, y: 10 }}
+                initial={{ opacity: 0, y: 18 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.25, delay: index * 0.03 }}
-                className="border border-border bg-card p-5 space-y-4"
+                transition={{ duration: 0.35, delay: index * 0.04 }}
+                className="overflow-hidden border border-border bg-card"
               >
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    <h3>{outfit.name}</h3>
-                    {outfit.tags && outfit.tags.length > 0 ? (
-                      <PrimitiveText as="p" variant="bodySm" tone="muted">
-                        {outfit.tags.join(" · ")}
+                <OutfitCollageCanvas items={outfit.items} maxVisibleItems={6} />
+
+                <div className="space-y-4 p-6">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <PrimitiveText as="p" variant="overline" tone="muted" className="mb-3">
+                        Saved Look
                       </PrimitiveText>
-                    ) : null}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <PrimitiveButton
-                      onClick={() => startEditing(outfit)}
-                      variant="outline"
-                      size="icon"
-                      aria-label="Edit outfit"
-                    >
-                      <Pencil className="w-4 h-4" />
-                    </PrimitiveButton>
-                    <PrimitiveButton
-                      onClick={() => void handleDelete(outfit.id)}
-                      variant="outline"
-                      size="icon"
-                      className="hover:border-destructive"
-                      aria-label="Delete outfit"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </PrimitiveButton>
-                  </div>
-                </div>
-
-                {outfit.notes ? (
-                  <PrimitiveText as="p" variant="bodySm" tone="muted">{outfit.notes}</PrimitiveText>
-                ) : null}
-
-                <div className="grid gap-2 sm:grid-cols-2">
-                  {outfit.items.map((item: ClothingItem) => (
-                    <PrimitiveButton
-                      key={item.id}
-                      onClick={() => onOpenItem(item.id)}
-                      variant="outline"
-                      className="h-auto w-full justify-start px-3 py-2 text-left"
-                    >
-                      <div className="flex items-center gap-3">
-                        <div className="h-9 w-9 shrink-0 border border-border rounded-full flex items-center justify-center bg-muted">
-                          {item.image_url ? (
-                            <img
-                              src={item.image_url}
-                              alt={item.name}
-                              className="h-full w-full rounded-full object-cover"
-                            />
-                          ) : (
-                            <PrimitiveText as="span" variant="caption">
-                              {buildPlaceholderLabel(item.name)}
-                            </PrimitiveText>
-                          )}
-                        </div>
-                        <div>
-                          <PrimitiveText as="p">{item.name}</PrimitiveText>
-                          <PrimitiveText as="p" variant="caption" tone="muted">
-                            <Shirt className="inline w-3 h-3 mr-1" />
-                            {item.tags.length > 0 ? formatTagLabel(item.tags[0]) : "Unstyled"}
+                      <PrimitiveText as="h3" variant="display" font="serif" className="break-words">
+                        {outfit.name}
+                      </PrimitiveText>
+                      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2">
+                        <PrimitiveText as="p" variant="bodySm" tone="muted">
+                          <Shirt className="mr-1 inline h-3 w-3" />
+                          {outfit.items.length} {outfit.items.length === 1 ? "piece" : "pieces"}
+                        </PrimitiveText>
+                        {outfit.tags && outfit.tags.length > 0 ? (
+                          <PrimitiveText as="p" variant="bodySm" tone="muted">
+                            {outfit.tags.join(" · ")}
                           </PrimitiveText>
-                        </div>
+                        ) : null}
                       </div>
-                    </PrimitiveButton>
-                  ))}
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <PrimitiveButton
+                        onClick={() => startEditing(outfit)}
+                        variant="outline"
+                        size="icon"
+                        aria-label="Edit outfit"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </PrimitiveButton>
+                      <PrimitiveButton
+                        onClick={() => void handleDelete(outfit.id)}
+                        variant="outline"
+                        size="icon"
+                        className="hover:border-destructive"
+                        aria-label="Delete outfit"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </PrimitiveButton>
+                    </div>
+                  </div>
+
+                  {outfit.notes ? (
+                    <PrimitiveText as="p" variant="bodySm" tone="muted" className="line-clamp-3">
+                      {outfit.notes}
+                    </PrimitiveText>
+                  ) : null}
+
                 </div>
               </motion.article>
             ))}
@@ -497,6 +330,134 @@ export function MyOutfitsPage({
           {flash.message}
         </motion.div>
       ) : null}
+
+      <Dialog open={Boolean(editingOutfitId)} onOpenChange={(open) => !open && resetForm()}>
+        <DialogContent className="w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] rounded-none border-border p-0 sm:w-[calc(100vw-3rem)] sm:max-w-[calc(100vw-3rem)] xl:max-w-[120rem] 2xl:max-w-[128rem]">
+          <div className="grid max-h-[90vh] overflow-hidden lg:grid-cols-[minmax(0,1.55fr)_minmax(28rem,0.95fr)] 2xl:grid-cols-[minmax(0,1.7fr)_minmax(32rem,0.9fr)]">
+            <div className="overflow-y-auto border-b border-border bg-stone-50 px-6 py-8 md:px-10 lg:border-b-0 lg:border-r lg:px-12">
+              <div
+                ref={formSectionRef}
+                className="flex h-full flex-col gap-6"
+              >
+                <PrimitiveText as="p" variant="overline" tone="muted">
+                  Outfit Preview
+                </PrimitiveText>
+                {editingOutfit ? (
+                  <>
+                    <div className="grid min-h-0 gap-4 lg:grid-cols-[5.75rem_minmax(0,1fr)] lg:items-start">
+                      <div className="min-w-0 lg:order-1">
+                        <OutfitCollageLayersPanel
+                          items={editingOutfit.items}
+                          layouts={editorLayouts}
+                          selectedItemId={selectedCollageItemId}
+                          onSelectItem={setSelectedCollageItemId}
+                          onReorder={(orderedItemIds) => {
+                            setEditorLayouts((current) => reorderCollageLayers(current, orderedItemIds));
+                            setFormState((current) => ({
+                              ...current,
+                              itemIds: orderedItemIds,
+                            }));
+                          }}
+                        />
+                      </div>
+                      <div className="min-w-0 lg:order-2">
+                        <OutfitCollageCanvas
+                          items={editingOutfit.items}
+                          layouts={editorLayouts}
+                          editable
+                          selectedItemId={selectedCollageItemId}
+                          onSelectItem={setSelectedCollageItemId}
+                          onLayoutsChange={setEditorLayouts}
+                          className="mx-auto w-full max-w-[72rem]"
+                        />
+                      </div>
+                    </div>
+                  </>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="overflow-y-auto p-6 lg:p-8 xl:p-10">
+              <DialogHeader className="mb-6 text-left sm:text-left">
+                <DialogTitle asChild>
+                  <PrimitiveText as="h2" variant="display" font="serif">
+                    Edit Outfit
+                  </PrimitiveText>
+                </DialogTitle>
+                <DialogDescription asChild>
+                  <PrimitiveText as="p" tone="muted">
+                    Update the saved outfit details while keeping the current look in view.
+                  </PrimitiveText>
+                </DialogDescription>
+              </DialogHeader>
+
+              <form onSubmit={handleSubmit} className="space-y-5">
+                <label className="block space-y-2">
+                  <PrimitiveText as="span" variant="bodySm" tone="muted">
+                    Title
+                  </PrimitiveText>
+                  <Input
+                    value={formState.name}
+                    onChange={(event) => setFormField("name", event.target.value)}
+                    placeholder="Weekend Brunch"
+                    maxLength={MAX_OUTFIT_NAME}
+                  />
+                </label>
+
+                <label className="block space-y-2">
+                  <PrimitiveText as="span" variant="bodySm" tone="muted">
+                    Tags
+                  </PrimitiveText>
+                  <Input
+                    value={formState.tagInput}
+                    onChange={(event) => setFormField("tagInput", event.target.value)}
+                    placeholder="casual, spring"
+                  />
+                </label>
+
+                <label className="block space-y-2">
+                  <PrimitiveText as="span" variant="bodySm" tone="muted">
+                    Notes
+                  </PrimitiveText>
+                  <Textarea
+                    value={formState.notes}
+                    onChange={(event) => setFormField("notes", event.target.value)}
+                    placeholder="When and where to wear this look"
+                    className="min-h-32"
+                    maxLength={MAX_OUTFIT_NOTES}
+                  />
+                </label>
+
+                {selectedItems.length > 0 ? (
+                  <div className="space-y-2">
+                    <PrimitiveText as="p" variant="bodySm" tone="muted">
+                      Included pieces
+                    </PrimitiveText>
+                    <div className="flex flex-wrap gap-2">
+                      {selectedItems.map((item) => (
+                        <div key={item.id} className="border border-border bg-card px-3 py-2">
+                          <PrimitiveText as="span" variant="bodySm">
+                            {item.name}
+                          </PrimitiveText>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                <DialogFooter className="pt-2 sm:justify-start">
+                  <PrimitiveButton type="submit" disabled={isSaving} variant="outline">
+                    Save Changes
+                  </PrimitiveButton>
+                  <PrimitiveButton type="button" onClick={resetForm} variant="outline">
+                    Cancel
+                  </PrimitiveButton>
+                </DialogFooter>
+              </form>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/front-end/src/app/components/MyOutfitsPage.tsx
+++ b/front-end/src/app/components/MyOutfitsPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import { motion } from "motion/react";
 import { Pencil, Shirt, Trash2 } from "lucide-react";
 import {
@@ -11,7 +11,8 @@ import {
   updateOutfit,
   User,
 } from "../lib/closet";
-import { OutfitCollageCanvas, OutfitCollageLayersPanel } from "./OutfitCollageCanvas";
+import { OutfitCollageCanvas } from "./OutfitCollageCanvas";
+import { OutfitCollageLayersPanel } from "./OutfitCollageLayersPanel";
 import {
   OutfitCollageLayout,
   reorderCollageLayers,
@@ -65,7 +66,6 @@ export function MyOutfitsPage({
   const [editorLayouts, setEditorLayouts] = useState<Record<number, OutfitCollageLayout>>({});
   const [selectedCollageItemId, setSelectedCollageItemId] = useState<number | null>(null);
   const [isSaving, setIsSaving] = useState(false);
-  const formSectionRef = useRef<HTMLElement | null>(null);
 
   const sortedItems = useMemo(
     () => [...user.clothing_items].sort((left, right) => left.name.localeCompare(right.name)),
@@ -247,16 +247,22 @@ export function MyOutfitsPage({
             </PrimitiveText>
           </div>
         ) : (
-          <div className="grid gap-6 md:grid-cols-2">
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             {outfits.map((outfit, index) => (
               <motion.article
                 key={outfit.id}
                 initial={{ opacity: 0, y: 18 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.35, delay: index * 0.04 }}
-                className="overflow-hidden border border-border bg-card"
+                className="mx-auto w-full max-w-[22rem] overflow-hidden border border-border bg-card"
               >
-                <OutfitCollageCanvas items={outfit.items} maxVisibleItems={6} />
+                <div className="px-5 pt-5">
+                  <OutfitCollageCanvas
+                    items={outfit.items}
+                    maxVisibleItems={6}
+                    className="mx-auto w-full max-w-[15.5rem]"
+                  />
+                </div>
 
                 <div className="space-y-4 p-6">
                   <div className="flex items-start justify-between gap-4">
@@ -314,11 +320,11 @@ export function MyOutfitsPage({
         )}
       </section>
 
-      {flash ? (
+      {flash && !editingOutfitId ? (
         <motion.div
           initial={{ opacity: 0, y: 12 }}
           animate={{ opacity: 1, y: 0 }}
-          className={`fixed bottom-6 right-6 z-50 max-w-sm border px-4 py-3 text-sm shadow-lg backdrop-blur ${
+          className={`fixed bottom-6 right-6 z-[70] max-w-sm border px-4 py-3 text-sm shadow-lg backdrop-blur ${
             flash.kind === "success"
               ? "border-foreground/20 bg-background/95 text-foreground"
               : "border-destructive/25 bg-destructive/10 text-destructive"
@@ -333,19 +339,16 @@ export function MyOutfitsPage({
 
       <Dialog open={Boolean(editingOutfitId)} onOpenChange={(open) => !open && resetForm()}>
         <DialogContent className="w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] rounded-none border-border p-0 sm:w-[calc(100vw-3rem)] sm:max-w-[calc(100vw-3rem)] xl:max-w-[120rem] 2xl:max-w-[128rem]">
-          <div className="grid max-h-[90vh] overflow-hidden lg:grid-cols-[minmax(0,1.55fr)_minmax(28rem,0.95fr)] 2xl:grid-cols-[minmax(0,1.7fr)_minmax(32rem,0.9fr)]">
-            <div className="overflow-y-auto border-b border-border bg-stone-50 px-6 py-8 md:px-10 lg:border-b-0 lg:border-r lg:px-12">
-              <div
-                ref={formSectionRef}
-                className="flex h-full flex-col gap-6"
-              >
+          <div className="max-h-[90vh] overflow-y-auto lg:grid lg:overflow-hidden lg:grid-cols-[minmax(0,1.55fr)_minmax(28rem,0.95fr)] 2xl:grid-cols-[minmax(0,1.7fr)_minmax(32rem,0.9fr)]">
+            <div className="min-h-[calc(100svh-8rem)] border-b border-border bg-stone-50 px-5 py-6 md:px-8 lg:min-h-0 lg:overflow-y-auto lg:border-b-0 lg:border-r lg:px-10">
+              <div className="flex h-full min-h-0 flex-col gap-4">
                 <PrimitiveText as="p" variant="overline" tone="muted">
                   Outfit Preview
                 </PrimitiveText>
                 {editingOutfit ? (
                   <>
-                    <div className="grid min-h-0 gap-4 lg:grid-cols-[5.75rem_minmax(0,1fr)] lg:items-start">
-                      <div className="min-w-0 lg:order-1">
+                    <div className="grid min-h-0 flex-1 grid-cols-[4.5rem_minmax(0,1fr)] items-center gap-3 sm:grid-cols-[5rem_minmax(0,1fr)] sm:gap-4 lg:grid-cols-[5.75rem_minmax(0,1fr)]">
+                      <div className="min-w-0">
                         <OutfitCollageLayersPanel
                           items={editingOutfit.items}
                           layouts={editorLayouts}
@@ -360,7 +363,8 @@ export function MyOutfitsPage({
                           }}
                         />
                       </div>
-                      <div className="min-w-0 lg:order-2">
+                      <div className="min-w-0">
+                        <div className="mx-auto w-full max-w-[min(20rem,calc((100vh-20rem)*0.8))] bg-white shadow-[0_24px_70px_rgba(15,23,42,0.16)] sm:max-w-[min(32rem,calc((100vh-22rem)*0.8))] lg:max-w-[min(72rem,calc((100vh-16rem)*0.8))]">
                         <OutfitCollageCanvas
                           items={editingOutfit.items}
                           layouts={editorLayouts}
@@ -368,8 +372,9 @@ export function MyOutfitsPage({
                           selectedItemId={selectedCollageItemId}
                           onSelectItem={setSelectedCollageItemId}
                           onLayoutsChange={setEditorLayouts}
-                          className="mx-auto w-full max-w-[72rem]"
+                          className="w-full"
                         />
+                        </div>
                       </div>
                     </div>
                   </>
@@ -377,7 +382,7 @@ export function MyOutfitsPage({
               </div>
             </div>
 
-            <div className="overflow-y-auto p-6 lg:p-8 xl:p-10">
+            <div className="p-6 lg:overflow-y-auto lg:p-8 xl:p-10">
               <DialogHeader className="mb-6 text-left sm:text-left">
                 <DialogTitle asChild>
                   <PrimitiveText as="h2" variant="display" font="serif">
@@ -390,6 +395,23 @@ export function MyOutfitsPage({
                   </PrimitiveText>
                 </DialogDescription>
               </DialogHeader>
+
+              {flash ? (
+                <motion.div
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className={`mb-5 border px-4 py-3 text-sm ${
+                    flash.kind === "success"
+                      ? "border-foreground/20 bg-background text-foreground"
+                      : "border-destructive/25 bg-destructive/10 text-destructive"
+                  }`}
+                  role={flash.kind === "error" ? "alert" : "status"}
+                  aria-live={flash.kind === "error" ? "assertive" : "polite"}
+                  aria-atomic="true"
+                >
+                  {flash.message}
+                </motion.div>
+              ) : null}
 
               <form onSubmit={handleSubmit} className="space-y-5">
                 <label className="block space-y-2">

--- a/front-end/src/app/components/OutfitCartSheet.tsx
+++ b/front-end/src/app/components/OutfitCartSheet.tsx
@@ -1,0 +1,211 @@
+import { ShoppingBag, Trash2 } from "lucide-react";
+import { ClothingItem, buildItemPreviewMetadata } from "../lib/closet";
+import { MAX_OUTFIT_NAME, MAX_OUTFIT_NOTES } from "../lib/inputLengthPolicy";
+import { Input } from "./ui/input";
+import { Textarea } from "./ui/textarea";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "./ui/sheet";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
+import { PrimitiveText } from "./primitives/PrimitiveText";
+
+interface OutfitCartSheetProps {
+  createErrorMessage?: string;
+  isCreating: boolean;
+  isOpen: boolean;
+  items: ClothingItem[];
+  onCreateOutfit: () => void;
+  onOpenChange: (open: boolean) => void;
+  onRemoveItem: (itemId: number) => void;
+  onTagInputChange: (value: string) => void;
+  onNotesChange: (value: string) => void;
+  onOutfitNameChange: (value: string) => void;
+  notes: string;
+  outfitName: string;
+  tagInput: string;
+}
+
+export function OutfitCartSheet({
+  createErrorMessage = "",
+  isCreating,
+  isOpen,
+  items,
+  onCreateOutfit,
+  onOpenChange,
+  onRemoveItem,
+  onTagInputChange,
+  onNotesChange,
+  onOutfitNameChange,
+  notes,
+  outfitName,
+  tagInput,
+}: OutfitCartSheetProps) {
+  const itemCount = items.length;
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full border-l border-border bg-stone-50 p-0 sm:max-w-md">
+        <SheetHeader className="gap-2 border-b border-border px-5 py-4 pr-14">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-foreground text-background">
+              <ShoppingBag className="h-4 w-4" />
+            </div>
+            <div>
+              <SheetTitle asChild>
+                <PrimitiveText as="h2" variant="title" font="serif">
+                  Outfit Cart
+                </PrimitiveText>
+              </SheetTitle>
+              {itemCount > 0 ? (
+                <SheetDescription asChild>
+                  <PrimitiveText as="p" variant="bodySm" tone="muted">
+                    {itemCount} {itemCount === 1 ? "piece" : "pieces"} ready to turn into an outfit.
+                  </PrimitiveText>
+                </SheetDescription>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="grid gap-3">
+            <div className="space-y-2">
+              <label htmlFor="outfit-cart-name" className="block">
+                <PrimitiveText as="p" variant="bodySm" tone="muted">
+                  Outfit name
+                </PrimitiveText>
+              </label>
+              <Input
+                id="outfit-cart-name"
+                value={outfitName}
+                onChange={(event) => onOutfitNameChange(event.target.value)}
+                placeholder="Optional now, editable later"
+                className="h-10 bg-white"
+                maxLength={MAX_OUTFIT_NAME}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="outfit-cart-tags" className="block">
+                <PrimitiveText as="span" variant="bodySm" tone="muted">
+                  Tags
+                </PrimitiveText>
+              </label>
+              <Input
+                id="outfit-cart-tags"
+                value={tagInput}
+                onChange={(event) => onTagInputChange(event.target.value)}
+                placeholder="ex. date night, spring, casual"
+                className="h-10 bg-white"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="outfit-cart-notes" className="block">
+                <PrimitiveText as="span" variant="bodySm" tone="muted">
+                  Notes
+                </PrimitiveText>
+              </label>
+              <Textarea
+                id="outfit-cart-notes"
+                value={notes}
+                onChange={(event) => onNotesChange(event.target.value)}
+                placeholder="Add styling notes, occasion ideas, or reminders."
+                className="min-h-20 bg-white py-2"
+                maxLength={MAX_OUTFIT_NOTES}
+              />
+            </div>
+          </div>
+        </SheetHeader>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {createErrorMessage ? (
+            <div className="mb-3 border border-destructive/20 bg-destructive/5 p-3">
+              <PrimitiveText as="p" variant="bodySm" tone="destructive">
+                {createErrorMessage}
+              </PrimitiveText>
+            </div>
+          ) : null}
+
+          {itemCount === 0 ? (
+            <div className="flex h-full min-h-52 flex-col items-center justify-center gap-2 border border-dashed border-border bg-white/70 px-5 text-center">
+              <PrimitiveText as="h3" variant="title" font="serif">
+                Your cart is empty
+              </PrimitiveText>
+              <PrimitiveText as="p" variant="bodySm" tone="muted">
+                Tap Add to Outfit on any closet card and it will appear here.
+              </PrimitiveText>
+            </div>
+          ) : (
+            <div className="space-y-2.5">
+              {items.map((item) => {
+                const metadata = buildItemPreviewMetadata(item.size, item.tags);
+
+                return (
+                  <div
+                    key={item.id}
+                    className="flex items-start gap-3 border border-border bg-white p-2.5 shadow-sm"
+                  >
+                    <div className="h-20 w-16 shrink-0 overflow-hidden bg-stone-200">
+                      {item.image_url ? (
+                        <img
+                          src={item.image_url}
+                          alt={item.name}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-full items-end bg-gradient-to-br from-stone-200 via-stone-100 to-stone-300 p-3">
+                          <PrimitiveText as="span" variant="overline">
+                            {item.category || "Closet piece"}
+                          </PrimitiveText>
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="min-w-0 flex-1">
+                      <PrimitiveText as="h3" variant="title" font="serif" className="break-words">
+                        {item.name}
+                      </PrimitiveText>
+                      {metadata ? (
+                        <PrimitiveText as="p" variant="bodySm" tone="muted" className="mt-0.5">
+                          {metadata}
+                        </PrimitiveText>
+                      ) : null}
+                    </div>
+
+                    <PrimitiveButton
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Remove ${item.name} from outfit`}
+                      onClick={() => onRemoveItem(item.id)}
+                      className="mt-0.5 h-8 w-8 shrink-0"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </PrimitiveButton>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <SheetFooter className="border-t border-border bg-background px-5 py-4">
+          <div className="space-y-3">
+            <PrimitiveButton
+              type="button"
+              onClick={onCreateOutfit}
+              disabled={itemCount === 0 || isCreating}
+              className="h-auto w-full px-5 py-3 text-base"
+            >
+              {isCreating ? "Creating outfit..." : "Create Outfit"}
+            </PrimitiveButton>
+          </div>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front-end/src/app/components/OutfitCollageCanvas.tsx
+++ b/front-end/src/app/components/OutfitCollageCanvas.tsx
@@ -8,7 +8,11 @@ import Moveable, {
   type OnResizeEnd,
   type OnResizeStart,
 } from "react-moveable";
-import { ClothingItem, buildPlaceholderLabel } from "../lib/closet";
+import { ClothingItem } from "../lib/closet";
+import {
+  ImageContentBounds,
+  measureImageContentBounds,
+} from "../lib/outfitImageBounds";
 import {
   clampCollageLayout,
   OutfitCollageLayout,
@@ -37,7 +41,6 @@ interface OutfitCollageCanvasProps {
   onSelectItem?: (itemId: number | null) => void;
   selectedItemId?: number | null;
 }
-
 export function OutfitCollageCanvas({
   className = "",
   editable = false,
@@ -53,6 +56,7 @@ export function OutfitCollageCanvas({
   const itemFrameRefs = useRef<Record<number, HTMLDivElement | null>>({});
   const transientRotationByItemId = useRef<Record<number, number>>({});
   const activeRotationGestureRef = useRef<ActiveRotationGesture | null>(null);
+  const [imageContentBoundsByItemId, setImageContentBoundsByItemId] = useState<Record<number, ImageContentBounds>>({});
   const [imageAspectRatioByItemId, setImageAspectRatioByItemId] = useState<Record<number, number>>({});
 
   const resolvedLayouts = useMemo(
@@ -70,51 +74,61 @@ export function OutfitCollageCanvas({
       Object.fromEntries(
         visibleItems.map((item) => [
           item.id,
-          normalizeLayoutToAspectRatio(resolvedLayouts[item.id], imageAspectRatioByItemId[item.id]),
+          normalizeLayoutToAspectRatio(
+            resolvedLayouts[item.id],
+            imageContentBoundsByItemId[item.id]?.aspectRatio ?? imageAspectRatioByItemId[item.id],
+          ),
         ]),
       ) as Record<number, OutfitCollageLayout>,
-    [imageAspectRatioByItemId, resolvedLayouts, visibleItems],
+    [imageAspectRatioByItemId, imageContentBoundsByItemId, resolvedLayouts, visibleItems],
   );
   const selectedTarget = editable && selectedItemId ? itemFrameRefs.current[selectedItemId] : null;
-  const displayLayouts = editable ? resolvedLayouts : normalizedLayouts;
+  const displayLayouts = normalizedLayouts;
+
+  function syncFrameToPercentLayout(itemId: number, layout: OutfitCollageLayout) {
+    const target = itemFrameRefs.current[itemId];
+    if (!target) {
+      return;
+    }
+
+    target.style.left = `${layout.x}%`;
+    target.style.top = `${layout.y}%`;
+    target.style.width = `${layout.width}%`;
+    target.style.height = `${layout.height}%`;
+    target.style.transform = `rotate(${layout.rotation}deg)`;
+  }
+
+  function syncFrameToPixelLayout(itemId: number, layout: OutfitCollageLayout, stageBounds: DOMRect) {
+    const target = itemFrameRefs.current[itemId];
+    if (!target) {
+      return;
+    }
+
+    target.style.left = `${(layout.x / 100) * stageBounds.width}px`;
+    target.style.top = `${(layout.y / 100) * stageBounds.height}px`;
+    target.style.width = `${(layout.width / 100) * stageBounds.width}px`;
+    target.style.height = `${(layout.height / 100) * stageBounds.height}px`;
+    target.style.transform = `rotate(${layout.rotation}deg)`;
+  }
 
   useLayoutEffect(() => {
-    if (editable && selectedItemId) {
-      pinItemFrameToPixels(selectedItemId);
-    }
+    visibleItems.forEach((item) => {
+      const layout = displayLayouts[item.id] ?? resolvedLayouts[item.id];
+      if (!layout) {
+        return;
+      }
 
-    moveableRef.current?.updateRect();
-  }, [displayLayouts, editable, selectedItemId]);
-
-  useEffect(() => {
-    if (!editable || !onLayoutsChange) {
-      return;
-    }
-
-    const nextEntries = visibleItems
-      .map((item) => {
-        const currentLayout = resolvedLayouts[item.id];
-        const normalizedLayout = normalizeLayoutToAspectRatio(currentLayout, imageAspectRatioByItemId[item.id]);
-        return layoutsDiffer(currentLayout, normalizedLayout) ? [item.id, normalizedLayout] : null;
-      })
-      .filter((entry): entry is [number, OutfitCollageLayout] => Boolean(entry));
-
-    if (nextEntries.length === 0) {
-      return;
-    }
-
-    onLayoutsChange({
-      ...resolvedLayouts,
-      ...Object.fromEntries(nextEntries),
+      syncFrameToPercentLayout(item.id, layout);
     });
-  }, [editable, imageAspectRatioByItemId, onLayoutsChange, resolvedLayouts, visibleItems]);
+    moveableRef.current?.updateRect();
+  }, [displayLayouts, resolvedLayouts, selectedItemId, visibleItems]);
 
   function updateItemLayout(itemId: number, nextPartial: Partial<OutfitCollageLayout>) {
     if (!onLayoutsChange) {
       return;
     }
 
-    const baseLayout = resolvedLayouts[itemId];
+    const baseLayout = displayLayouts[itemId] ?? resolvedLayouts[itemId];
     const nextLayout = clampCollageLayout({
       ...baseLayout,
       ...nextPartial,
@@ -155,7 +169,9 @@ export function OutfitCollageCanvas({
     activeRotationGestureRef.current = {
       itemId,
       startPointerAngle: pointAngleFromRectCenter(frameRect, clientX, clientY),
-      startRotation: transientRotationByItemId.current[itemId] ?? resolvedLayouts[itemId].rotation,
+      startRotation:
+        transientRotationByItemId.current[itemId]
+        ?? (displayLayouts[itemId] ?? resolvedLayouts[itemId]).rotation,
     };
   }
 
@@ -173,7 +189,12 @@ export function OutfitCollageCanvas({
     }
 
     pinItemFrameToPixels(selectedItemId);
-    event.setRatio(imageAspectRatioByItemId[selectedItemId] ?? (resolvedLayouts[selectedItemId].width / Math.max(resolvedLayouts[selectedItemId].height, 0.001)));
+    const selectedLayout = displayLayouts[selectedItemId] ?? resolvedLayouts[selectedItemId];
+    event.setRatio(
+      imageContentBoundsByItemId[selectedItemId]?.aspectRatio
+      ?? imageAspectRatioByItemId[selectedItemId]
+      ?? (selectedLayout.width / Math.max(selectedLayout.height, 0.001)),
+    );
     event.dragStart?.set([ 0, 0 ]);
   }
 
@@ -218,37 +239,37 @@ export function OutfitCollageCanvas({
   }
 
   function pinItemFrameToPixels(itemId: number) {
-    const target = itemFrameRefs.current[itemId];
     const stageBounds = stageRef.current?.getBoundingClientRect();
-    const layout = resolvedLayouts[itemId];
+    const layout = displayLayouts[itemId] ?? resolvedLayouts[itemId];
 
-    if (!target || !stageBounds) {
+    if (!stageBounds) {
       return;
     }
 
-    target.style.left = `${(layout.x / 100) * stageBounds.width}px`;
-    target.style.top = `${(layout.y / 100) * stageBounds.height}px`;
-    target.style.width = `${(layout.width / 100) * stageBounds.width}px`;
-    target.style.height = `${(layout.height / 100) * stageBounds.height}px`;
-    target.style.transform = `rotate(${layout.rotation}deg)`;
+    syncFrameToPixelLayout(itemId, layout, stageBounds);
     transientRotationByItemId.current[itemId] = layout.rotation;
   }
 
   function commitItemFrameFromPixels(itemId: number) {
     const target = itemFrameRefs.current[itemId];
     const stageBounds = stageRef.current?.getBoundingClientRect();
+    const baseLayout = displayLayouts[itemId] ?? resolvedLayouts[itemId];
 
-    if (!target || !stageBounds) {
+    if (!target || !stageBounds || !baseLayout) {
       return;
     }
 
-    updateItemLayout(itemId, {
+    const nextLayout = clampCollageLayout({
+      ...baseLayout,
       x: pixelsToPercent(parseFloat(target.style.left || "0"), stageBounds.width),
       y: pixelsToPercent(parseFloat(target.style.top || "0"), stageBounds.height),
       width: Math.max(MIN_ITEM_SIZE_PERCENT, pixelsToPercent(parseFloat(target.style.width || "0"), stageBounds.width)),
       height: Math.max(MIN_ITEM_SIZE_PERCENT, pixelsToPercent(parseFloat(target.style.height || "0"), stageBounds.height)),
       rotation: transientRotationByItemId.current[itemId] ?? 0,
     });
+
+    syncFrameToPercentLayout(itemId, nextLayout);
+    updateItemLayout(itemId, nextLayout);
   }
 
   useEffect(() => {
@@ -290,12 +311,15 @@ export function OutfitCollageCanvas({
       window.removeEventListener("pointerup", handleWindowPointerEnd);
       window.removeEventListener("pointercancel", handleWindowPointerEnd);
     };
-  }, [resolvedLayouts]);
+  }, [displayLayouts, resolvedLayouts]);
   return (
     <div
       ref={stageRef}
-      className={`relative aspect-[4/5] overflow-hidden bg-gradient-to-br from-stone-100 via-white to-stone-100 ${editable ? "touch-none" : ""} ${className}`.trim()}
-      style={editable ? ({ "--moveable-color": "#111111" } as CSSProperties) : undefined}
+      className={`relative overflow-hidden bg-white ${editable ? "touch-none" : ""} ${className}`.trim()}
+      style={{
+        aspectRatio: String(COLLAGE_STAGE_ASPECT_RATIO),
+        ...(editable ? ({ "--moveable-color": "#111111" } as CSSProperties) : {}),
+      }}
       onPointerDown={handleStagePointerDown}
     >
       {visibleItems.map((item, index) => {
@@ -330,23 +354,51 @@ export function OutfitCollageCanvas({
               event.stopPropagation();
               onSelectItem?.(item.id);
             }}
+            onKeyDown={(event) => {
+              if (event.key !== "Enter" && event.key !== " ") {
+                return;
+              }
+
+              event.preventDefault();
+              onSelectItem?.(item.id);
+            }}
           >
             <div className="relative h-full w-full overflow-hidden bg-transparent">
               {item.image_url ? (
                 <img
                   src={item.image_url}
                   alt={item.name}
-                  className="pointer-events-none h-full w-full object-contain drop-shadow-[0_10px_18px_rgba(0,0,0,0.12)]"
+                  className="pointer-events-none absolute max-w-none"
+                  style={imageStyleForContentBounds(imageContentBoundsByItemId[item.id])}
                   onLoad={(event) => {
-                    const nextRatio = event.currentTarget.naturalWidth / Math.max(1, event.currentTarget.naturalHeight);
+                    const nextAspectRatio = event.currentTarget.naturalWidth / Math.max(1, event.currentTarget.naturalHeight);
                     setImageAspectRatioByItemId((current) =>
-                      nearlyEqual(current[item.id] ?? 0, nextRatio)
+                      nearlyEqual(current[item.id] ?? 0, nextAspectRatio, 0.001)
                         ? current
                         : {
                             ...current,
-                            [item.id]: nextRatio,
+                            [item.id]: nextAspectRatio,
                           },
                     );
+                    void measureImageContentBounds({
+                      imageUrl: item.image_url,
+                    }).then((nextBounds) => {
+                      if (!nextBounds) {
+                        return;
+                      }
+
+                      setImageContentBoundsByItemId((current) => {
+                        const previous = current[item.id];
+                        if (previous && imageContentBoundsEqual(previous, nextBounds)) {
+                          return current;
+                        }
+
+                        return {
+                          ...current,
+                          [item.id]: nextBounds,
+                        };
+                      });
+                    });
                   }}
                 />
               ) : (
@@ -432,19 +484,37 @@ function normalizeLayoutToAspectRatio(
   });
 }
 
-function nearlyEqual(left: number, right: number, tolerance = 0.002) {
-  return Math.abs(left - right) <= tolerance;
+function imageStyleForContentBounds(bounds?: ImageContentBounds): CSSProperties {
+  if (!bounds) {
+    return {
+      height: "100%",
+      left: 0,
+      objectFit: "contain",
+      top: 0,
+      width: "100%",
+    };
+  }
+
+  return {
+    height: `${100 / bounds.heightFraction}%`,
+    left: `${-(bounds.leftFraction / bounds.widthFraction) * 100}%`,
+    top: `${-(bounds.topFraction / bounds.heightFraction) * 100}%`,
+    width: `${100 / bounds.widthFraction}%`,
+  };
 }
 
-function layoutsDiffer(left: OutfitCollageLayout, right: OutfitCollageLayout) {
+function imageContentBoundsEqual(left: ImageContentBounds, right: ImageContentBounds) {
   return (
-    !nearlyEqual(left.x, right.x)
-    || !nearlyEqual(left.y, right.y)
-    || !nearlyEqual(left.width, right.width)
-    || !nearlyEqual(left.height, right.height)
-    || !nearlyEqual(left.rotation, right.rotation)
-    || left.layer_order !== right.layer_order
+    nearlyEqual(left.leftFraction, right.leftFraction, 0.001)
+    && nearlyEqual(left.topFraction, right.topFraction, 0.001)
+    && nearlyEqual(left.widthFraction, right.widthFraction, 0.001)
+    && nearlyEqual(left.heightFraction, right.heightFraction, 0.001)
+    && nearlyEqual(left.aspectRatio, right.aspectRatio, 0.001)
   );
+}
+
+function nearlyEqual(left: number, right: number, tolerance = 0.002) {
+  return Math.abs(left - right) <= tolerance;
 }
 
 function pointAngleFromRectCenter(rect: DOMRect, clientX: number, clientY: number) {
@@ -459,142 +529,4 @@ function pixelsToPercent(value: number, total: number) {
   }
 
   return (value / total) * 100;
-}
-
-interface OutfitCollageLayersPanelProps {
-  items: ClothingItem[];
-  layouts: Record<number, OutfitCollageLayout>;
-  onReorder: (orderedItemIds: number[]) => void;
-  onSelectItem: (itemId: number) => void;
-  selectedItemId?: number | null;
-}
-
-export function OutfitCollageLayersPanel({
-  items,
-  layouts,
-  onReorder,
-  onSelectItem,
-  selectedItemId = null,
-}: OutfitCollageLayersPanelProps) {
-  const orderedItems = useMemo(
-    () => [...sortItemsByCollageLayer(items, layouts)].reverse(),
-    [items, layouts],
-  );
-  const [draggingItemId, setDraggingItemId] = useState<number | null>(null);
-  const [dragHoverItemId, setDragHoverItemId] = useState<number | null>(null);
-  const lastDropTargetIdRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (!draggingItemId) {
-      return;
-    }
-
-    function handleWindowPointerMove(event: PointerEvent) {
-      const hoveredElement = document.elementFromPoint(event.clientX, event.clientY);
-      const layerButton = hoveredElement instanceof HTMLElement
-        ? hoveredElement.closest<HTMLElement>("[data-layer-item-id]")
-        : null;
-
-      if (!layerButton) {
-        setDragHoverItemId(null);
-        return;
-      }
-
-      const targetItemId = Number(layerButton.dataset.layerItemId);
-      if (!Number.isFinite(targetItemId)) {
-        return;
-      }
-
-      setDragHoverItemId(targetItemId);
-      if (lastDropTargetIdRef.current === targetItemId) {
-        return;
-      }
-
-      reorderItems(draggingItemId, targetItemId);
-      lastDropTargetIdRef.current = targetItemId;
-    }
-
-    function handleWindowPointerUp() {
-      setDraggingItemId(null);
-      setDragHoverItemId(null);
-      lastDropTargetIdRef.current = null;
-    }
-
-    window.addEventListener("pointermove", handleWindowPointerMove);
-    window.addEventListener("pointerup", handleWindowPointerUp);
-    window.addEventListener("pointercancel", handleWindowPointerUp);
-
-    return () => {
-      window.removeEventListener("pointermove", handleWindowPointerMove);
-      window.removeEventListener("pointerup", handleWindowPointerUp);
-      window.removeEventListener("pointercancel", handleWindowPointerUp);
-    };
-  }, [draggingItemId]);
-
-  function reorderItems(draggedItemId: number, targetItemId: number) {
-    if (draggedItemId === targetItemId) {
-      return;
-    }
-
-    const reordered = [...orderedItems];
-    const draggingIndex = reordered.findIndex((entry) => entry.id === draggedItemId);
-    const targetIndex = reordered.findIndex((entry) => entry.id === targetItemId);
-    if (draggingIndex < 0 || targetIndex < 0) {
-      return;
-    }
-
-    const [draggingItem] = reordered.splice(draggingIndex, 1);
-    reordered.splice(targetIndex, 0, draggingItem);
-    onReorder([...reordered].reverse().map((entry) => entry.id));
-  }
-
-  function handleLayerPointerDown(itemId: number) {
-    onSelectItem(itemId);
-    setDraggingItemId(itemId);
-    setDragHoverItemId(itemId);
-    lastDropTargetIdRef.current = itemId;
-  }
-
-  return (
-    <div className="flex h-full min-h-0 flex-col gap-3 border border-border bg-card/90 p-3">
-      <PrimitiveText as="p" variant="overline" tone="muted">
-        Layers
-      </PrimitiveText>
-      <div className="flex min-h-0 flex-col gap-2 overflow-y-auto">
-        {orderedItems.map((item) => {
-          const isSelected = selectedItemId === item.id;
-
-          return (
-            <button
-              key={item.id}
-              type="button"
-              data-layer-item-id={item.id}
-              onClick={() => onSelectItem(item.id)}
-              onPointerDown={(event) => {
-                event.preventDefault();
-                handleLayerPointerDown(item.id);
-              }}
-              className={`group flex aspect-[3/4] w-full items-center justify-center overflow-hidden border bg-background transition-colors ${
-                isSelected ? "border-foreground shadow-[0_0_0_1px_rgba(17,17,17,0.18)]" : "border-border hover:bg-stone-50"
-              } ${
-                draggingItemId === item.id ? "cursor-grabbing opacity-80" : "cursor-grab"
-              } ${
-                dragHoverItemId === item.id && draggingItemId && draggingItemId !== item.id ? "border-foreground/70 bg-stone-50" : ""
-              }`}
-              aria-label={`Select layer ${item.name}`}
-              title={item.name}
-            >
-              {item.image_url ? (
-                <img src={item.image_url} alt="" className="h-full w-full object-cover" />
-              ) : (
-                <PrimitiveText as="span" variant="bodySm" tone="muted">
-                  {buildPlaceholderLabel(item.name) || "?"}
-                </PrimitiveText>
-              )}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
 }

--- a/front-end/src/app/components/OutfitCollageCanvas.tsx
+++ b/front-end/src/app/components/OutfitCollageCanvas.tsx
@@ -19,11 +19,15 @@ import {
   resolveOutfitCollageLayouts,
   sortItemsByCollageLayer,
 } from "../lib/outfitCollage";
+import {
+  COLLAGE_STAGE_ASPECT_RATIO,
+  normalizeOutfitCollageLayoutToAspectRatio,
+  resolveOutfitCollageResizeAspectRatio,
+} from "../lib/outfitCollageRenderMath";
 import { PrimitiveText } from "./primitives/PrimitiveText";
 
 const MOVEABLE_RENDER_DIRECTIONS = [ "nw", "ne", "sw", "se" ] as const;
 const MIN_ITEM_SIZE_PERCENT = 8;
-const COLLAGE_STAGE_ASPECT_RATIO = 4 / 5;
 
 interface ActiveRotationGesture {
   itemId: number;
@@ -74,7 +78,7 @@ export function OutfitCollageCanvas({
       Object.fromEntries(
         visibleItems.map((item) => [
           item.id,
-          normalizeLayoutToAspectRatio(
+          normalizeOutfitCollageLayoutToAspectRatio(
             resolvedLayouts[item.id],
             imageContentBoundsByItemId[item.id]?.aspectRatio ?? imageAspectRatioByItemId[item.id],
           ),
@@ -190,11 +194,11 @@ export function OutfitCollageCanvas({
 
     pinItemFrameToPixels(selectedItemId);
     const selectedLayout = displayLayouts[selectedItemId] ?? resolvedLayouts[selectedItemId];
-    event.setRatio(
-      imageContentBoundsByItemId[selectedItemId]?.aspectRatio
-      ?? imageAspectRatioByItemId[selectedItemId]
-      ?? (selectedLayout.width / Math.max(selectedLayout.height, 0.001)),
-    );
+    event.setRatio(resolveOutfitCollageResizeAspectRatio({
+      contentBoundsAspectRatio: imageContentBoundsByItemId[selectedItemId]?.aspectRatio,
+      intrinsicAspectRatio: imageAspectRatioByItemId[selectedItemId],
+      layout: selectedLayout,
+    }));
     event.dragStart?.set([ 0, 0 ]);
   }
 
@@ -448,40 +452,6 @@ export function OutfitCollageCanvas({
       ) : null}
     </div>
   );
-}
-
-function normalizeLayoutToAspectRatio(
-  layout: OutfitCollageLayout,
-  aspectRatio?: number,
-): OutfitCollageLayout {
-  if (!aspectRatio || !Number.isFinite(aspectRatio) || aspectRatio <= 0) {
-    return clampCollageLayout(layout);
-  }
-
-  const safeLayout = clampCollageLayout(layout);
-  const currentRatio = (
-    safeLayout.width * COLLAGE_STAGE_ASPECT_RATIO
-  ) / Math.max(safeLayout.height, 0.001);
-
-  if (Math.abs(currentRatio - aspectRatio) < 0.001) {
-    return safeLayout;
-  }
-
-  if (currentRatio > aspectRatio) {
-    const width = (safeLayout.height * aspectRatio) / COLLAGE_STAGE_ASPECT_RATIO;
-    return clampCollageLayout({
-      ...safeLayout,
-      x: safeLayout.x + (safeLayout.width - width) / 2,
-      width,
-    });
-  }
-
-  const height = (safeLayout.width * COLLAGE_STAGE_ASPECT_RATIO) / aspectRatio;
-  return clampCollageLayout({
-    ...safeLayout,
-    y: safeLayout.y + (safeLayout.height - height) / 2,
-    height,
-  });
 }
 
 function imageStyleForContentBounds(bounds?: ImageContentBounds): CSSProperties {

--- a/front-end/src/app/components/OutfitCollageCanvas.tsx
+++ b/front-end/src/app/components/OutfitCollageCanvas.tsx
@@ -1,0 +1,600 @@
+import type { CSSProperties } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import Moveable, {
+  type OnDrag,
+  type OnDragEnd,
+  type OnDragStart,
+  type OnResize,
+  type OnResizeEnd,
+  type OnResizeStart,
+} from "react-moveable";
+import { ClothingItem, buildPlaceholderLabel } from "../lib/closet";
+import {
+  clampCollageLayout,
+  OutfitCollageLayout,
+  resolveOutfitCollageLayouts,
+  sortItemsByCollageLayer,
+} from "../lib/outfitCollage";
+import { PrimitiveText } from "./primitives/PrimitiveText";
+
+const MOVEABLE_RENDER_DIRECTIONS = [ "nw", "ne", "sw", "se" ] as const;
+const MIN_ITEM_SIZE_PERCENT = 8;
+const COLLAGE_STAGE_ASPECT_RATIO = 4 / 5;
+
+interface ActiveRotationGesture {
+  itemId: number;
+  startPointerAngle: number;
+  startRotation: number;
+}
+
+interface OutfitCollageCanvasProps {
+  className?: string;
+  editable?: boolean;
+  items: ClothingItem[];
+  layouts?: Record<number, OutfitCollageLayout>;
+  maxVisibleItems?: number;
+  onLayoutsChange?: (layouts: Record<number, OutfitCollageLayout>) => void;
+  onSelectItem?: (itemId: number | null) => void;
+  selectedItemId?: number | null;
+}
+
+export function OutfitCollageCanvas({
+  className = "",
+  editable = false,
+  items,
+  layouts,
+  maxVisibleItems,
+  onLayoutsChange,
+  onSelectItem,
+  selectedItemId = null,
+}: OutfitCollageCanvasProps) {
+  const moveableRef = useRef<Moveable | null>(null);
+  const stageRef = useRef<HTMLDivElement | null>(null);
+  const itemFrameRefs = useRef<Record<number, HTMLDivElement | null>>({});
+  const transientRotationByItemId = useRef<Record<number, number>>({});
+  const activeRotationGestureRef = useRef<ActiveRotationGesture | null>(null);
+  const [imageAspectRatioByItemId, setImageAspectRatioByItemId] = useState<Record<number, number>>({});
+
+  const resolvedLayouts = useMemo(
+    () => resolveOutfitCollageLayouts(items, layouts),
+    [items, layouts],
+  );
+  const orderedItems = useMemo(
+    () => sortItemsByCollageLayer(items, resolvedLayouts),
+    [items, resolvedLayouts],
+  );
+  const visibleItems = maxVisibleItems ? orderedItems.slice(0, maxVisibleItems) : orderedItems;
+  const hiddenCount = Math.max(0, orderedItems.length - visibleItems.length);
+  const normalizedLayouts = useMemo(
+    () =>
+      Object.fromEntries(
+        visibleItems.map((item) => [
+          item.id,
+          normalizeLayoutToAspectRatio(resolvedLayouts[item.id], imageAspectRatioByItemId[item.id]),
+        ]),
+      ) as Record<number, OutfitCollageLayout>,
+    [imageAspectRatioByItemId, resolvedLayouts, visibleItems],
+  );
+  const selectedTarget = editable && selectedItemId ? itemFrameRefs.current[selectedItemId] : null;
+  const displayLayouts = editable ? resolvedLayouts : normalizedLayouts;
+
+  useLayoutEffect(() => {
+    if (editable && selectedItemId) {
+      pinItemFrameToPixels(selectedItemId);
+    }
+
+    moveableRef.current?.updateRect();
+  }, [displayLayouts, editable, selectedItemId]);
+
+  useEffect(() => {
+    if (!editable || !onLayoutsChange) {
+      return;
+    }
+
+    const nextEntries = visibleItems
+      .map((item) => {
+        const currentLayout = resolvedLayouts[item.id];
+        const normalizedLayout = normalizeLayoutToAspectRatio(currentLayout, imageAspectRatioByItemId[item.id]);
+        return layoutsDiffer(currentLayout, normalizedLayout) ? [item.id, normalizedLayout] : null;
+      })
+      .filter((entry): entry is [number, OutfitCollageLayout] => Boolean(entry));
+
+    if (nextEntries.length === 0) {
+      return;
+    }
+
+    onLayoutsChange({
+      ...resolvedLayouts,
+      ...Object.fromEntries(nextEntries),
+    });
+  }, [editable, imageAspectRatioByItemId, onLayoutsChange, resolvedLayouts, visibleItems]);
+
+  function updateItemLayout(itemId: number, nextPartial: Partial<OutfitCollageLayout>) {
+    if (!onLayoutsChange) {
+      return;
+    }
+
+    const baseLayout = resolvedLayouts[itemId];
+    const nextLayout = clampCollageLayout({
+      ...baseLayout,
+      ...nextPartial,
+    });
+
+    onLayoutsChange({
+      ...resolvedLayouts,
+      [itemId]: nextLayout,
+    });
+  }
+
+  function handleDrag(event: OnDrag) {
+    if (!selectedItemId) {
+      return;
+    }
+    event.target.style.left = `${event.left}px`;
+    event.target.style.top = `${event.top}px`;
+  }
+
+  function handleResize(event: OnResize) {
+    if (!selectedItemId) {
+      return;
+    }
+    event.target.style.left = `${event.drag.left}px`;
+    event.target.style.top = `${event.drag.top}px`;
+    event.target.style.width = `${Math.max(event.width, 1)}px`;
+    event.target.style.height = `${Math.max(event.height, 1)}px`;
+  }
+
+  function beginRotation(itemId: number, clientX: number, clientY: number) {
+    const target = itemFrameRefs.current[itemId];
+    if (!target) {
+      return;
+    }
+
+    pinItemFrameToPixels(itemId);
+    const frameRect = target.getBoundingClientRect();
+    activeRotationGestureRef.current = {
+      itemId,
+      startPointerAngle: pointAngleFromRectCenter(frameRect, clientX, clientY),
+      startRotation: transientRotationByItemId.current[itemId] ?? resolvedLayouts[itemId].rotation,
+    };
+  }
+
+  function handleDragStart(_event: OnDragStart) {
+    if (!selectedItemId) {
+      return;
+    }
+
+    pinItemFrameToPixels(selectedItemId);
+  }
+
+  function handleResizeStart(event: OnResizeStart) {
+    if (!selectedItemId) {
+      return;
+    }
+
+    pinItemFrameToPixels(selectedItemId);
+    event.setRatio(imageAspectRatioByItemId[selectedItemId] ?? (resolvedLayouts[selectedItemId].width / Math.max(resolvedLayouts[selectedItemId].height, 0.001)));
+    event.dragStart?.set([ 0, 0 ]);
+  }
+
+  function handleGestureEnd(_event: OnDragEnd | OnResizeEnd) {
+    if (!selectedItemId) {
+      return;
+    }
+
+    commitItemFrameFromPixels(selectedItemId);
+  }
+
+  function handleStagePointerDown(event: React.PointerEvent<HTMLDivElement>) {
+    if (!editable) {
+      return;
+    }
+
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      onSelectItem?.(null);
+      return;
+    }
+
+    if (selectedItemId && target.closest(".moveable-rotation-control")) {
+      event.preventDefault();
+      event.stopPropagation();
+      beginRotation(selectedItemId, event.clientX, event.clientY);
+      return;
+    }
+
+    if (
+      target.closest("[data-collage-item-frame='true']")
+      || target.closest(".moveable-control-box")
+      || target.closest(".moveable-area")
+      || target.closest(".moveable-control")
+      || target.closest(".moveable-rotation-control")
+      || target.closest(".moveable-line")
+    ) {
+      return;
+    }
+
+    onSelectItem?.(null);
+  }
+
+  function pinItemFrameToPixels(itemId: number) {
+    const target = itemFrameRefs.current[itemId];
+    const stageBounds = stageRef.current?.getBoundingClientRect();
+    const layout = resolvedLayouts[itemId];
+
+    if (!target || !stageBounds) {
+      return;
+    }
+
+    target.style.left = `${(layout.x / 100) * stageBounds.width}px`;
+    target.style.top = `${(layout.y / 100) * stageBounds.height}px`;
+    target.style.width = `${(layout.width / 100) * stageBounds.width}px`;
+    target.style.height = `${(layout.height / 100) * stageBounds.height}px`;
+    target.style.transform = `rotate(${layout.rotation}deg)`;
+    transientRotationByItemId.current[itemId] = layout.rotation;
+  }
+
+  function commitItemFrameFromPixels(itemId: number) {
+    const target = itemFrameRefs.current[itemId];
+    const stageBounds = stageRef.current?.getBoundingClientRect();
+
+    if (!target || !stageBounds) {
+      return;
+    }
+
+    updateItemLayout(itemId, {
+      x: pixelsToPercent(parseFloat(target.style.left || "0"), stageBounds.width),
+      y: pixelsToPercent(parseFloat(target.style.top || "0"), stageBounds.height),
+      width: Math.max(MIN_ITEM_SIZE_PERCENT, pixelsToPercent(parseFloat(target.style.width || "0"), stageBounds.width)),
+      height: Math.max(MIN_ITEM_SIZE_PERCENT, pixelsToPercent(parseFloat(target.style.height || "0"), stageBounds.height)),
+      rotation: transientRotationByItemId.current[itemId] ?? 0,
+    });
+  }
+
+  useEffect(() => {
+    function handleWindowPointerMove(event: PointerEvent) {
+      const gesture = activeRotationGestureRef.current;
+      if (!gesture) {
+        return;
+      }
+
+      const target = itemFrameRefs.current[gesture.itemId];
+      if (!target) {
+        return;
+      }
+
+      const frameRect = target.getBoundingClientRect();
+      const nextPointerAngle = pointAngleFromRectCenter(frameRect, event.clientX, event.clientY);
+      const nextRotation = gesture.startRotation + (nextPointerAngle - gesture.startPointerAngle);
+      transientRotationByItemId.current[gesture.itemId] = nextRotation;
+      target.style.transform = `rotate(${nextRotation}deg)`;
+      moveableRef.current?.updateRect();
+    }
+
+    function handleWindowPointerEnd() {
+      const gesture = activeRotationGestureRef.current;
+      if (!gesture) {
+        return;
+      }
+
+      activeRotationGestureRef.current = null;
+      commitItemFrameFromPixels(gesture.itemId);
+    }
+
+    window.addEventListener("pointermove", handleWindowPointerMove);
+    window.addEventListener("pointerup", handleWindowPointerEnd);
+    window.addEventListener("pointercancel", handleWindowPointerEnd);
+
+    return () => {
+      window.removeEventListener("pointermove", handleWindowPointerMove);
+      window.removeEventListener("pointerup", handleWindowPointerEnd);
+      window.removeEventListener("pointercancel", handleWindowPointerEnd);
+    };
+  }, [resolvedLayouts]);
+  return (
+    <div
+      ref={stageRef}
+      className={`relative aspect-[4/5] overflow-hidden bg-gradient-to-br from-stone-100 via-white to-stone-100 ${editable ? "touch-none" : ""} ${className}`.trim()}
+      style={editable ? ({ "--moveable-color": "#111111" } as CSSProperties) : undefined}
+      onPointerDown={handleStagePointerDown}
+    >
+      {visibleItems.map((item, index) => {
+        const layout = displayLayouts[item.id] ?? resolvedLayouts[item.id];
+        const isLastVisibleTile = index === visibleItems.length - 1;
+        const showHiddenCount = hiddenCount > 0 && isLastVisibleTile && !editable;
+
+        return (
+          <div
+            key={item.id}
+            ref={(node) => {
+              itemFrameRefs.current[item.id] = node;
+            }}
+            data-collage-item-frame="true"
+            role={editable ? "button" : undefined}
+            tabIndex={editable ? 0 : -1}
+            className={`absolute overflow-visible ${editable ? "cursor-move" : ""}`}
+            style={{
+              left: `${layout.x}%`,
+              top: `${layout.y}%`,
+              width: `${layout.width}%`,
+              height: `${layout.height}%`,
+              transform: `rotate(${layout.rotation}deg)`,
+              transformOrigin: "center center",
+              zIndex: layout.layer_order + 1,
+            }}
+            onPointerDown={(event) => {
+              event.stopPropagation();
+              onSelectItem?.(item.id);
+            }}
+            onClick={(event) => {
+              event.stopPropagation();
+              onSelectItem?.(item.id);
+            }}
+          >
+            <div className="relative h-full w-full overflow-hidden bg-transparent">
+              {item.image_url ? (
+                <img
+                  src={item.image_url}
+                  alt={item.name}
+                  className="pointer-events-none h-full w-full object-contain drop-shadow-[0_10px_18px_rgba(0,0,0,0.12)]"
+                  onLoad={(event) => {
+                    const nextRatio = event.currentTarget.naturalWidth / Math.max(1, event.currentTarget.naturalHeight);
+                    setImageAspectRatioByItemId((current) =>
+                      nearlyEqual(current[item.id] ?? 0, nextRatio)
+                        ? current
+                        : {
+                            ...current,
+                            [item.id]: nextRatio,
+                          },
+                    );
+                  }}
+                />
+              ) : (
+                <div className="pointer-events-none flex h-full w-full items-end border border-border/40 bg-white/85 p-4 text-left shadow-sm">
+                  <div>
+                    <PrimitiveText as="p" variant="title" font="serif">
+                      {item.name}
+                    </PrimitiveText>
+                  </div>
+                </div>
+              )}
+
+              {showHiddenCount ? (
+                <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-full bg-black/45">
+                  <PrimitiveText as="p" variant="title" font="serif" className="text-white">
+                    +{hiddenCount}
+                  </PrimitiveText>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        );
+      })}
+
+      {editable && selectedTarget ? (
+        <Moveable
+          ref={moveableRef}
+          target={selectedTarget}
+          container={stageRef.current ?? undefined}
+          draggable
+          resizable
+          rotatable
+          keepRatio
+          edge={false}
+          origin={false}
+          renderDirections={[ ...MOVEABLE_RENDER_DIRECTIONS ]}
+          rotationPosition="top"
+          throttleDrag={0}
+          throttleResize={0}
+          onDragStart={handleDragStart}
+          onDrag={handleDrag}
+          onDragEnd={handleGestureEnd}
+          onResizeStart={handleResizeStart}
+          onResize={handleResize}
+          onResizeEnd={handleGestureEnd}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function normalizeLayoutToAspectRatio(
+  layout: OutfitCollageLayout,
+  aspectRatio?: number,
+): OutfitCollageLayout {
+  if (!aspectRatio || !Number.isFinite(aspectRatio) || aspectRatio <= 0) {
+    return clampCollageLayout(layout);
+  }
+
+  const safeLayout = clampCollageLayout(layout);
+  const currentRatio = (
+    safeLayout.width * COLLAGE_STAGE_ASPECT_RATIO
+  ) / Math.max(safeLayout.height, 0.001);
+
+  if (Math.abs(currentRatio - aspectRatio) < 0.001) {
+    return safeLayout;
+  }
+
+  if (currentRatio > aspectRatio) {
+    const width = (safeLayout.height * aspectRatio) / COLLAGE_STAGE_ASPECT_RATIO;
+    return clampCollageLayout({
+      ...safeLayout,
+      x: safeLayout.x + (safeLayout.width - width) / 2,
+      width,
+    });
+  }
+
+  const height = (safeLayout.width * COLLAGE_STAGE_ASPECT_RATIO) / aspectRatio;
+  return clampCollageLayout({
+    ...safeLayout,
+    y: safeLayout.y + (safeLayout.height - height) / 2,
+    height,
+  });
+}
+
+function nearlyEqual(left: number, right: number, tolerance = 0.002) {
+  return Math.abs(left - right) <= tolerance;
+}
+
+function layoutsDiffer(left: OutfitCollageLayout, right: OutfitCollageLayout) {
+  return (
+    !nearlyEqual(left.x, right.x)
+    || !nearlyEqual(left.y, right.y)
+    || !nearlyEqual(left.width, right.width)
+    || !nearlyEqual(left.height, right.height)
+    || !nearlyEqual(left.rotation, right.rotation)
+    || left.layer_order !== right.layer_order
+  );
+}
+
+function pointAngleFromRectCenter(rect: DOMRect, clientX: number, clientY: number) {
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+  return Math.atan2(clientY - centerY, clientX - centerX) * (180 / Math.PI);
+}
+
+function pixelsToPercent(value: number, total: number) {
+  if (!Number.isFinite(value) || total <= 0) {
+    return 0;
+  }
+
+  return (value / total) * 100;
+}
+
+interface OutfitCollageLayersPanelProps {
+  items: ClothingItem[];
+  layouts: Record<number, OutfitCollageLayout>;
+  onReorder: (orderedItemIds: number[]) => void;
+  onSelectItem: (itemId: number) => void;
+  selectedItemId?: number | null;
+}
+
+export function OutfitCollageLayersPanel({
+  items,
+  layouts,
+  onReorder,
+  onSelectItem,
+  selectedItemId = null,
+}: OutfitCollageLayersPanelProps) {
+  const orderedItems = useMemo(
+    () => [...sortItemsByCollageLayer(items, layouts)].reverse(),
+    [items, layouts],
+  );
+  const [draggingItemId, setDraggingItemId] = useState<number | null>(null);
+  const [dragHoverItemId, setDragHoverItemId] = useState<number | null>(null);
+  const lastDropTargetIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!draggingItemId) {
+      return;
+    }
+
+    function handleWindowPointerMove(event: PointerEvent) {
+      const hoveredElement = document.elementFromPoint(event.clientX, event.clientY);
+      const layerButton = hoveredElement instanceof HTMLElement
+        ? hoveredElement.closest<HTMLElement>("[data-layer-item-id]")
+        : null;
+
+      if (!layerButton) {
+        setDragHoverItemId(null);
+        return;
+      }
+
+      const targetItemId = Number(layerButton.dataset.layerItemId);
+      if (!Number.isFinite(targetItemId)) {
+        return;
+      }
+
+      setDragHoverItemId(targetItemId);
+      if (lastDropTargetIdRef.current === targetItemId) {
+        return;
+      }
+
+      reorderItems(draggingItemId, targetItemId);
+      lastDropTargetIdRef.current = targetItemId;
+    }
+
+    function handleWindowPointerUp() {
+      setDraggingItemId(null);
+      setDragHoverItemId(null);
+      lastDropTargetIdRef.current = null;
+    }
+
+    window.addEventListener("pointermove", handleWindowPointerMove);
+    window.addEventListener("pointerup", handleWindowPointerUp);
+    window.addEventListener("pointercancel", handleWindowPointerUp);
+
+    return () => {
+      window.removeEventListener("pointermove", handleWindowPointerMove);
+      window.removeEventListener("pointerup", handleWindowPointerUp);
+      window.removeEventListener("pointercancel", handleWindowPointerUp);
+    };
+  }, [draggingItemId]);
+
+  function reorderItems(draggedItemId: number, targetItemId: number) {
+    if (draggedItemId === targetItemId) {
+      return;
+    }
+
+    const reordered = [...orderedItems];
+    const draggingIndex = reordered.findIndex((entry) => entry.id === draggedItemId);
+    const targetIndex = reordered.findIndex((entry) => entry.id === targetItemId);
+    if (draggingIndex < 0 || targetIndex < 0) {
+      return;
+    }
+
+    const [draggingItem] = reordered.splice(draggingIndex, 1);
+    reordered.splice(targetIndex, 0, draggingItem);
+    onReorder([...reordered].reverse().map((entry) => entry.id));
+  }
+
+  function handleLayerPointerDown(itemId: number) {
+    onSelectItem(itemId);
+    setDraggingItemId(itemId);
+    setDragHoverItemId(itemId);
+    lastDropTargetIdRef.current = itemId;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3 border border-border bg-card/90 p-3">
+      <PrimitiveText as="p" variant="overline" tone="muted">
+        Layers
+      </PrimitiveText>
+      <div className="flex min-h-0 flex-col gap-2 overflow-y-auto">
+        {orderedItems.map((item) => {
+          const isSelected = selectedItemId === item.id;
+
+          return (
+            <button
+              key={item.id}
+              type="button"
+              data-layer-item-id={item.id}
+              onClick={() => onSelectItem(item.id)}
+              onPointerDown={(event) => {
+                event.preventDefault();
+                handleLayerPointerDown(item.id);
+              }}
+              className={`group flex aspect-[3/4] w-full items-center justify-center overflow-hidden border bg-background transition-colors ${
+                isSelected ? "border-foreground shadow-[0_0_0_1px_rgba(17,17,17,0.18)]" : "border-border hover:bg-stone-50"
+              } ${
+                draggingItemId === item.id ? "cursor-grabbing opacity-80" : "cursor-grab"
+              } ${
+                dragHoverItemId === item.id && draggingItemId && draggingItemId !== item.id ? "border-foreground/70 bg-stone-50" : ""
+              }`}
+              aria-label={`Select layer ${item.name}`}
+              title={item.name}
+            >
+              {item.image_url ? (
+                <img src={item.image_url} alt="" className="h-full w-full object-cover" />
+              ) : (
+                <PrimitiveText as="span" variant="bodySm" tone="muted">
+                  {buildPlaceholderLabel(item.name) || "?"}
+                </PrimitiveText>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/front-end/src/app/components/OutfitCollageLayersPanel.tsx
+++ b/front-end/src/app/components/OutfitCollageLayersPanel.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { ClothingItem, buildPlaceholderLabel } from "../lib/closet";
+import { OutfitCollageLayout, sortItemsByCollageLayer } from "../lib/outfitCollage";
+import { PrimitiveText } from "./primitives/PrimitiveText";
+
+interface OutfitCollageLayersPanelProps {
+  items: ClothingItem[];
+  layouts: Record<number, OutfitCollageLayout>;
+  onReorder: (orderedItemIds: number[]) => void;
+  onSelectItem: (itemId: number) => void;
+  selectedItemId?: number | null;
+}
+
+export function OutfitCollageLayersPanel({
+  items,
+  layouts,
+  onReorder,
+  onSelectItem,
+  selectedItemId = null,
+}: OutfitCollageLayersPanelProps) {
+  const orderedItems = useMemo(
+    () => [...sortItemsByCollageLayer(items, layouts)].reverse(),
+    [items, layouts],
+  );
+  const [draggingItemId, setDraggingItemId] = useState<number | null>(null);
+  const [dragHoverItemId, setDragHoverItemId] = useState<number | null>(null);
+  const lastDropTargetIdRef = useRef<number | null>(null);
+  const keyboardHintId = useId();
+
+  useEffect(() => {
+    if (!draggingItemId) {
+      return;
+    }
+
+    function handleWindowPointerMove(event: PointerEvent) {
+      const hoveredElement = document.elementFromPoint(event.clientX, event.clientY);
+      const layerButton = hoveredElement instanceof HTMLElement
+        ? hoveredElement.closest<HTMLElement>("[data-layer-item-id]")
+        : null;
+
+      if (!layerButton) {
+        setDragHoverItemId(null);
+        return;
+      }
+
+      const targetItemId = Number(layerButton.dataset.layerItemId);
+      if (!Number.isFinite(targetItemId)) {
+        return;
+      }
+
+      setDragHoverItemId(targetItemId);
+      if (lastDropTargetIdRef.current === targetItemId) {
+        return;
+      }
+
+      reorderItems(draggingItemId, targetItemId);
+      lastDropTargetIdRef.current = targetItemId;
+    }
+
+    function handleWindowPointerUp() {
+      setDraggingItemId(null);
+      setDragHoverItemId(null);
+      lastDropTargetIdRef.current = null;
+    }
+
+    window.addEventListener("pointermove", handleWindowPointerMove);
+    window.addEventListener("pointerup", handleWindowPointerUp);
+    window.addEventListener("pointercancel", handleWindowPointerUp);
+
+    return () => {
+      window.removeEventListener("pointermove", handleWindowPointerMove);
+      window.removeEventListener("pointerup", handleWindowPointerUp);
+      window.removeEventListener("pointercancel", handleWindowPointerUp);
+    };
+  }, [draggingItemId, orderedItems]);
+
+  function reorderItems(draggedItemId: number, targetItemId: number) {
+    if (draggedItemId === targetItemId) {
+      return;
+    }
+
+    const reordered = [...orderedItems];
+    const draggingIndex = reordered.findIndex((entry) => entry.id === draggedItemId);
+    const targetIndex = reordered.findIndex((entry) => entry.id === targetItemId);
+    if (draggingIndex < 0 || targetIndex < 0) {
+      return;
+    }
+
+    const [draggingItem] = reordered.splice(draggingIndex, 1);
+    reordered.splice(targetIndex, 0, draggingItem);
+    onReorder([...reordered].reverse().map((entry) => entry.id));
+  }
+
+  function moveItemToIndex(itemId: number, targetIndex: number) {
+    const currentIndex = orderedItems.findIndex((entry) => entry.id === itemId);
+    if (currentIndex < 0 || targetIndex < 0 || targetIndex >= orderedItems.length || currentIndex === targetIndex) {
+      return;
+    }
+
+    const reordered = [...orderedItems];
+    const [item] = reordered.splice(currentIndex, 1);
+    reordered.splice(targetIndex, 0, item);
+    onReorder([...reordered].reverse().map((entry) => entry.id));
+  }
+
+  function handleLayerPointerDown(itemId: number) {
+    onSelectItem(itemId);
+    setDraggingItemId(itemId);
+    setDragHoverItemId(itemId);
+    lastDropTargetIdRef.current = itemId;
+  }
+
+  function handleLayerKeyDown(event: React.KeyboardEvent<HTMLButtonElement>, itemId: number) {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onSelectItem(itemId);
+      return;
+    }
+
+    if (!event.altKey) {
+      return;
+    }
+
+    const currentIndex = orderedItems.findIndex((entry) => entry.id === itemId);
+    if (currentIndex < 0) {
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveItemToIndex(itemId, Math.max(0, currentIndex - 1));
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveItemToIndex(itemId, Math.min(orderedItems.length - 1, currentIndex + 1));
+      return;
+    }
+
+    if (event.key === "Home") {
+      event.preventDefault();
+      moveItemToIndex(itemId, 0);
+      return;
+    }
+
+    if (event.key === "End") {
+      event.preventDefault();
+      moveItemToIndex(itemId, orderedItems.length - 1);
+    }
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-2 border border-border bg-card/90 p-2 sm:gap-3 sm:p-3">
+      <PrimitiveText as="p" variant="overline" tone="muted" className="text-[0.65rem] sm:text-[0.7rem]">
+        Layers
+      </PrimitiveText>
+      <p id={keyboardHintId} className="sr-only">
+        Press Enter or Space to select a layer. Press Option plus Arrow Up or Arrow Down to reorder layers.
+      </p>
+      <div className="flex min-h-0 flex-col gap-2 overflow-y-auto">
+        {orderedItems.map((item) => {
+          const isSelected = selectedItemId === item.id;
+
+          return (
+            <button
+              key={item.id}
+              type="button"
+              data-layer-item-id={item.id}
+              onClick={() => onSelectItem(item.id)}
+              onPointerDown={(event) => {
+                event.preventDefault();
+                handleLayerPointerDown(item.id);
+              }}
+              onKeyDown={(event) => handleLayerKeyDown(event, item.id)}
+              className={`group flex aspect-[3/4] w-full items-center justify-center overflow-hidden border bg-background transition-colors ${
+                isSelected ? "border-foreground shadow-[0_0_0_1px_rgba(17,17,17,0.18)]" : "border-border hover:bg-stone-50"
+              } ${
+                draggingItemId === item.id ? "cursor-grabbing opacity-80" : "cursor-grab"
+              } ${
+                dragHoverItemId === item.id && draggingItemId && draggingItemId !== item.id ? "border-foreground/70 bg-stone-50" : ""
+              }`}
+              aria-describedby={keyboardHintId}
+              aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown Alt+Home Alt+End"
+              aria-label={`Select layer ${item.name}`}
+              title={item.name}
+            >
+              {item.image_url ? (
+                <img src={item.image_url} alt="" className="h-full w-full object-cover" />
+              ) : (
+                <PrimitiveText as="span" variant="bodySm" tone="muted">
+                  {buildPlaceholderLabel(item.name) || "?"}
+                </PrimitiveText>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/front-end/src/app/components/OutfitCreatedDialog.tsx
+++ b/front-end/src/app/components/OutfitCreatedDialog.tsx
@@ -1,0 +1,61 @@
+import { CheckCircle2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
+import { PrimitiveText } from "./primitives/PrimitiveText";
+
+interface OutfitCreatedDialogProps {
+  isOpen: boolean;
+  onBackToCloset: () => void;
+  onGoToOutfits: () => void;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function OutfitCreatedDialog({
+  isOpen,
+  onBackToCloset,
+  onGoToOutfits,
+  onOpenChange,
+}: OutfitCreatedDialogProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md rounded-none border-border p-8">
+        <DialogHeader className="items-center text-center sm:items-center sm:text-center">
+          <div className="mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-foreground text-background">
+            <CheckCircle2 className="h-6 w-6" />
+          </div>
+          <DialogTitle asChild>
+            <PrimitiveText as="h2" variant="display" font="serif" className="text-center">
+              Outfit created
+            </PrimitiveText>
+          </DialogTitle>
+          <DialogDescription asChild>
+            <PrimitiveText as="p" tone="muted" className="text-center">
+              Your selected pieces were saved as a new outfit.
+            </PrimitiveText>
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="mt-2 flex-col gap-3 sm:flex-col sm:justify-stretch">
+          <PrimitiveButton type="button" onClick={onBackToCloset} className="h-auto w-full py-3">
+            Back to Closet
+          </PrimitiveButton>
+          <PrimitiveButton
+            type="button"
+            variant="outline"
+            onClick={onGoToOutfits}
+            className="h-auto w-full py-3"
+          >
+            Outfits
+          </PrimitiveButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front-end/src/app/lib/closet.ts
+++ b/front-end/src/app/lib/closet.ts
@@ -143,6 +143,38 @@ export interface Outfit {
   updated_at?: string;
 }
 
+function normalizeAttachmentUrl(rawUrl: unknown) {
+  if (typeof rawUrl !== "string" || rawUrl.trim().length === 0) {
+    return null;
+  }
+
+  const trimmed = rawUrl.trim();
+
+  if (typeof window === "undefined") {
+    return trimmed;
+  }
+
+  if (!isLocalDevelopmentHost(window.location.hostname) || window.location.port === "3000") {
+    return trimmed;
+  }
+
+  try {
+    const normalizedBackendOrigin = new URL(BACKEND_BASE_URL, window.location.origin).origin;
+    const parsed = new URL(trimmed, normalizedBackendOrigin);
+
+    if (
+      parsed.origin === normalizedBackendOrigin
+      && parsed.pathname.startsWith("/rails/active_storage/")
+    ) {
+      return `${parsed.pathname}${parsed.search}`;
+    }
+  } catch {
+    return trimmed;
+  }
+
+  return trimmed;
+}
+
 export type CreateItemMode = "manual" | "image";
 
 export interface ClothingItemFormValues {
@@ -489,18 +521,18 @@ export async function createOutfitUpload(
   formData.append("outfit_upload[user_id]", String(userId));
   formData.append("outfit_upload[source_photo]", photoOptions.photo);
 
-  return requestJson<OutfitUpload>(`${API_BASE_URL}/outfit_uploads`, {
+  return normalizeOutfitUploadPayload(await requestJson<OutfitUpload>(`${API_BASE_URL}/outfit_uploads`, {
     method: "POST",
     body: formData,
-  });
+  }));
 }
 
 export async function fetchOutfitUpload(id: number, signal?: AbortSignal) {
-  return requestJson<OutfitUpload>(`${API_BASE_URL}/outfit_uploads/${id}`, { signal });
+  return normalizeOutfitUploadPayload(await requestJson<OutfitUpload>(`${API_BASE_URL}/outfit_uploads/${id}`, { signal }));
 }
 
 export async function fetchOutfits(signal?: AbortSignal) {
-  return requestJson<Outfit[]>(`${API_BASE_URL}/outfits`, { signal });
+  return (await requestJson<Outfit[]>(`${API_BASE_URL}/outfits`, { signal })).map(normalizeOutfitPayload);
 }
 
 interface CreateOutfitInput {
@@ -537,13 +569,13 @@ function buildOutfitPayload(input: {
 }
 
 export async function createOutfit(input: CreateOutfitInput) {
-  return requestJson<Outfit>(`${API_BASE_URL}/outfits`, {
+  return normalizeOutfitPayload(await requestJson<Outfit>(`${API_BASE_URL}/outfits`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(buildOutfitPayload(input)),
-  });
+  }));
 }
 
 interface UpdateOutfitInput {
@@ -556,13 +588,13 @@ interface UpdateOutfitInput {
 }
 
 export async function updateOutfit(input: UpdateOutfitInput) {
-  return requestJson<Outfit>(`${API_BASE_URL}/outfits/${input.id}`, {
+  return normalizeOutfitPayload(await requestJson<Outfit>(`${API_BASE_URL}/outfits/${input.id}`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(buildOutfitPayload(input)),
-  });
+  }));
 }
 
 export async function destroyOutfit(id: number) {
@@ -727,8 +759,33 @@ function normalizeClothingItemPayload(item: ClothingItem): ClothingItem {
     ...item,
     category: normalizeCategoryValue(item.category) || null,
     brand: item.brand?.trim() ? item.brand.trim() : null,
+    cleaned_image_url: normalizeAttachmentUrl(item.cleaned_image_url),
+    image_url: normalizeAttachmentUrl(item.image_url),
+    original_image_url: normalizeAttachmentUrl(item.original_image_url),
     tags: normalizeTagList((item as ClothingItem & { tags?: unknown }).tags),
     collage_layout,
+  };
+}
+
+function normalizeOutfitDetectionPayload(detection: OutfitDetection): OutfitDetection {
+  return {
+    ...detection,
+    cleaned_image_url: normalizeAttachmentUrl(detection.cleaned_image_url),
+  };
+}
+
+function normalizeOutfitUploadPayload(upload: OutfitUpload): OutfitUpload {
+  return {
+    ...upload,
+    detections: (upload.detections ?? []).map(normalizeOutfitDetectionPayload),
+    source_photo_url: normalizeAttachmentUrl(upload.source_photo_url),
+  };
+}
+
+function normalizeOutfitPayload(outfit: Outfit): Outfit {
+  return {
+    ...outfit,
+    items: (outfit.items ?? []).map(normalizeClothingItemPayload),
   };
 }
 

--- a/front-end/src/app/lib/closet.ts
+++ b/front-end/src/app/lib/closet.ts
@@ -1,4 +1,5 @@
 import { requestJson, requestJsonOrNull, requestVoid } from "./api";
+import { OutfitCollageLayout } from "./outfitCollage";
 
 const LOCAL_BACKEND_BASE_URL = "http://127.0.0.1:3000";
 
@@ -53,6 +54,9 @@ export interface ClothingItem {
   clean_image_provider?: string | null;
   clean_image_model?: string | null;
   clean_image_generated_at?: string | null;
+  outfit_item_id?: number;
+  layer_order?: number;
+  collage_layout?: OutfitCollageLayout | null;
   user?: UserSummary;
 }
 
@@ -503,12 +507,18 @@ interface CreateOutfitInput {
   userId: number;
   name: string;
   itemIds: number[];
+  itemLayouts?: OutfitCollageLayoutInput[];
   notes?: string;
   tags?: string[];
 }
 
+interface OutfitCollageLayoutInput extends OutfitCollageLayout {
+  item_id: number;
+}
+
 function buildOutfitPayload(input: {
   itemIds: number[];
+  itemLayouts?: OutfitCollageLayoutInput[];
   name: string;
   notes?: string;
   tags?: string[];
@@ -519,6 +529,7 @@ function buildOutfitPayload(input: {
       user_id: input.userId,
       name: input.name,
       item_ids: input.itemIds,
+      item_layouts: input.itemLayouts,
       notes: input.notes,
       tags: input.tags,
     },
@@ -539,6 +550,7 @@ interface UpdateOutfitInput {
   id: number;
   name: string;
   itemIds: number[];
+  itemLayouts?: OutfitCollageLayoutInput[];
   notes?: string;
   tags?: string[];
 }
@@ -689,11 +701,34 @@ function normalizeCategoryValue(rawCategory: unknown) {
 }
 
 function normalizeClothingItemPayload(item: ClothingItem): ClothingItem {
+  const rawLayout = (item as ClothingItem & { collage_layout?: Partial<OutfitCollageLayout> | null }).collage_layout;
+  const collage_layout =
+    rawLayout &&
+    typeof rawLayout.x === "number" &&
+    typeof rawLayout.y === "number" &&
+    typeof rawLayout.width === "number" &&
+    typeof rawLayout.height === "number"
+      ? {
+          x: rawLayout.x,
+          y: rawLayout.y,
+          width: rawLayout.width,
+          height: rawLayout.height,
+          rotation: typeof rawLayout.rotation === "number" ? rawLayout.rotation : 0,
+          layer_order:
+            typeof rawLayout.layer_order === "number"
+              ? rawLayout.layer_order
+              : typeof item.layer_order === "number"
+                ? item.layer_order
+                : 0,
+        }
+      : null;
+
   return {
     ...item,
     category: normalizeCategoryValue(item.category) || null,
     brand: item.brand?.trim() ? item.brand.trim() : null,
     tags: normalizeTagList((item as ClothingItem & { tags?: unknown }).tags),
+    collage_layout,
   };
 }
 

--- a/front-end/src/app/lib/outfitCollage.ts
+++ b/front-end/src/app/lib/outfitCollage.ts
@@ -1,0 +1,173 @@
+import type { ClothingItem } from "./closet";
+
+export interface OutfitCollageLayout {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: number;
+  layer_order: number;
+}
+
+interface NumericCollageFrame {
+  height: number;
+  left: number;
+  rotate: number;
+  top: number;
+  width: number;
+  zIndex: number;
+}
+
+const DEFAULT_COLLAGE_FRAMES: Record<number, NumericCollageFrame[]> = {
+  1: [
+    { left: 12, top: 6, width: 76, height: 84, rotate: -2, zIndex: 0 },
+  ],
+  2: [
+    { left: 16, top: 7, width: 68, height: 40, rotate: -4, zIndex: 0 },
+    { left: 12, top: 48, width: 76, height: 36, rotate: 2, zIndex: 1 },
+  ],
+  3: [
+    { left: 9, top: 9, width: 38, height: 34, rotate: -7, zIndex: 0 },
+    { left: 51, top: 8, width: 35, height: 32, rotate: 6, zIndex: 1 },
+    { left: 18, top: 42, width: 64, height: 42, rotate: -2, zIndex: 2 },
+  ],
+  4: [
+    { left: 7, top: 7, width: 36, height: 30, rotate: -8, zIndex: 0 },
+    { left: 54, top: 8, width: 31, height: 29, rotate: 6, zIndex: 1 },
+    { left: 10, top: 35, width: 34, height: 28, rotate: -4, zIndex: 2 },
+    { left: 27, top: 48, width: 50, height: 34, rotate: 2, zIndex: 3 },
+  ],
+  5: [
+    { left: 6, top: 6, width: 28, height: 24, rotate: -9, zIndex: 0 },
+    { left: 38, top: 4, width: 30, height: 28, rotate: 4, zIndex: 1 },
+    { left: 70, top: 9, width: 20, height: 20, rotate: 8, zIndex: 2 },
+    { left: 8, top: 34, width: 28, height: 24, rotate: -3, zIndex: 3 },
+    { left: 24, top: 42, width: 58, height: 40, rotate: -1, zIndex: 4 },
+  ],
+  6: [
+    { left: 6, top: 6, width: 26, height: 22, rotate: -10, zIndex: 0 },
+    { left: 35, top: 4, width: 28, height: 25, rotate: 4, zIndex: 1 },
+    { left: 68, top: 8, width: 20, height: 18, rotate: 8, zIndex: 2 },
+    { left: 7, top: 32, width: 24, height: 22, rotate: -4, zIndex: 3 },
+    { left: 40, top: 28, width: 42, height: 31, rotate: 2, zIndex: 4 },
+    { left: 16, top: 60, width: 64, height: 23, rotate: -2, zIndex: 5 },
+  ],
+};
+
+function gridFallbackFrame(index: number, count: number): NumericCollageFrame {
+  const columns = Math.min(3, Math.max(1, Math.ceil(Math.sqrt(count))));
+  const rows = Math.ceil(count / columns);
+  const horizontalGap = 4;
+  const verticalGap = 4;
+  const width = (100 - horizontalGap * (columns + 1)) / columns;
+  const height = (100 - verticalGap * (rows + 1)) / rows;
+  const column = index % columns;
+  const row = Math.floor(index / columns);
+  const rotationPattern = [ -6, 4, -2, 5, -4, 3 ];
+
+  return {
+    left: horizontalGap + column * (width + horizontalGap),
+    top: verticalGap + row * (height + verticalGap),
+    width,
+    height,
+    rotate: rotationPattern[index % rotationPattern.length],
+    zIndex: index,
+  };
+}
+
+function defaultFrameFor(index: number, count: number): NumericCollageFrame {
+  if (count <= 6) {
+    return DEFAULT_COLLAGE_FRAMES[count][index];
+  }
+
+  return gridFallbackFrame(index, count);
+}
+
+export function buildDefaultOutfitCollageLayouts(
+  items: Pick<ClothingItem, "id">[],
+): Record<number, OutfitCollageLayout> {
+  const count = items.length;
+
+  return Object.fromEntries(
+    items.map((item, index) => {
+      const frame = defaultFrameFor(index, count);
+      return [
+        item.id,
+        {
+          x: frame.left,
+          y: frame.top,
+          width: frame.width,
+          height: frame.height,
+          rotation: frame.rotate,
+          layer_order: frame.zIndex,
+        },
+      ];
+    }),
+  );
+}
+
+export function resolveOutfitCollageLayouts(
+  items: ClothingItem[],
+  overrides: Record<number, OutfitCollageLayout> = {},
+): Record<number, OutfitCollageLayout> {
+  const defaults = buildDefaultOutfitCollageLayouts(items);
+
+  return Object.fromEntries(
+    items.map((item) => {
+      const preferred = overrides[item.id] ?? item.collage_layout ?? defaults[item.id];
+      return [
+        item.id,
+        {
+          x: preferred.x,
+          y: preferred.y,
+          width: preferred.width,
+          height: preferred.height,
+          rotation: preferred.rotation,
+          layer_order: preferred.layer_order,
+        },
+      ];
+    }),
+  );
+}
+
+export function sortItemsByCollageLayer(
+  items: ClothingItem[],
+  layouts: Record<number, OutfitCollageLayout>,
+) {
+  return [...items].sort((left, right) => {
+    const leftOrder = layouts[left.id]?.layer_order ?? left.layer_order ?? 0;
+    const rightOrder = layouts[right.id]?.layer_order ?? right.layer_order ?? 0;
+    return leftOrder - rightOrder || left.id - right.id;
+  });
+}
+
+export function reorderCollageLayers(
+  layouts: Record<number, OutfitCollageLayout>,
+  orderedItemIds: number[],
+): Record<number, OutfitCollageLayout> {
+  return Object.fromEntries(
+    orderedItemIds.map((itemId, index) => [
+      itemId,
+      {
+        ...layouts[itemId],
+        layer_order: index,
+      },
+    ]),
+  );
+}
+
+export function clampCollageLayout(layout: OutfitCollageLayout): OutfitCollageLayout {
+  const width = Math.min(100, Math.max(10, layout.width));
+  const height = Math.min(100, Math.max(10, layout.height));
+  const x = Math.min(100 - width, Math.max(0, layout.x));
+  const y = Math.min(100 - height, Math.max(0, layout.y));
+
+  return {
+    ...layout,
+    x,
+    y,
+    width,
+    height,
+    rotation: Number.isFinite(layout.rotation) ? layout.rotation : 0,
+  };
+}

--- a/front-end/src/app/lib/outfitCollage.ts
+++ b/front-end/src/app/lib/outfitCollage.ts
@@ -18,6 +18,8 @@ interface NumericCollageFrame {
   zIndex: number;
 }
 
+const MAX_OFF_STAGE_VISIBLE_FRACTION = 0.5;
+
 const DEFAULT_COLLAGE_FRAMES: Record<number, NumericCollageFrame[]> = {
   1: [
     { left: 12, top: 6, width: 76, height: 84, rotate: -2, zIndex: 0 },
@@ -159,8 +161,14 @@ export function reorderCollageLayers(
 export function clampCollageLayout(layout: OutfitCollageLayout): OutfitCollageLayout {
   const width = Math.min(100, Math.max(10, layout.width));
   const height = Math.min(100, Math.max(10, layout.height));
-  const x = Math.min(100 - width, Math.max(0, layout.x));
-  const y = Math.min(100 - height, Math.max(0, layout.y));
+  const minVisibleWidth = width * MAX_OFF_STAGE_VISIBLE_FRACTION;
+  const minVisibleHeight = height * MAX_OFF_STAGE_VISIBLE_FRACTION;
+  const minX = minVisibleWidth - width;
+  const maxX = 100 - minVisibleWidth;
+  const minY = minVisibleHeight - height;
+  const maxY = 100 - minVisibleHeight;
+  const x = Math.min(maxX, Math.max(minX, layout.x));
+  const y = Math.min(maxY, Math.max(minY, layout.y));
 
   return {
     ...layout,

--- a/front-end/src/app/lib/outfitCollageRenderMath.ts
+++ b/front-end/src/app/lib/outfitCollageRenderMath.ts
@@ -1,0 +1,55 @@
+import { clampCollageLayout, type OutfitCollageLayout } from "./outfitCollage.ts";
+
+export const COLLAGE_STAGE_ASPECT_RATIO = 4 / 5;
+
+interface ResolveResizeAspectRatioOptions {
+  contentBoundsAspectRatio?: number;
+  intrinsicAspectRatio?: number;
+  layout: OutfitCollageLayout;
+}
+
+export function normalizeOutfitCollageLayoutToAspectRatio(
+  layout: OutfitCollageLayout,
+  aspectRatio?: number,
+): OutfitCollageLayout {
+  if (!aspectRatio || !Number.isFinite(aspectRatio) || aspectRatio <= 0) {
+    return clampCollageLayout(layout);
+  }
+
+  const safeLayout = clampCollageLayout(layout);
+  const currentRatio = (
+    safeLayout.width * COLLAGE_STAGE_ASPECT_RATIO
+  ) / Math.max(safeLayout.height, 0.001);
+
+  if (Math.abs(currentRatio - aspectRatio) < 0.001) {
+    return safeLayout;
+  }
+
+  if (currentRatio > aspectRatio) {
+    const width = (safeLayout.height * aspectRatio) / COLLAGE_STAGE_ASPECT_RATIO;
+    return clampCollageLayout({
+      ...safeLayout,
+      x: safeLayout.x + (safeLayout.width - width) / 2,
+      width,
+    });
+  }
+
+  const height = (safeLayout.width * COLLAGE_STAGE_ASPECT_RATIO) / aspectRatio;
+  return clampCollageLayout({
+    ...safeLayout,
+    y: safeLayout.y + (safeLayout.height - height) / 2,
+    height,
+  });
+}
+
+export function resolveOutfitCollageResizeAspectRatio({
+  contentBoundsAspectRatio,
+  intrinsicAspectRatio,
+  layout,
+}: ResolveResizeAspectRatioOptions) {
+  return (
+    contentBoundsAspectRatio
+    ?? intrinsicAspectRatio
+    ?? (layout.width / Math.max(layout.height, 0.001))
+  );
+}

--- a/front-end/src/app/lib/outfitImageBounds.ts
+++ b/front-end/src/app/lib/outfitImageBounds.ts
@@ -1,0 +1,306 @@
+const EDGE_BACKGROUND_ALPHA_THRESHOLD = 8;
+const EDGE_BACKGROUND_MIN_RGB = 250;
+const EDGE_BACKGROUND_MAX_RGB_DELTA = 6;
+const MIN_OPAQUE_EDGE_TRIM_FRACTION = 0.02;
+const MIN_OPAQUE_EDGE_AREA_REDUCTION = 0.08;
+
+export interface ImageContentBounds {
+  aspectRatio: number;
+  heightFraction: number;
+  leftFraction: number;
+  topFraction: number;
+  widthFraction: number;
+}
+
+interface MeasureImageContentBoundsOptions {
+  imageUrl: string;
+}
+
+interface LoadedCanvasImage {
+  cleanup: () => void;
+  image: HTMLImageElement;
+}
+
+const imageContentBoundsCache = new Map<string, ImageContentBounds | null>();
+const imageContentBoundsPromiseCache = new Map<string, Promise<ImageContentBounds | null>>();
+
+export function measureImageContentBounds({
+  imageUrl,
+}: MeasureImageContentBoundsOptions): Promise<ImageContentBounds | null> {
+  if (imageContentBoundsCache.has(imageUrl)) {
+    return Promise.resolve(imageContentBoundsCache.get(imageUrl) ?? null);
+  }
+
+  const pendingBounds = imageContentBoundsPromiseCache.get(imageUrl);
+  if (pendingBounds) {
+    return pendingBounds;
+  }
+
+  const measurementPromise = computeImageContentBounds({
+    imageUrl,
+  }).then((nextBounds) => {
+    imageContentBoundsCache.set(imageUrl, nextBounds);
+    imageContentBoundsPromiseCache.delete(imageUrl);
+    return nextBounds;
+  });
+
+  imageContentBoundsPromiseCache.set(imageUrl, measurementPromise);
+  return measurementPromise;
+}
+
+async function computeImageContentBounds({
+  imageUrl,
+}: MeasureImageContentBoundsOptions): Promise<ImageContentBounds | null> {
+  let loadedImage: LoadedCanvasImage | null = null;
+  let fallback: ImageContentBounds | null = null;
+
+  try {
+    loadedImage = await loadCanvasSafeImage(imageUrl);
+    const image = loadedImage.image;
+    const width = image.naturalWidth;
+    const height = image.naturalHeight;
+
+    if (!width || !height) {
+      return null;
+    }
+
+    fallback = fullImageContentBounds(width, height);
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+    if (!context) {
+      return fallback;
+    }
+
+    context.clearRect(0, 0, width, height);
+    context.drawImage(image, 0, 0, width, height);
+
+    const data = context.getImageData(0, 0, width, height).data;
+    const alphaBounds = detectContentBounds(data, width, height, isTransparentBackgroundPixel);
+    if (alphaBounds && !isFullImageContentBounds(alphaBounds)) {
+      return alphaBounds;
+    }
+
+    const opaqueWhiteBounds = detectContentBounds(data, width, height, isOpaqueNeutralWhitePixel);
+    if (opaqueWhiteBounds && shouldUseOpaqueWhiteTrim(opaqueWhiteBounds)) {
+      return opaqueWhiteBounds;
+    }
+
+    return alphaBounds ?? fallback;
+  } catch {
+    return fallback;
+  } finally {
+    loadedImage?.cleanup();
+  }
+}
+
+function detectContentBounds(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+  isBackgroundPixel: (data: Uint8ClampedArray, pixelIndex: number) => boolean,
+) {
+  const backgroundMask = buildEdgeBackgroundMask(data, width, height, isBackgroundPixel);
+  let minX = width;
+  let minY = height;
+  let maxX = -1;
+  let maxY = -1;
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const pixelIndex = y * width + x;
+      if (backgroundMask[pixelIndex]) {
+        continue;
+      }
+
+      if (x < minX) {
+        minX = x;
+      }
+      if (y < minY) {
+        minY = y;
+      }
+      if (x > maxX) {
+        maxX = x;
+      }
+      if (y > maxY) {
+        maxY = y;
+      }
+    }
+  }
+
+  if (maxX < minX || maxY < minY) {
+    return fullImageContentBounds(width, height);
+  }
+
+  const contentWidth = maxX - minX + 1;
+  const contentHeight = maxY - minY + 1;
+
+  return {
+    leftFraction: minX / width,
+    topFraction: minY / height,
+    widthFraction: contentWidth / width,
+    heightFraction: contentHeight / height,
+    aspectRatio: contentWidth / Math.max(contentHeight, 1),
+  };
+}
+
+export function isFullImageContentBounds(bounds: ImageContentBounds) {
+  return (
+    nearlyEqual(bounds.leftFraction, 0, 0.001)
+    && nearlyEqual(bounds.topFraction, 0, 0.001)
+    && nearlyEqual(bounds.widthFraction, 1, 0.001)
+    && nearlyEqual(bounds.heightFraction, 1, 0.001)
+  );
+}
+
+function shouldUseOpaqueWhiteTrim(bounds: ImageContentBounds) {
+  if (isFullImageContentBounds(bounds)) {
+    return false;
+  }
+
+  const rightTrim = 1 - (bounds.leftFraction + bounds.widthFraction);
+  const bottomTrim = 1 - (bounds.topFraction + bounds.heightFraction);
+  const trimmedSides = [
+    bounds.leftFraction,
+    bounds.topFraction,
+    rightTrim,
+    bottomTrim,
+  ].filter((trimFraction) => trimFraction >= MIN_OPAQUE_EDGE_TRIM_FRACTION).length;
+  const visibleAreaFraction = bounds.widthFraction * bounds.heightFraction;
+
+  return (
+    trimmedSides >= 2
+    && 1 - visibleAreaFraction >= MIN_OPAQUE_EDGE_AREA_REDUCTION
+  );
+}
+
+function fullImageContentBounds(width: number, height: number): ImageContentBounds {
+  return {
+    aspectRatio: width / Math.max(height, 1),
+    heightFraction: 1,
+    leftFraction: 0,
+    topFraction: 0,
+    widthFraction: 1,
+  };
+}
+
+function buildEdgeBackgroundMask(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+  isBackgroundPixel: (data: Uint8ClampedArray, pixelIndex: number) => boolean,
+) {
+  const visited = new Uint8Array(width * height);
+  const queue = new Int32Array(width * height);
+  let queueStart = 0;
+  let queueEnd = 0;
+
+  function enqueue(x: number, y: number) {
+    if (x < 0 || y < 0 || x >= width || y >= height) {
+      return;
+    }
+
+    const pixelIndex = y * width + x;
+    if (visited[pixelIndex] || !isBackgroundPixel(data, pixelIndex)) {
+      return;
+    }
+
+    visited[pixelIndex] = 1;
+    queue[queueEnd] = pixelIndex;
+    queueEnd += 1;
+  }
+
+  for (let x = 0; x < width; x += 1) {
+    enqueue(x, 0);
+    enqueue(x, height - 1);
+  }
+
+  for (let y = 1; y < height - 1; y += 1) {
+    enqueue(0, y);
+    enqueue(width - 1, y);
+  }
+
+  while (queueStart < queueEnd) {
+    const pixelIndex = queue[queueStart];
+    queueStart += 1;
+
+    const x = pixelIndex % width;
+    const y = Math.floor(pixelIndex / width);
+
+    enqueue(x - 1, y);
+    enqueue(x + 1, y);
+    enqueue(x, y - 1);
+    enqueue(x, y + 1);
+  }
+
+  return visited;
+}
+
+function isTransparentBackgroundPixel(data: Uint8ClampedArray, pixelIndex: number) {
+  const alpha = data[pixelIndex * 4 + 3];
+  return alpha <= EDGE_BACKGROUND_ALPHA_THRESHOLD;
+}
+
+function isOpaqueNeutralWhitePixel(data: Uint8ClampedArray, pixelIndex: number) {
+  const channelOffset = pixelIndex * 4;
+  const red = data[channelOffset];
+  const green = data[channelOffset + 1];
+  const blue = data[channelOffset + 2];
+  const alpha = data[channelOffset + 3];
+  const maxChannel = Math.max(red, green, blue);
+  const minChannel = Math.min(red, green, blue);
+
+  return (
+    alpha > EDGE_BACKGROUND_ALPHA_THRESHOLD
+    && red >= EDGE_BACKGROUND_MIN_RGB
+    && green >= EDGE_BACKGROUND_MIN_RGB
+    && blue >= EDGE_BACKGROUND_MIN_RGB
+    && maxChannel - minChannel <= EDGE_BACKGROUND_MAX_RGB_DELTA
+  );
+}
+
+async function loadCanvasSafeImage(imageUrl: string): Promise<LoadedCanvasImage> {
+  if (imageUrl.startsWith("data:") || imageUrl.startsWith("blob:")) {
+    return {
+      cleanup: () => {},
+      image: await loadImageElement(imageUrl),
+    };
+  }
+
+  const response = await fetch(imageUrl, {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unable to load image ${imageUrl}: ${response.status}`);
+  }
+
+  const blob = await response.blob();
+  const objectUrl = URL.createObjectURL(blob);
+
+  try {
+    return {
+      cleanup: () => URL.revokeObjectURL(objectUrl),
+      image: await loadImageElement(objectUrl),
+    };
+  } catch (error) {
+    URL.revokeObjectURL(objectUrl);
+    throw error;
+  }
+}
+
+function loadImageElement(src: string) {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.decoding = "async";
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error(`Unable to decode image: ${src}`));
+    image.src = src;
+  });
+}
+
+function nearlyEqual(left: number, right: number, tolerance = 0.002) {
+  return Math.abs(left - right) <= tolerance;
+}

--- a/front-end/tests/outfit-collage-contracts.test.ts
+++ b/front-end/tests/outfit-collage-contracts.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveOutfitCollageLayouts } from "../src/app/lib/outfitCollage.ts";
+import {
+  COLLAGE_STAGE_ASPECT_RATIO,
+  normalizeOutfitCollageLayoutToAspectRatio,
+  resolveOutfitCollageResizeAspectRatio,
+} from "../src/app/lib/outfitCollageRenderMath.ts";
+
+function collageFrameRatio(layout: { width: number; height: number }) {
+  return (layout.width * COLLAGE_STAGE_ASPECT_RATIO) / Math.max(layout.height, 0.001);
+}
+
+test("saved collage layouts seed the editor with the same normalized preview frames", () => {
+  const items = [
+    {
+      id: 11,
+      layer_order: 0,
+      collage_layout: {
+        x: 18,
+        y: 10,
+        width: 44,
+        height: 48,
+        rotation: -8,
+        layer_order: 0,
+      },
+    },
+    {
+      id: 24,
+      layer_order: 1,
+      collage_layout: {
+        x: 36,
+        y: 32,
+        width: 40,
+        height: 42,
+        rotation: 6,
+        layer_order: 1,
+      },
+    },
+  ] as const;
+
+  const aspectRatioByItemId = {
+    11: 0.72,
+    24: 0.58,
+  } as const;
+
+  const editorSeedLayouts = resolveOutfitCollageLayouts(items as never);
+  const savedDisplayLayouts = Object.fromEntries(
+    items.map((item) => [
+      item.id,
+      normalizeOutfitCollageLayoutToAspectRatio(
+        item.collage_layout,
+        aspectRatioByItemId[item.id as keyof typeof aspectRatioByItemId],
+      ),
+    ]),
+  );
+  const editorDisplayLayouts = Object.fromEntries(
+    items.map((item) => [
+      item.id,
+      normalizeOutfitCollageLayoutToAspectRatio(
+        editorSeedLayouts[item.id],
+        aspectRatioByItemId[item.id as keyof typeof aspectRatioByItemId],
+      ),
+    ]),
+  );
+
+  assert.deepEqual(editorSeedLayouts[11], items[0].collage_layout);
+  assert.deepEqual(editorSeedLayouts[24], items[1].collage_layout);
+  assert.deepEqual(editorDisplayLayouts, savedDisplayLayouts);
+});
+
+test("normalized collage layouts are idempotent across repeated saved/editor renders", () => {
+  const layout = {
+    x: 12,
+    y: 48,
+    width: 76,
+    height: 36,
+    rotation: 2,
+    layer_order: 1,
+  };
+
+  const once = normalizeOutfitCollageLayoutToAspectRatio(layout, 0.64);
+  const twice = normalizeOutfitCollageLayoutToAspectRatio(once, 0.64);
+
+  assert.deepEqual(twice, once);
+});
+
+test("resize ratio fallback prefers the real image ratio over the current layout frame ratio", () => {
+  const intrinsicAspectRatio = 0.64;
+  const initialLayout = {
+    x: 12,
+    y: 41.19,
+    width: 76,
+    height: 36,
+    rotation: 2,
+    layer_order: 1,
+  };
+  const laterLayout = {
+    x: 40.4,
+    y: 63.26,
+    width: 47.06,
+    height: 14.27,
+    rotation: 2,
+    layer_order: 1,
+  };
+
+  assert.notEqual(collageFrameRatio(initialLayout), intrinsicAspectRatio);
+  assert.notEqual(collageFrameRatio(laterLayout), intrinsicAspectRatio);
+
+  assert.equal(
+    resolveOutfitCollageResizeAspectRatio({
+      intrinsicAspectRatio,
+      layout: initialLayout,
+    }),
+    intrinsicAspectRatio,
+  );
+  assert.equal(
+    resolveOutfitCollageResizeAspectRatio({
+      intrinsicAspectRatio,
+      layout: laterLayout,
+    }),
+    intrinsicAspectRatio,
+  );
+});

--- a/front-end/vite.config.ts
+++ b/front-end/vite.config.ts
@@ -42,6 +42,10 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: (requestPath) => requestPath.replace(/^\/api/, ''),
         },
+        '/rails/active_storage': {
+          target: `http://${backendHost}:${backendPort}`,
+          changeOrigin: true,
+        },
       },
     },
 


### PR DESCRIPTION
## Summary

This branch adds a full saved-outfit editing workflow and tightens the rendering contract between the outfit gallery and the Edit Outfit modal.

The main motivation was to make saved outfits feel like a real feature instead of a static list: users can now build outfits from the closet flow, see them rendered consistently on the `/outfits` page, and reopen them in an editor that preserves the same composition. Along the way, this branch also fixes a number of rendering, sizing, and mobile UX issues that made the outfit collage editor feel unreliable.

## Motivation

Before this branch:
- outfit creation and saved-outfit browsing were disconnected
- saved outfits did not have a strong edit flow for composition and metadata
- the `/outfits` page and the Edit Outfit modal could drift visually
- local Active Storage image handling caused noise and blocked some image-measurement behavior in development
- mobile editing put too much emphasis on controls instead of the outfit preview

This branch makes saved outfits a first-class workflow and reinforces an important repo contract: the saved outfit preview and the editor preview should behave as the same rendering system.

## External-Facing Changes

- Added a closet-side “outfit cart” flow so users can build an outfit from selected closet items, name it, tag it, and save it directly from the closet experience.
- Added a richer `/outfits` page for browsing saved looks.
- Added an Edit Outfit modal with:
  - direct move/resize/rotate controls for outfit items
  - layer selection and reordering
  - metadata editing for title, tags, and notes
- Made saved outfit cards slimmer and changed the default desktop gallery layout to three cards per row.
- Improved mobile editing so the outfit preview is the focal point, with details below the editor instead of competing for the same viewport.
- Tightened collage/editor behavior so resize controls stay aligned with the rendered item instead of drifting across repeated reselection/resizing.
- Improved cleaned PNG output by adding transparent-background post-processing and a sharpen step to make item imagery feel crisper.

## Internal-Facing Changes

### Frontend
- Added `OutfitCartSheet` and supporting closet-page orchestration for building outfits from selected closet items.
- Added a shared `OutfitCollageCanvas` renderer/editor based on `react-moveable`.
- Added `outfitCollage.ts` for shared layout defaults, ordering, clamping, and normalization helpers.
- Added `OutfitCollageLayersPanel.tsx` to separate layer controls from the main collage canvas.
- Added `outfitImageBounds.ts` for cached image-bounds measurement used by the collage renderer/editor.
- Added same-origin dev handling for local Active Storage media by proxying `/rails/active_storage` through Vite and normalizing attachment URLs on the frontend.
- Removed temporary collage debugging logs before merge while keeping the corrected resize/render behavior.

### Backend
- Added persistence for per-item outfit collage layout data.
- Updated outfit update flow to accept and validate saved item layout payloads.
- Updated API presenters so outfits return the layout data needed by the shared frontend collage renderer.
- Added model and integration coverage for saved layout behavior and layout constraints.
- Added transparent background cleanup/sharpening for cleaned item images.

## Documentation

Updated:
- `CHANGELOG.md`
- `PROJECT_INDEX.md`
- `front-end/README.md`
- `back-end/README.md`

to reflect the new outfit cart flow, saved outfit editor, collage rendering architecture, and clean-image pipeline changes.

## Testing

- `npm run build`
- `bin/rails test test/integration/outfits_flow_test.rb test/models/outfit_item_test.rb test/services/clean_image_background_remover_test.rb`

## Notes For Reviewers

The biggest architectural addition here is the shared outfit collage system. Both the saved gallery and the edit modal now depend on the same layout contract, which should make future outfit-editor work safer and easier to reason about.

Closes #118 