### PR TITLE
Add filter-aware closet search suggestions with fuzzy matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added filter-aware closet search suggestions with fuzzy typo matching: typing in the closet search field now opens an item dropdown that respects active tag, color, and brand filters, click fills the search query, and Enter opens the highlighted item.
 - Fixed Heroku frontend deploys by keeping the Vite build-time plugins (`@tailwindcss/vite` and `@vitejs/plugin-react`) in production dependencies and pinning the root Node runtime to `22.x`.
 - Added a configurable post-removal sharpen step to AI-cleaned transparent PNG outputs so item edges render a bit crisper after background removal.
 - Added automated saved-outfit collage contract coverage for backend round-trips and frontend layout math so saved cards, the editor preview, and resize-ratio fallback stay aligned.

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -79,7 +79,7 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
 - The saved-outfit collage editor is library-backed: `react-moveable` owns the move/resize/rotate controls, while `OutfitCollageCanvas` keeps the rendered image viewport and persisted collage layout data in sync.
 - The saved card and edit modal intentionally share the same collage-layout math: the editor seeds its layouts from the saved API payload, and both views normalize those layouts through the same render-math helpers so the saved preview matches what the editor shows after save.
 - Item and outfit text inputs are length-capped through `src/app/lib/inputLengthPolicy.ts`, which mirrors the backend `InputLengthPolicy` constants and applies them as `maxLength` on the relevant `<input>` and `<textarea>` controls.
-- Closet filtering and sorting are handled through focused helpers in `src/app/lib/closetFilters.ts`.
+- Closet filtering, fuzzy search, and sorting are handled through focused helpers in `src/app/lib/closetFilters.ts`. The closet search field shows filter-aware item suggestions while typing (click fills the query, Enter opens the highlighted item).
 - Item create and edit flows send multipart form data so photos can be uploaded, cropped, removed, or sourced from detected outfit-photo regions.
 - The item editor can request AI metadata suggestions for type, name, brand, and tags, and can request cleaned item imagery for catalog-style presentation; the backend now strips the generated white studio background before returning the final cleaned PNG.
 - Image-based item creation submits an outfit photo to `POST /outfit_uploads`, renders detections, and supports promoting a reviewed detection into a closet item.
@@ -104,7 +104,11 @@ Routes are coordinated in `src/app/App.tsx` and parsed in `src/app/lib/routes.ts
 - `tests/outfit-collage-contracts.test.ts`
   Node-based frontend contract tests covering saved-view/editor layout parity and the resize-aspect fallback that prevents reselection drift
 - `src/app/lib/closetFilters.ts`
-  Closet search, filter, and sort helpers
+  Closet search, fuzzy matching, filter-aware suggestion helpers, and sort helpers
+- `src/app/components/ClosetSearchField.tsx`
+  Closet page search input with filter-aware item suggestions (click to fill, Enter to open item)
+- `tests/closetFilters.test.ts`
+  Node-based tests for closet fuzzy search and filter-aware suggestions
 - `src/app/lib/usePageData.ts`
   Shared async page-loading hook
 - `src/app/lib/useItemPhotoState.ts`

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node --test tests/*.test.ts"
+    "test": "node --experimental-strip-types --test tests/*.test.ts"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useDeferredValue, useEffect, useState } from "react";
 import { motion } from "motion/react";
-import { Search, ShoppingBag } from "lucide-react";
+import { ShoppingBag } from "lucide-react";
 import { AddItemMenu } from "./components/AddItemMenu";
 import { ClothingCard } from "./components/ClothingCard";
 import { CreateItemPage } from "./components/CreateItemPage";
@@ -40,7 +40,7 @@ import { HomeLanding } from "./components/shared/HomeLanding";
 import { NotFoundPage } from "./components/shared/NotFoundPage";
 import { SiteFooter } from "./components/shared/SiteFooter";
 import { SiteHeader } from "./components/shared/SiteHeader";
-import { Input } from "./components/ui/input";
+import { ClosetSearchField } from "./components/ClosetSearchField";
 import {
   ClothingItem,
   createOutfit,
@@ -57,6 +57,8 @@ import {
   buildGroupedTagOptions,
   ClosetSortOption,
   filterClothingItems,
+  formatClosetSearchSuggestionLabel,
+  getClosetSearchSuggestions,
   hasActiveClosetControls,
 } from "./lib/closetFilters";
 import {
@@ -318,6 +320,15 @@ export default function App() {
     selectedColors,
     selectedOtherTags,
     sortOption,
+  );
+  const closetSearchSuggestions = getClosetSearchSuggestions(
+    clothingItems,
+    searchQuery,
+    selectedBrands,
+    selectedColors,
+    selectedOtherTags,
+    sortOption,
+    { limit: 8 },
   );
   const hasActiveFilters = hasActiveClosetControls(
     searchQuery,
@@ -644,15 +655,19 @@ export default function App() {
               className="mb-8 space-y-5"
             >
               <div className="space-y-3 min-[660px]:grid min-[660px]:gap-3 min-[660px]:space-y-0 min-[660px]:grid-cols-[minmax(0,3.2fr)_repeat(3,minmax(0,0.8fr))_minmax(0,1fr)] min-[660px]:items-start">
-                <div className="relative min-w-0 self-start">
+                <div className="min-w-0 self-start">
                   <label htmlFor="closet-search" className="sr-only">
                     Search closet items
                   </label>
-                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                  <Input
+                  <ClosetSearchField
                     id="closet-search"
                     value={searchQuery}
-                    onChange={(event) => setSearchQuery(event.target.value)}
+                    onChange={setSearchQuery}
+                    suggestions={closetSearchSuggestions}
+                    onSelectSuggestion={(item) =>
+                      setSearchQuery(formatClosetSearchSuggestionLabel(item))
+                    }
+                    onOpenItem={(item) => navigateTo(`/items/${item.id}`)}
                     placeholder="Search by name or describe an item with tags"
                     className="h-14 pl-10"
                   />

--- a/front-end/src/app/components/ClosetSearchField.tsx
+++ b/front-end/src/app/components/ClosetSearchField.tsx
@@ -1,0 +1,159 @@
+import { KeyboardEvent, useEffect, useState } from "react";
+import { Search } from "lucide-react";
+import { ClothingItem } from "../lib/closet";
+import {
+  formatClosetSearchSuggestionDetail,
+  formatClosetSearchSuggestionLabel,
+} from "../lib/closetFilters";
+import { Input } from "./ui/input";
+import { Popover, PopoverAnchor, PopoverContent } from "./ui/popover";
+import { Command, CommandGroup, CommandItem, CommandList } from "./ui/command";
+import { PrimitiveText } from "./primitives/PrimitiveText";
+
+interface ClosetSearchFieldProps {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  suggestions: ClothingItem[];
+  onSelectSuggestion: (item: ClothingItem) => void;
+  onOpenItem: (item: ClothingItem) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+export function ClosetSearchField({
+  id,
+  value,
+  onChange,
+  suggestions,
+  onSelectSuggestion,
+  onOpenItem,
+  placeholder,
+  className,
+}: ClosetSearchFieldProps) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const showSuggestions = open && value.trim().length > 0 && suggestions.length > 0;
+
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [value, suggestions]);
+
+  function closeSuggestions() {
+    setOpen(false);
+    setActiveIndex(-1);
+  }
+
+  function handleInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeSuggestions();
+      return;
+    }
+
+    if (!showSuggestions) {
+      if (event.key === "ArrowDown" && suggestions.length > 0) {
+        event.preventDefault();
+        setOpen(true);
+        setActiveIndex(0);
+      }
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((current) => Math.min(current + 1, suggestions.length - 1));
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((current) => Math.max(current - 1, 0));
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const targetIndex = activeIndex >= 0 ? activeIndex : 0;
+      const targetItem = suggestions[targetIndex];
+      if (targetItem) {
+        onOpenItem(targetItem);
+        closeSuggestions();
+      }
+    }
+  }
+
+  return (
+    <Popover open={showSuggestions} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div className="relative min-w-0">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            id={id}
+            value={value}
+            placeholder={placeholder}
+            className={className}
+            role="combobox"
+            aria-expanded={showSuggestions}
+            aria-controls={showSuggestions ? `${id}-suggestions` : undefined}
+            aria-autocomplete="list"
+            onChange={(event) => {
+              onChange(event.target.value);
+              setOpen(event.target.value.trim().length > 0);
+            }}
+            onFocus={() => {
+              if (value.trim().length > 0 && suggestions.length > 0) {
+                setOpen(true);
+              }
+            }}
+            onBlur={() => {
+              window.setTimeout(() => closeSuggestions(), 150);
+            }}
+            onKeyDown={handleInputKeyDown}
+          />
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        id={`${id}-suggestions`}
+        align="start"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        className="p-0"
+        style={{ width: "var(--radix-popover-trigger-width)" }}
+      >
+        <Command shouldFilter={false}>
+          <CommandList>
+            <CommandGroup>
+              {suggestions.map((item, index) => {
+                const detail = formatClosetSearchSuggestionDetail(item);
+                return (
+                  <CommandItem
+                    key={item.id}
+                    value={String(item.id)}
+                    data-selected={index === activeIndex ? true : undefined}
+                    className="flex flex-col items-start gap-0.5 py-2"
+                    onMouseEnter={() => setActiveIndex(index)}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      onSelectSuggestion(item);
+                      closeSuggestions();
+                    }}
+                  >
+                    <PrimitiveText as="span" variant="bodySm">
+                      {formatClosetSearchSuggestionLabel(item)}
+                    </PrimitiveText>
+                    {detail ? (
+                      <PrimitiveText as="span" variant="bodySm" tone="muted">
+                        {detail}
+                      </PrimitiveText>
+                    ) : null}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/front-end/src/app/lib/closetFilters.ts
+++ b/front-end/src/app/lib/closetFilters.ts
@@ -67,18 +67,100 @@ function itemMatchesSelectedBrand(item: ClothingItem, selectedBrand: string): bo
   return normalizeKey(itemBrand) === normalizeKey(selectedBrand);
 }
 
-export function matchesSearchQuery(item: ClothingItem, query: string) {
+export function buildClothingItemSearchHaystack(item: ClothingItem): string {
+  return [item.name, item.category, item.brand, item.size, ...item.tags]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function levenshteinDistance(left: string, right: string): number {
+  if (left === right) {
+    return 0;
+  }
+
+  if (left.length === 0) {
+    return right.length;
+  }
+
+  if (right.length === 0) {
+    return left.length;
+  }
+
+  const rows = left.length + 1;
+  const cols = right.length + 1;
+  const matrix = Array.from({ length: rows }, () => Array<number>(cols).fill(0));
+
+  for (let row = 0; row < rows; row += 1) {
+    matrix[row][0] = row;
+  }
+
+  for (let col = 0; col < cols; col += 1) {
+    matrix[0][col] = col;
+  }
+
+  for (let row = 1; row < rows; row += 1) {
+    for (let col = 1; col < cols; col += 1) {
+      const cost = left[row - 1] === right[col - 1] ? 0 : 1;
+      matrix[row][col] = Math.min(
+        matrix[row - 1][col] + 1,
+        matrix[row][col - 1] + 1,
+        matrix[row - 1][col - 1] + cost,
+      );
+    }
+  }
+
+  return matrix[rows - 1][cols - 1];
+}
+
+function maxFuzzyDistance(term: string, candidate: string): number {
+  const shortest = Math.min(term.length, candidate.length);
+  if (shortest <= 3) {
+    return 0;
+  }
+  if (shortest <= 6) {
+    return 1;
+  }
+  return 2;
+}
+
+export function termMatchesInHaystack(term: string, haystack: string): boolean {
+  const normalizedTerm = term.trim().toLowerCase();
+  if (!normalizedTerm) {
+    return true;
+  }
+
+  if (haystack.includes(normalizedTerm)) {
+    return true;
+  }
+
+  if (normalizedTerm.length < 3) {
+    return false;
+  }
+
+  const tokens = haystack.split(/\s+/).filter(Boolean);
+  return tokens.some((token) => {
+    if (token.includes(normalizedTerm) || normalizedTerm.includes(token)) {
+      return true;
+    }
+
+    const allowedDistance = maxFuzzyDistance(normalizedTerm, token);
+    if (allowedDistance === 0) {
+      return false;
+    }
+
+    return levenshteinDistance(normalizedTerm, token) <= allowedDistance;
+  });
+}
+
+export function matchesSearchQuery(item: ClothingItem, query: string): boolean {
   const normalizedQuery = query.trim().toLowerCase();
   if (!normalizedQuery) {
     return true;
   }
 
-  const haystack = [item.name, item.size, item.brand, ...item.tags]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-
-  return normalizedQuery.split(/\s+/).every((term) => haystack.includes(term));
+  const haystack = buildClothingItemSearchHaystack(item);
+  return normalizedQuery.split(/\s+/).every((term) => termMatchesInHaystack(term, haystack));
 }
 
 export function sortClothingItems(items: ClothingItem[], sortOption: ClosetSortOption) {
@@ -137,6 +219,25 @@ export function buildGroupedTagOptions(items: ClothingItem[]): GroupedTagOptions
   };
 }
 
+export function passesClothingItemFilters(
+  item: ClothingItem,
+  selectedBrands: string[],
+  selectedColors: string[],
+  selectedOtherTags: string[],
+): boolean {
+  const selectedTagTokens = [...selectedColors, ...selectedOtherTags];
+
+  if (selectedTagTokens.length > 0 && !selectedTagTokens.some((tag) => item.tags.includes(tag))) {
+    return false;
+  }
+
+  if (selectedBrands.length > 0 && !selectedBrands.some((brand) => itemMatchesSelectedBrand(item, brand))) {
+    return false;
+  }
+
+  return true;
+}
+
 export function filterClothingItems(
   items: ClothingItem[],
   searchQuery: string,
@@ -145,15 +246,9 @@ export function filterClothingItems(
   selectedOtherTags: string[],
   sortOption: ClosetSortOption,
 ) {
-  const selectedTagTokens = [...selectedColors, ...selectedOtherTags];
-
   return sortClothingItems(
     items.filter((item) => {
-      if (selectedTagTokens.length > 0 && !selectedTagTokens.some((tag) => item.tags.includes(tag))) {
-        return false;
-      }
-
-      if (selectedBrands.length > 0 && !selectedBrands.some((brand) => itemMatchesSelectedBrand(item, brand))) {
+      if (!passesClothingItemFilters(item, selectedBrands, selectedColors, selectedOtherTags)) {
         return false;
       }
 
@@ -161,6 +256,42 @@ export function filterClothingItems(
     }),
     sortOption,
   );
+}
+
+export function getClosetSearchSuggestions(
+  items: ClothingItem[],
+  searchQuery: string,
+  selectedBrands: string[],
+  selectedColors: string[],
+  selectedOtherTags: string[],
+  sortOption: ClosetSortOption,
+  options: { limit?: number } = {},
+): ClothingItem[] {
+  const limit = options.limit ?? 8;
+  if (!searchQuery.trim()) {
+    return [];
+  }
+
+  return filterClothingItems(
+    items,
+    searchQuery,
+    selectedBrands,
+    selectedColors,
+    selectedOtherTags,
+    sortOption,
+  ).slice(0, limit);
+}
+
+export function formatClosetSearchSuggestionLabel(item: ClothingItem): string {
+  return item.name.trim();
+}
+
+export function formatClosetSearchSuggestionDetail(item: ClothingItem): string | null {
+  const parts = [item.brand?.trim(), item.category?.trim(), ...item.tags.slice(0, 2)].filter(Boolean);
+  if (parts.length === 0) {
+    return item.size ? `Size ${item.size}` : null;
+  }
+  return parts.join(" · ");
 }
 
 export function hasActiveClosetControls(

--- a/front-end/tests/closetFilters.test.ts
+++ b/front-end/tests/closetFilters.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ClothingItem } from "../src/app/lib/closet.ts";
+import {
+  getClosetSearchSuggestions,
+  matchesSearchQuery,
+  termMatchesInHaystack,
+} from "../src/app/lib/closetFilters.ts";
+
+function makeItem(overrides: Partial<ClothingItem> & Pick<ClothingItem, "id" | "name">): ClothingItem {
+  return {
+    id: overrides.id,
+    name: overrides.name,
+    size: overrides.size ?? "medium",
+    date: overrides.date ?? null,
+    user_id: overrides.user_id ?? 1,
+    tags: overrides.tags ?? [],
+    brand: overrides.brand ?? null,
+    category: overrides.category ?? null,
+    created_at: overrides.created_at,
+  };
+}
+
+test("termMatchesInHaystack supports substring matches", () => {
+  assert.equal(termMatchesInHaystack("blue", "navy blue sweater"), true);
+});
+
+test("termMatchesInHaystack supports fuzzy typo matches", () => {
+  assert.equal(termMatchesInHaystack("swetshirt", "gray sweatshirt cotton"), true);
+  assert.equal(termMatchesInHaystack("nikee", "nike running shoes"), true);
+});
+
+test("matchesSearchQuery requires every term to match", () => {
+  const item = makeItem({ id: 1, name: "Navy Wool Sweater", tags: ["wool", "blue"] });
+
+  assert.equal(matchesSearchQuery(item, "navy wool"), true);
+  assert.equal(matchesSearchQuery(item, "navy leather"), false);
+});
+
+test("getClosetSearchSuggestions returns empty list for blank query", () => {
+  const items = [makeItem({ id: 1, name: "Denim Jacket", tags: ["denim"] })];
+
+  assert.deepEqual(
+    getClosetSearchSuggestions(items, "   ", [], [], [], "name-asc"),
+    [],
+  );
+});
+
+test("getClosetSearchSuggestions respects active filters", () => {
+  const items = [
+    makeItem({ id: 1, name: "Blue Tee", brand: "Nike", tags: ["blue", "cotton"] }),
+    makeItem({ id: 2, name: "Red Tee", brand: "Adidas", tags: ["red", "cotton"] }),
+  ];
+
+  const suggestions = getClosetSearchSuggestions(
+    items,
+    "tee",
+    ["Nike"],
+    [],
+    [],
+    "name-asc",
+    { limit: 8 },
+  );
+
+  assert.equal(suggestions.length, 1);
+  assert.equal(suggestions[0]?.id, 1);
+});
+
+test("getClosetSearchSuggestions limits results", () => {
+  const items = Array.from({ length: 12 }, (_, index) =>
+    makeItem({ id: index + 1, name: `Item ${index + 1}`, tags: ["shared"] }),
+  );
+
+  const suggestions = getClosetSearchSuggestions(
+    items,
+    "item",
+    [],
+    [],
+    [],
+    "name-asc",
+    { limit: 3 },
+  );
+
+  assert.equal(suggestions.length, 3);
+});


### PR DESCRIPTION
Summary

- Adds a typeahead dropdown to closet search while typing (not on empty focus).
- Suggestions use the same filter + search pipeline as the grid, including Brand/Color/Tag filters.
- Adds fuzzy matching (Levenshtein) so typos like `swetshirt` still return matches.
- Click suggestion → fills search and narrows grid.
- Enter on highlighted suggestion → navigates to `/items/:id`.
- Adds `closetFilters` unit tests and updates README/CHANGELOG.

Test plan

- Sign in and open closet with several items.
- Empty search focus → no dropdown.
- Partial query → dropdown + grid show matches.
- Click suggestion → search fills and grid updates.
- Highlight + Enter → opens item detail page.
- Active Brand/Color/Tag filters apply to suggestions.
- Typo query still returns fuzzy matches.
- Nonsense query → no dropdown; empty state unchanged.
- Escape or blur → dropdown closes.