### PR TITLE
Add email/password auth and account management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added email/password registration, sign-in, password reset, and account settings (profile edit, change password, delete account) alongside existing Google OAuth, with terms acceptance on signup and protected-route redirects to `/sign-in`.
 - Patched audited backend dependencies by upgrading `puma` to `8.0.2`, `erb` to `6.0.4`, `faraday` to `2.14.2`, `jwt` to `3.2.0`, and the transitive OAuth stack to `oauth2 2.0.22` so the branch clears the current `bundler-audit` CVEs for the Rails server and Google sign-in path.
 - Added filter-aware closet search suggestions with fuzzy typo matching: typing in the closet search field now opens an item dropdown that respects active tag, color, and brand filters, click fills the search query, and Enter opens the highlighted item.
 - Added explicit OpenRouter completion-token caps for structured vision, metadata suggestion, and AI clean-image requests, with backend env overrides, so per-key spend limits are less likely to reject a single request for asking for too large a completion budget.

--- a/back-end/app/controllers/application_controller.rb
+++ b/back-end/app/controllers/application_controller.rb
@@ -58,7 +58,7 @@ class ApplicationController < ActionController::API
   def require_login
     return if logged_in?
 
-    render_unauthorized("Please sign in with Google.")
+    render_unauthorized("Please sign in to continue.")
   end
 
   def require_admin

--- a/back-end/app/controllers/password_resets_controller.rb
+++ b/back-end/app/controllers/password_resets_controller.rb
@@ -1,0 +1,51 @@
+class PasswordResetsController < ApplicationController
+  def create
+    email = params.dig(:password_reset, :email).to_s.strip.downcase
+    user = User.find_by_normalized_email(email)
+
+    development_reset_url = nil
+
+    if user&.password_login_enabled?
+      token = user.generate_token_for(:password_reset)
+      UserMailer.password_reset(user, token).deliver_later
+      development_reset_url = frontend_password_reset_url(token) if Rails.env.development?
+    end
+
+    payload = {
+      message: "If an account with that email exists, password reset instructions were sent."
+    }
+    payload[:development_reset_url] = development_reset_url if development_reset_url.present?
+
+    render json: payload
+  end
+
+  def update
+    user = User.find_by_password_reset_token(params.dig(:password_reset, :token).to_s)
+    if user.nil?
+      render json: { error: "This reset link is invalid or has expired." }, status: :unprocessable_content
+      return
+    end
+
+    user.password = params.dig(:password_reset, :password)
+    user.password_confirmation = params.dig(:password_reset, :password_confirmation)
+
+    if user.save
+      render json: { message: "Your password has been updated. You can sign in now." }
+    else
+      render_validation_errors(user)
+    end
+  end
+
+  private
+
+  def frontend_password_reset_url(token)
+    base = ENV["FRONTEND_BASE_URL"].presence || begin
+      host = ENV.fetch("FRONTEND_HOST", "127.0.0.1")
+      port = ENV.fetch("FRONTEND_PORT", "5173")
+      scheme = ENV.fetch("FRONTEND_SCHEME", "http")
+      "#{scheme}://#{host}:#{port}"
+    end
+
+    "#{base}/reset-password?token=#{CGI.escape(token)}"
+  end
+end

--- a/back-end/app/controllers/sessions_controller.rb
+++ b/back-end/app/controllers/sessions_controller.rb
@@ -1,18 +1,11 @@
 class SessionsController < ApplicationController
   def create
-    auth_hash = request.env["omniauth.auth"]
-    if auth_hash.blank?
-      redirect_to frontend_login_redirect(error: "google_auth_failed")
+    if request.env["omniauth.auth"].present?
+      create_from_google
       return
     end
 
-    user = User.from_google_auth(auth_hash)
-    reset_session
-    session[:user_id] = user.id
-
-    redirect_to frontend_closet_redirect
-  rescue ActiveRecord::RecordInvalid
-    redirect_to frontend_login_redirect(error: "signin_failed")
+    create_from_credentials
   end
 
   def failure
@@ -31,6 +24,32 @@ class SessionsController < ApplicationController
   end
 
   private
+
+  def create_from_google
+    auth_hash = request.env["omniauth.auth"]
+    user = User.from_google_auth(auth_hash)
+    reset_session
+    session[:user_id] = user.id
+
+    redirect_to frontend_closet_redirect
+  rescue ActiveRecord::RecordInvalid
+    redirect_to frontend_login_redirect(error: "signin_failed")
+  end
+
+  def create_from_credentials
+    email = params.dig(:session, :email).to_s.strip.downcase
+    password = params.dig(:session, :password).to_s
+    user = User.find_by_normalized_email(email)
+
+    unless user&.password_login_enabled? && user.authenticate(password)
+      render_unauthorized("Invalid email or password.")
+      return
+    end
+
+    reset_session
+    session[:user_id] = user.id
+    render json: payloads.user(user)
+  end
 
   def frontend_base_url
     configured_base_url = ENV["FRONTEND_BASE_URL"]&.strip
@@ -52,6 +71,6 @@ class SessionsController < ApplicationController
   end
 
   def frontend_login_redirect(error:)
-    "#{frontend_base_url}/?auth_error=#{CGI.escape(error)}"
+    "#{frontend_base_url}/sign-in?auth_error=#{CGI.escape(error)}"
   end
 end

--- a/back-end/app/controllers/users_controller.rb
+++ b/back-end/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :require_login
+  before_action :require_login, except: :create
   before_action :require_admin, only: %i[index show]
   before_action :set_user, only: %i[ show update destroy ]
 
@@ -26,10 +26,26 @@ class UsersController < ApplicationController
   end
 
   def create
-    render_unauthorized("User creation is handled through Google sign-in.")
+    user = User.register_with_password!(registration_params)
+    reset_session
+    session[:user_id] = user.id
+    render json: payloads.user(user), status: :created
+  rescue ActiveRecord::RecordInvalid => error
+    render_validation_errors(error.record)
   end
 
   def update
+    if password_change_requested? && !@user.password_login_enabled?
+      render json: { error: "Password is managed through Google sign-in for this account." },
+             status: :unprocessable_content
+      return
+    end
+
+    if password_change_requested? && !@user.authenticate_current_password(params.dig(:user, :current_password))
+      render json: { error: "Current password is incorrect." }, status: :unauthorized
+      return
+    end
+
     if @user.update(user_params)
       render json: payloads.user(@user)
     else
@@ -38,7 +54,14 @@ class UsersController < ApplicationController
   end
 
   def destroy
+    if @user.password_login_enabled? && !@user.authenticate_current_password(params.dig(:user, :password))
+      render json: { error: "Current password is incorrect." }, status: :unauthorized
+      return
+    end
+
+    deleting_self = @user.id == current_user.id
     @user.destroy
+    reset_session if deleting_self
     head :no_content
   end
 
@@ -48,14 +71,36 @@ class UsersController < ApplicationController
     @user = admin? ? User.find(params[:id]) : current_user
   end
 
+  def registration_params
+    params.require(:user).permit(
+      :username,
+      :email,
+      :preferred_style,
+      :password,
+      :password_confirmation,
+      :accepted_terms
+    )
+  end
+
   def user_params
-    permitted = params.require(:user).permit(:username, :preferred_style, :password, :password_confirmation)
+    permitted = params.require(:user).permit(
+      :username,
+      :preferred_style,
+      :password,
+      :password_confirmation
+    )
 
     if permitted[:password].blank? && permitted[:password_confirmation].blank?
       permitted.except(:password, :password_confirmation)
     else
       permitted
     end
+  end
+
+  def password_change_requested?
+    password = params.dig(:user, :password).to_s
+    password_confirmation = params.dig(:user, :password_confirmation).to_s
+    password.present? || password_confirmation.present?
   end
 
   def resolved_per_page

--- a/back-end/app/mailers/user_mailer.rb
+++ b/back-end/app/mailers/user_mailer.rb
@@ -1,0 +1,27 @@
+class UserMailer < ApplicationMailer
+  def password_reset(user, token)
+    @user = user
+    @reset_url = password_reset_url(token: token)
+
+    mail to: user.email, subject: "Reset your #{PROJECT_NAME} password"
+  end
+
+  private
+
+  PROJECT_NAME = "Curated Closet"
+
+  def password_reset_url(token:)
+    "#{frontend_base_url}/reset-password?token=#{CGI.escape(token)}"
+  end
+
+  def frontend_base_url
+    configured = ENV["FRONTEND_BASE_URL"]&.strip
+    return configured if configured.present?
+
+    host = ENV.fetch("FRONTEND_HOST", "127.0.0.1")
+    port = ENV.fetch("FRONTEND_PORT", "5173")
+    scheme = ENV.fetch("FRONTEND_SCHEME", "http")
+
+    "#{scheme}://#{host}:#{port}"
+  end
+end

--- a/back-end/app/models/user.rb
+++ b/back-end/app/models/user.rb
@@ -1,17 +1,29 @@
 class User < ApplicationRecord
+  EMAIL_PROVIDER = "email"
+  GOOGLE_PROVIDER = "google_oauth2"
+
   has_secure_password
 
   has_many :clothing_items, dependent: :destroy
   has_many :outfits, dependent: :destroy
   has_many :outfit_uploads, dependent: :destroy
 
+  generates_token_for :password_reset, expires_in: 2.hours do
+    password_salt&.last(10)
+  end
+
   validates :username, presence: true, uniqueness: true,
                        length: { maximum: InputLengthPolicy::MAX_USERNAME }
-  validates :email, length: { maximum: InputLengthPolicy::MAX_EMAIL }, allow_blank: true
+  validates :email, length: { maximum: InputLengthPolicy::MAX_EMAIL },
+                    uniqueness: { case_sensitive: false, allow_blank: true }
+  validates :email, presence: true, if: :email_account?
   validates :preferred_style, length: { maximum: InputLengthPolicy::MAX_PREFERRED_STYLE },
                               allow_blank: true
   validates :provider, presence: true
   validates :uid, presence: true, uniqueness: { scope: :provider }
+  validate :accepted_terms_must_be_present, on: :registration
+
+  attr_accessor :accepted_terms, :current_password
 
   def self.from_google_auth(auth_hash)
     user = find_for_google_auth(auth_hash)
@@ -22,7 +34,8 @@ class User < ApplicationRecord
       uid: auth_hash.uid,
       email: auth_hash.info.email,
       username: resolved_google_username(user, preferred_username),
-      avatar_url: auth_hash.info.image
+      avatar_url: auth_hash.info.image,
+      accepted_terms_at: user.accepted_terms_at || Time.current
     )
 
     user.password = SecureRandom.hex(24) if user.new_record?
@@ -30,10 +43,44 @@ class User < ApplicationRecord
     user
   end
 
+  def self.register_with_password!(attributes)
+    existing = find_by_normalized_email(attributes[:email])
+    if existing.present?
+      if existing.google_account?
+        raise ActiveRecord::RecordInvalid.new(existing.tap {
+          _1.errors.add(:email, "is already linked to Google sign-in. Use Google to access that account.")
+        })
+      end
+
+      raise ActiveRecord::RecordInvalid.new(existing.tap {
+        _1.errors.add(:email, "is already in use.")
+      })
+    end
+
+    accepted_terms = ActiveModel::Type::Boolean.new.cast(attributes[:accepted_terms])
+    user = new(
+      username: attributes[:username].to_s.strip,
+      email: attributes[:email].to_s.strip.downcase,
+      preferred_style: attributes[:preferred_style].to_s.strip.presence,
+      provider: EMAIL_PROVIDER,
+      uid: email_uid(attributes[:email])
+    )
+    user.accepted_terms = accepted_terms
+    user.accepted_terms_at = Time.current if accepted_terms
+    user.password = attributes[:password]
+    user.password_confirmation = attributes[:password_confirmation]
+    user.save!(context: :registration)
+    user
+  end
+
   def self.find_for_google_auth(auth_hash)
     find_by(provider: auth_hash.provider, uid: auth_hash.uid) ||
       find_by_normalized_email(auth_hash.info.email) ||
       new
+  end
+
+  def self.find_by_password_reset_token(token)
+    find_by_token_for(:password_reset, token.to_s)
   end
 
   def self.resolved_google_username(user, preferred_username)
@@ -56,10 +103,42 @@ class User < ApplicationRecord
     where("lower(email) = ?", email.to_s.downcase).first
   end
 
+  def self.email_uid(email)
+    email.to_s.strip.downcase
+  end
+
   def self.username_taken?(username, except_id: nil)
     scope = where(username: username)
     scope = scope.where.not(id: except_id) if except_id.present?
     scope.exists?
   end
-  private_class_method :find_for_google_auth, :find_by_normalized_email, :resolved_google_username, :username_taken?
+
+  def email_account?
+    provider == EMAIL_PROVIDER
+  end
+
+  def google_account?
+    provider == GOOGLE_PROVIDER
+  end
+
+  def password_login_enabled?
+    email_account?
+  end
+
+  def authenticate_current_password(candidate)
+    return true unless password_login_enabled?
+
+    authenticate(candidate.to_s).present?
+  end
+
+  private_class_method :find_for_google_auth, :resolved_google_username, :username_taken?, :email_uid
+
+  private
+
+  def accepted_terms_must_be_present
+    return if accepted_terms_at.present?
+    return if ActiveModel::Type::Boolean.new.cast(accepted_terms)
+
+    errors.add(:accepted_terms, "must be accepted before creating an account.")
+  end
 end

--- a/back-end/app/presenters/api_payloads.rb
+++ b/back-end/app/presenters/api_payloads.rb
@@ -18,6 +18,9 @@ class ApiPayloads
       payload["clothing_items_count"] = clothing_item_count_for_user(user)
     end
 
+    payload["auth_provider"] = user.provider
+    payload["password_login_enabled"] = user.password_login_enabled?
+
     payload
   end
 

--- a/back-end/app/views/user_mailer/password_reset.text.erb
+++ b/back-end/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,8 @@
+Hi <%= @user.username %>,
+
+We received a request to reset your Curated Closet password.
+
+Open this link to choose a new password (valid for 2 hours):
+<%= @reset_url %>
+
+If you did not request a reset, you can ignore this email.

--- a/back-end/config/routes.rb
+++ b/back-end/config/routes.rb
@@ -14,7 +14,10 @@ Rails.application.routes.draw do
   scope defaults: { format: :json } do
     root "clothing_items#index"
     get "me", to: "sessions#me"
+    post "session", to: "sessions#create"
     delete "session", to: "sessions#destroy"
+    post "password_reset", to: "password_resets#create"
+    patch "password_reset", to: "password_resets#update"
 
     resources :users, except: %i[new edit]
     resources :clothing_items, except: %i[new edit] do

--- a/back-end/db/migrate/20260518200000_add_account_auth_fields_to_users.rb
+++ b/back-end/db/migrate/20260518200000_add_account_auth_fields_to_users.rb
@@ -1,0 +1,12 @@
+class AddAccountAuthFieldsToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :accepted_terms_at, :datetime unless column_exists?(:users, :accepted_terms_at)
+
+    if index_exists?(:users, :email, name: "index_users_on_email")
+      remove_index :users, name: "index_users_on_email"
+    end
+
+    add_index :users, :email, unique: true, where: "email IS NOT NULL AND email != ''",
+                              name: "index_users_on_email"
+  end
+end

--- a/back-end/db/schema.rb
+++ b/back-end/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_25_214500) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_21_165312) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -42,16 +42,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_214500) do
   create_table "clothing_items", force: :cascade do |t|
     t.string "brand", limit: 80
     t.string "category", limit: 60
-    t.boolean "clean_image_cutout_fallback", default: false
     t.text "clean_image_error_message"
     t.datetime "clean_image_generated_at"
     t.string "clean_image_model"
     t.string "clean_image_provider"
     t.integer "clean_image_status", default: 0, null: false
-    t.string "clean_image_variant"
     t.datetime "created_at", null: false
     t.datetime "date"
     t.string "name", limit: 120, null: false
+    t.string "purchase_currency", limit: 3
+    t.decimal "purchase_price", precision: 10, scale: 2
     t.integer "size"
     t.integer "source_outfit_detection_id"
     t.integer "source_outfit_upload_id"
@@ -69,13 +69,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_214500) do
     t.float "bbox_x"
     t.float "bbox_y"
     t.string "category", null: false
-    t.boolean "clean_image_cutout_fallback", default: false
     t.text "clean_image_error_message"
     t.datetime "clean_image_generated_at"
     t.string "clean_image_model"
     t.string "clean_image_provider"
     t.integer "clean_image_status", default: 0, null: false
-    t.string "clean_image_variant"
     t.float "coarse_bbox_height"
     t.float "coarse_bbox_width"
     t.float "coarse_bbox_x"
@@ -143,6 +141,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_214500) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.datetime "accepted_terms_at"
     t.boolean "admin", default: false, null: false
     t.string "avatar_url"
     t.datetime "created_at", null: false
@@ -153,7 +152,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_214500) do
     t.string "uid", limit: 255, null: false
     t.datetime "updated_at", null: false
     t.string "username", limit: 60, null: false
-    t.index ["email"], name: "index_users_on_email"
+    t.index ["email"], name: "index_users_on_email", unique: true, where: "email IS NOT NULL AND email != ''"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 

--- a/back-end/test/integration/auth_flow_test.rb
+++ b/back-end/test/integration/auth_flow_test.rb
@@ -1,0 +1,137 @@
+require "test_helper"
+
+class AuthFlowTest < ActionDispatch::IntegrationTest
+  test "can register with email and password" do
+    assert_difference("User.count", 1) do
+      post users_url, params: {
+        user: {
+          username: "sam closet",
+          email: "sam@example.com",
+          preferred_style: "minimal",
+          password: "password123",
+          password_confirmation: "password123",
+          accepted_terms: true
+        }
+      }, as: :json
+    end
+
+    assert_response :created
+    assert_equal "sam closet", response_json["username"]
+    assert_equal "email", response_json["auth_provider"]
+    assert response_json["password_login_enabled"]
+  end
+
+  test "registration requires accepted terms" do
+    assert_no_difference("User.count") do
+      post users_url, params: {
+        user: {
+          username: "no terms",
+          email: "noterms@example.com",
+          password: "password123",
+          password_confirmation: "password123",
+          accepted_terms: false
+        }
+      }, as: :json
+    end
+
+    assert_response :unprocessable_content
+    assert_includes response_json["errors"], "Accepted terms must be accepted before creating an account."
+  end
+
+  test "can sign in with email and password" do
+    post session_url, params: {
+      session: {
+        email: users(:one).email,
+        password: "password123"
+      }
+    }, as: :json
+
+    assert_response :unauthorized
+
+    user = User.register_with_password!(
+      username: "login user",
+      email: "login@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      accepted_terms: true
+    )
+
+    post session_url, params: {
+      session: {
+        email: user.email,
+        password: "password123"
+      }
+    }, as: :json
+
+    assert_response :success
+    assert_equal user.id, response_json["id"]
+  end
+
+  test "can request and complete password reset for email accounts" do
+    user = User.register_with_password!(
+      username: "reset user",
+      email: "reset@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      accepted_terms: true
+    )
+
+    assert_enqueued_emails 1 do
+      post password_reset_url, params: {
+        password_reset: { email: user.email }
+      }, as: :json
+    end
+
+    assert_response :success
+    token = user.generate_token_for(:password_reset)
+
+    patch password_reset_url, params: {
+      password_reset: {
+        token: token,
+        password: "newpassword123",
+        password_confirmation: "newpassword123"
+      }
+    }, as: :json
+
+    assert_response :success
+    assert user.reload.authenticate("newpassword123")
+  end
+
+  test "can change password with current password" do
+    user = User.register_with_password!(
+      username: "change pw",
+      email: "changepw@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      accepted_terms: true
+    )
+
+    patch user_url(user), params: {
+      user: {
+        current_password: "password123",
+        password: "newpassword123",
+        password_confirmation: "newpassword123"
+      }
+    }, headers: auth_headers(user), as: :json
+
+    assert_response :success
+    assert user.reload.authenticate("newpassword123")
+  end
+
+  test "google-linked user cannot register duplicate email" do
+    assert_no_difference("User.count") do
+      post users_url, params: {
+        user: {
+          username: "dup",
+          email: users(:one).email,
+          password: "password123",
+          password_confirmation: "password123",
+          accepted_terms: true
+        }
+      }, as: :json
+    end
+
+    assert_response :unprocessable_content
+    assert_includes response_json["errors"], "Email is already linked to Google sign-in. Use Google to access that account."
+  end
+end

--- a/back-end/test/integration/users_flow_test.rb
+++ b/back-end/test/integration/users_flow_test.rb
@@ -60,20 +60,22 @@ class UsersFlowTest < ActionDispatch::IntegrationTest
     assert_equal "You're not authorized to view this page.", response_json["error"]
   end
 
-  test "user creation is handled through google sign-in" do
-    assert_no_difference("User.count") do
+  test "registration does not require an existing session" do
+    assert_difference("User.count", 1) do
       post users_url, params: {
         user: {
           username: "sam",
+          email: "sam-register@example.com",
           preferred_style: "smart casual",
           password: "password123",
-          password_confirmation: "password123"
+          password_confirmation: "password123",
+          accepted_terms: true
         }
-      }, headers: auth_headers(@user), as: :json
+      }, as: :json
     end
 
-    assert_response :unauthorized
-    assert_equal "User creation is handled through Google sign-in.", response_json["error"]
+    assert_response :created
+    assert_equal "sam", response_json["username"]
   end
 
   test "can update a user without changing password" do

--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -58,8 +58,7 @@
         "tw-animate-css": "^1.4.0",
         "vaul": "^1.1.2",
         "vite": "^8.0.13"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/@cfcs/core": {
       "version": "0.0.6",

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -2,6 +2,11 @@ import { Dispatch, SetStateAction, useDeferredValue, useEffect, useRef, useState
 import { motion } from "motion/react";
 import { ShoppingBag } from "lucide-react";
 import { Toaster, toast } from "sonner";
+import { AccountSettingsPage } from "./components/AccountSettingsPage";
+import { ForgotPasswordPage } from "./components/auth/ForgotPasswordPage";
+import { ResetPasswordPage } from "./components/auth/ResetPasswordPage";
+import { SignInPage } from "./components/auth/SignInPage";
+import { SignUpPage } from "./components/auth/SignUpPage";
 import { AddItemMenu } from "./components/AddItemMenu";
 import { ClothingCard } from "./components/ClothingCard";
 import { CreateItemPage } from "./components/CreateItemPage";
@@ -66,6 +71,7 @@ import {
   AppRoute,
   authErrorMessage,
   getRouteFromLocation,
+  isAuthRoute,
   isClosetRoute,
   isOutfitRoute,
   isProtectedRoute,
@@ -215,7 +221,10 @@ export default function App() {
       return;
     }
 
-    setHomeMessage({ kind: "error", text: authErrorMessage(authError) });
+    if (route.kind === "home") {
+      setHomeMessage({ kind: "error", text: authErrorMessage(authError) });
+    }
+
     query.delete("auth_error");
 
     const nextSearch = query.toString();
@@ -224,8 +233,7 @@ export default function App() {
   }, [route.kind]);
 
   useEffect(() => {
-    const shouldLoadSession = route.kind === "home" || isProtectedRoute(route);
-    const unauthorizedMessage = "You do not have permission to view this page. Please log in.";
+    const shouldLoadSession = route.kind === "home" || isProtectedRoute(route) || isAuthRoute(route);
 
     if (!shouldLoadSession) {
       setIsLoading(false);
@@ -236,8 +244,7 @@ export default function App() {
       setIsLoading(false);
 
       if (!user && isProtectedRoute(route)) {
-        setHomeMessage({ kind: "error", text: unauthorizedMessage });
-        navigateTo("/");
+        navigateTo("/sign-in");
       }
 
       return;
@@ -255,8 +262,7 @@ export default function App() {
         if (!nextUser) {
           setUser(null);
           if (isProtectedRoute(route)) {
-            setHomeMessage({ kind: "error", text: unauthorizedMessage });
-            navigateTo("/");
+            navigateTo("/sign-in");
           }
           return;
         }
@@ -294,7 +300,7 @@ export default function App() {
   }, [outfitCartStatusMessage]);
 
   useEffect(() => {
-    if (route.kind === "home" && user) {
+    if (user && (route.kind === "home" || isAuthRoute(route))) {
       navigateTo("/closet");
     }
   }, [route.kind, user]);
@@ -470,7 +476,8 @@ export default function App() {
     navigateTo("/");
   }
 
-  const shouldRenderStandaloneAuthPage = !user && (route.kind === "home" || isLoggedOutProtectedRoute);
+  const shouldRenderStandaloneAuthPage =
+    !user && (route.kind === "home" || isAuthRoute(route) || isLoggedOutProtectedRoute);
 
   let pageContent;
 
@@ -478,8 +485,46 @@ export default function App() {
     return <div className="min-h-screen bg-background" />;
   }
 
-  if ((!user && route.kind === "home") || (isLoggedOutProtectedRoute && !isLoading)) {
+  if (!user && route.kind === "sign-in" && !isLoading) {
+    pageContent = (
+      <SignInPage
+        authError={new URLSearchParams(window.location.search).get("auth_error")}
+        onSignedIn={(nextUser) => {
+          hasResolvedSessionRef.current = true;
+          setUser(nextUser);
+          setHomeMessage(null);
+        }}
+      />
+    );
+  } else if (!user && route.kind === "sign-up" && !isLoading) {
+    pageContent = (
+      <SignUpPage
+        onRegistered={(nextUser) => {
+          hasResolvedSessionRef.current = true;
+          setUser(nextUser);
+          setHomeMessage(null);
+        }}
+      />
+    );
+  } else if (!user && route.kind === "forgot-password" && !isLoading) {
+    pageContent = <ForgotPasswordPage />;
+  } else if (!user && route.kind === "reset-password" && !isLoading) {
+    pageContent = <ResetPasswordPage token={route.token} />;
+  } else if ((!user && route.kind === "home") || (isLoggedOutProtectedRoute && !isLoading)) {
     pageContent = <HomeLanding homeMessage={homeMessage} />;
+  } else if (route.kind === "account" && user) {
+    pageContent = (
+      <AccountSettingsPage
+        user={user}
+        onBack={() => navigateTo("/closet")}
+        onUserUpdated={(nextUser) => setUser(nextUser)}
+        onAccountDeleted={() => {
+          hasResolvedSessionRef.current = true;
+          setUser(null);
+          setHomeMessage({ kind: "success", text: "Your account was deleted." });
+        }}
+      />
+    );
   } else if (route.kind === "about") {
     pageContent = <AboutPage />;
   } else if (route.kind === "privacy") {

--- a/front-end/src/app/components/AccountSettingsPage.tsx
+++ b/front-end/src/app/components/AccountSettingsPage.tsx
@@ -1,0 +1,279 @@
+import { FormEvent, useState } from "react";
+import { ArrowLeft } from "lucide-react";
+import {
+  deleteCurrentUser,
+  logoutSession,
+  updateCurrentUser,
+  type User,
+} from "../lib/closet";
+import { MAX_PREFERRED_STYLE, MAX_USERNAME } from "../lib/inputLengthPolicy";
+import { navigateTo } from "../lib/routes";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
+import { PrimitiveText } from "./primitives/PrimitiveText";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+
+interface AccountSettingsPageProps {
+  user: User;
+  onAccountDeleted: () => void;
+  onBack: () => void;
+  onUserUpdated: (user: User) => void;
+}
+
+export function AccountSettingsPage({
+  user,
+  onAccountDeleted,
+  onBack,
+  onUserUpdated,
+}: AccountSettingsPageProps) {
+  const [username, setUsername] = useState(user.username);
+  const [preferredStyle, setPreferredStyle] = useState(user.preferred_style ?? "");
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [deletePassword, setDeletePassword] = useState("");
+  const [profileMessage, setProfileMessage] = useState("");
+  const [profileError, setProfileError] = useState("");
+  const [deleteError, setDeleteError] = useState("");
+  const [isSavingProfile, setIsSavingProfile] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  const passwordLoginEnabled = Boolean(user.password_login_enabled);
+
+  async function handleProfileSubmit(event: FormEvent) {
+    event.preventDefault();
+    setProfileError("");
+    setProfileMessage("");
+
+    if (password && password !== passwordConfirmation) {
+      setProfileError("New password confirmation does not match.");
+      return;
+    }
+
+    setIsSavingProfile(true);
+
+    try {
+      const nextUser = await updateCurrentUser(user.id, {
+        username: username.trim(),
+        preferredStyle: preferredStyle.trim(),
+        currentPassword: currentPassword || undefined,
+        password: password || undefined,
+        passwordConfirmation: passwordConfirmation || undefined,
+      });
+      onUserUpdated(nextUser);
+      setCurrentPassword("");
+      setPassword("");
+      setPasswordConfirmation("");
+      setProfileMessage("Account settings saved.");
+    } catch (error) {
+      setProfileError(error instanceof Error ? error.message : "Unable to save account settings.");
+    } finally {
+      setIsSavingProfile(false);
+    }
+  }
+
+  async function handleDeleteAccount() {
+    setDeleteError("");
+    setIsDeleting(true);
+
+    try {
+      await deleteCurrentUser(user.id, passwordLoginEnabled ? deletePassword : undefined);
+      await logoutSession();
+      onAccountDeleted();
+      navigateTo("/");
+    } catch (error) {
+      setDeleteError(error instanceof Error ? error.message : "Unable to delete your account.");
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-12">
+      <PrimitiveButton
+        onClick={onBack}
+        variant="ghost"
+        className="mb-8 h-auto px-0 py-0 text-muted-foreground"
+      >
+        <ArrowLeft className="size-4" />
+        Back
+      </PrimitiveButton>
+
+      <PrimitiveText as="h1" variant="display" font="serif" className="mb-2">
+        Account
+      </PrimitiveText>
+      <PrimitiveText as="p" tone="muted" className="mb-8">
+        Manage your profile, password, and account deletion.
+      </PrimitiveText>
+
+      <section className="mb-10 space-y-5 border border-border p-6">
+        <PrimitiveText as="h2" variant="title">
+          Profile
+        </PrimitiveText>
+
+        <form className="space-y-4" onSubmit={(event) => void handleProfileSubmit(event)} noValidate>
+          <div className="space-y-2">
+            <Label htmlFor="account-email">Email</Label>
+            <Input id="account-email" value={user.email ?? ""} readOnly disabled className="h-11" />
+            <PrimitiveText as="p" variant="bodySm" tone="muted">
+              {passwordLoginEnabled
+                ? "Signed in with email and password."
+                : "Signed in with Google. Password changes are managed through Google."}
+            </PrimitiveText>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="account-username">Username</Label>
+            <Input
+              id="account-username"
+              maxLength={MAX_USERNAME}
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              className="h-11"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="account-style">Preferred style</Label>
+            <Input
+              id="account-style"
+              maxLength={MAX_PREFERRED_STYLE}
+              value={preferredStyle}
+              onChange={(event) => setPreferredStyle(event.target.value)}
+              className="h-11"
+            />
+          </div>
+
+          {passwordLoginEnabled ? (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="account-current-password">Current password</Label>
+                <Input
+                  id="account-current-password"
+                  type="password"
+                  autoComplete="current-password"
+                  value={currentPassword}
+                  onChange={(event) => setCurrentPassword(event.target.value)}
+                  className="h-11"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="account-new-password">New password</Label>
+                <Input
+                  id="account-new-password"
+                  type="password"
+                  autoComplete="new-password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  className="h-11"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="account-new-password-confirmation">Confirm new password</Label>
+                <Input
+                  id="account-new-password-confirmation"
+                  type="password"
+                  autoComplete="new-password"
+                  value={passwordConfirmation}
+                  onChange={(event) => setPasswordConfirmation(event.target.value)}
+                  className="h-11"
+                />
+              </div>
+            </>
+          ) : null}
+
+          {profileMessage ? (
+            <PrimitiveText as="p" variant="bodySm" role="status" className="text-emerald-900">
+              {profileMessage}
+            </PrimitiveText>
+          ) : null}
+
+          {profileError ? (
+            <PrimitiveText as="p" variant="bodySm" className="text-destructive" role="alert">
+              {profileError}
+            </PrimitiveText>
+          ) : null}
+
+          <PrimitiveButton type="submit" disabled={isSavingProfile}>
+            {isSavingProfile ? "Saving..." : "Save changes"}
+          </PrimitiveButton>
+        </form>
+      </section>
+
+      <section className="space-y-4 border border-destructive/30 bg-destructive/5 p-6">
+        <PrimitiveText as="h2" variant="title">
+          Delete account
+        </PrimitiveText>
+        <PrimitiveText as="p" tone="muted">
+          This permanently removes your closet, outfits, and uploaded images. This cannot be undone.
+        </PrimitiveText>
+
+        {passwordLoginEnabled ? (
+          <div className="space-y-2">
+            <Label htmlFor="account-delete-password">Confirm with your password</Label>
+            <Input
+              id="account-delete-password"
+              type="password"
+              autoComplete="current-password"
+              value={deletePassword}
+              onChange={(event) => setDeletePassword(event.target.value)}
+              className="h-11"
+            />
+          </div>
+        ) : null}
+
+        {deleteError ? (
+          <PrimitiveText as="p" variant="bodySm" className="text-destructive" role="alert">
+            {deleteError}
+          </PrimitiveText>
+        ) : null}
+
+        <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+          <PrimitiveButton
+            type="button"
+            variant="outline"
+            className="border-destructive/30 text-destructive hover:bg-destructive/5"
+            onClick={() => setIsDeleteDialogOpen(true)}
+          >
+            Delete account
+          </PrimitiveButton>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete your account?</AlertDialogTitle>
+              <AlertDialogDescription>
+                All clothing items, outfits, and photos will be removed permanently.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                disabled={isDeleting || (passwordLoginEnabled && !deletePassword)}
+                className="bg-destructive text-white hover:bg-destructive/90"
+                onClick={(event) => {
+                  event.preventDefault();
+                  void handleDeleteAccount();
+                }}
+              >
+                {isDeleting ? "Deleting..." : "Delete account"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </section>
+    </div>
+  );
+}

--- a/front-end/src/app/components/auth/AuthPageLayout.tsx
+++ b/front-end/src/app/components/auth/AuthPageLayout.tsx
@@ -1,0 +1,55 @@
+import { ReactNode } from "react";
+import { motion } from "motion/react";
+import { HomeFooterLinks } from "../info/HomeFooterLinks";
+import { PrimitiveText } from "../primitives/PrimitiveText";
+
+interface AuthPageLayoutProps {
+  children: ReactNode;
+  description?: string;
+  title: string;
+}
+
+export function AuthPageLayout({ children, description, title }: AuthPageLayoutProps) {
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:border focus:border-foreground focus:bg-background focus:px-4 focus:py-2"
+      >
+        Skip to main content
+      </a>
+
+      <main id="main-content" className="flex flex-1 items-center justify-center px-6 py-12">
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+          className="w-full max-w-md space-y-8"
+        >
+          <div className="text-center">
+            <img
+              src="/brand-mark.png"
+              alt=""
+              aria-hidden
+              className="mx-auto mb-6 h-16 w-auto object-contain"
+            />
+            <PrimitiveText as="h1" variant="title" font="serif" className="mb-2">
+              {title}
+            </PrimitiveText>
+            {description ? (
+              <PrimitiveText as="p" tone="muted">
+                {description}
+              </PrimitiveText>
+            ) : null}
+          </div>
+
+          {children}
+        </motion.div>
+      </main>
+
+      <footer className="border-t border-border px-6 py-8">
+        <HomeFooterLinks className="justify-center" />
+      </footer>
+    </div>
+  );
+}

--- a/front-end/src/app/components/auth/ForgotPasswordPage.tsx
+++ b/front-end/src/app/components/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,98 @@
+import { FormEvent, useState } from "react";
+import { requestPasswordReset } from "../../lib/closet";
+import { MAX_EMAIL } from "../../lib/inputLengthPolicy";
+import { navigateTo } from "../../lib/routes";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
+import { PrimitiveText } from "../primitives/PrimitiveText";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { AuthPageLayout } from "./AuthPageLayout";
+
+export function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [statusMessage, setStatusMessage] = useState("");
+  const [developmentResetUrl, setDevelopmentResetUrl] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setErrorMessage("");
+    setStatusMessage("");
+    setDevelopmentResetUrl("");
+    setIsSubmitting(true);
+
+    try {
+      const response = await requestPasswordReset(email.trim());
+      setStatusMessage(response.message);
+      if (response.development_reset_url) {
+        setDevelopmentResetUrl(response.development_reset_url);
+      }
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Unable to request a password reset right now.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthPageLayout
+      title="Reset password"
+      description="We will email reset instructions if an account exists for that address."
+    >
+      <form className="space-y-5" onSubmit={(event) => void handleSubmit(event)} noValidate>
+        <div className="space-y-2">
+          <Label htmlFor="forgot-password-email">Email</Label>
+          <Input
+            id="forgot-password-email"
+            type="email"
+            autoComplete="email"
+            required
+            maxLength={MAX_EMAIL}
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            className="h-11"
+          />
+        </div>
+
+        {statusMessage ? (
+          <PrimitiveText as="p" variant="bodySm" role="status" className="text-emerald-900">
+            {statusMessage}
+          </PrimitiveText>
+        ) : null}
+
+        {developmentResetUrl ? (
+          <PrimitiveText as="p" variant="bodySm" tone="muted">
+            Development reset link:{" "}
+            <a href={developmentResetUrl} className="underline underline-offset-2">
+              open reset page
+            </a>
+          </PrimitiveText>
+        ) : null}
+
+        {errorMessage ? (
+          <PrimitiveText as="p" variant="bodySm" className="text-destructive" role="alert">
+            {errorMessage}
+          </PrimitiveText>
+        ) : null}
+
+        <PrimitiveButton type="submit" disabled={isSubmitting} className="h-11 w-full">
+          {isSubmitting ? "Sending..." : "Send reset instructions"}
+        </PrimitiveButton>
+      </form>
+
+      <PrimitiveText as="p" variant="bodySm" tone="muted" className="text-center">
+        <PrimitiveButton
+          type="button"
+          variant="link"
+          className="h-auto px-0 py-0"
+          onClick={() => navigateTo("/sign-in")}
+        >
+          Back to sign in
+        </PrimitiveButton>
+      </PrimitiveText>
+    </AuthPageLayout>
+  );
+}

--- a/front-end/src/app/components/auth/ResetPasswordPage.tsx
+++ b/front-end/src/app/components/auth/ResetPasswordPage.tsx
@@ -1,0 +1,118 @@
+import { FormEvent, useState } from "react";
+import { resetPassword } from "../../lib/closet";
+import { navigateTo } from "../../lib/routes";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
+import { PrimitiveText } from "../primitives/PrimitiveText";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { AuthPageLayout } from "./AuthPageLayout";
+
+interface ResetPasswordPageProps {
+  token: string | null;
+}
+
+export function ResetPasswordPage({ token }: ResetPasswordPageProps) {
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [statusMessage, setStatusMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setErrorMessage("");
+    setStatusMessage("");
+
+    if (!token) {
+      setErrorMessage("This reset link is missing a token.");
+      return;
+    }
+
+    if (password !== passwordConfirmation) {
+      setErrorMessage("Password confirmation does not match.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await resetPassword({
+        token,
+        password,
+        passwordConfirmation,
+      });
+      setStatusMessage(response.message);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Unable to reset your password.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthPageLayout title="Choose a new password" description="Enter a new password for your account.">
+      {!token ? (
+        <PrimitiveText as="p" tone="muted" role="alert">
+          This reset link is invalid. Request a new one from the forgot-password page.
+        </PrimitiveText>
+      ) : (
+        <form className="space-y-5" onSubmit={(event) => void handleSubmit(event)} noValidate>
+          <div className="space-y-2">
+            <Label htmlFor="reset-password">New password</Label>
+            <Input
+              id="reset-password"
+              type="password"
+              autoComplete="new-password"
+              required
+              minLength={8}
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="h-11"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="reset-password-confirmation">Confirm new password</Label>
+            <Input
+              id="reset-password-confirmation"
+              type="password"
+              autoComplete="new-password"
+              required
+              minLength={8}
+              value={passwordConfirmation}
+              onChange={(event) => setPasswordConfirmation(event.target.value)}
+              className="h-11"
+            />
+          </div>
+
+          {statusMessage ? (
+            <PrimitiveText as="p" variant="bodySm" role="status" className="text-emerald-900">
+              {statusMessage}
+            </PrimitiveText>
+          ) : null}
+
+          {errorMessage ? (
+            <PrimitiveText as="p" variant="bodySm" className="text-destructive" role="alert">
+              {errorMessage}
+            </PrimitiveText>
+          ) : null}
+
+          <PrimitiveButton type="submit" disabled={isSubmitting} className="h-11 w-full">
+            {isSubmitting ? "Saving..." : "Update password"}
+          </PrimitiveButton>
+        </form>
+      )}
+
+      <PrimitiveText as="p" variant="bodySm" tone="muted" className="text-center">
+        <PrimitiveButton
+          type="button"
+          variant="link"
+          className="h-auto px-0 py-0"
+          onClick={() => navigateTo("/sign-in")}
+        >
+          Back to sign in
+        </PrimitiveButton>
+      </PrimitiveText>
+    </AuthPageLayout>
+  );
+}

--- a/front-end/src/app/components/auth/SignInPage.tsx
+++ b/front-end/src/app/components/auth/SignInPage.tsx
@@ -1,0 +1,111 @@
+import { FormEvent, useState } from "react";
+import { beginGoogleSignIn, signInWithEmail, type User } from "../../lib/closet";
+import { authErrorMessage, navigateTo } from "../../lib/routes";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
+import { PrimitiveText } from "../primitives/PrimitiveText";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { AuthPageLayout } from "./AuthPageLayout";
+
+interface SignInPageProps {
+  authError?: string | null;
+  onSignedIn: (user: User) => void;
+}
+
+export function SignInPage({ authError, onSignedIn }: SignInPageProps) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState(authError ? authErrorMessage(authError) : "");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setErrorMessage("");
+    setIsSubmitting(true);
+
+    try {
+      const user = await signInWithEmail(email.trim(), password);
+      onSignedIn(user);
+      navigateTo("/closet");
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Unable to sign in right now.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthPageLayout title="Sign in" description="Access your closet with email or Google.">
+      <form className="space-y-5" onSubmit={(event) => void handleSubmit(event)} noValidate>
+        <div className="space-y-2">
+          <Label htmlFor="sign-in-email">Email</Label>
+          <Input
+            id="sign-in-email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            className="h-11"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <Label htmlFor="sign-in-password">Password</Label>
+            <PrimitiveButton
+              type="button"
+              variant="link"
+              className="h-auto px-0 py-0 text-sm"
+              onClick={() => navigateTo("/forgot-password")}
+            >
+              Forgot password?
+            </PrimitiveButton>
+          </div>
+          <Input
+            id="sign-in-password"
+            type="password"
+            autoComplete="current-password"
+            required
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            className="h-11"
+          />
+        </div>
+
+        {errorMessage ? (
+          <PrimitiveText as="p" variant="bodySm" className="text-destructive" role="alert">
+            {errorMessage}
+          </PrimitiveText>
+        ) : null}
+
+        <PrimitiveButton type="submit" disabled={isSubmitting} className="h-11 w-full">
+          {isSubmitting ? "Signing in..." : "Sign in with email"}
+        </PrimitiveButton>
+      </form>
+
+      <div className="space-y-3">
+        <PrimitiveButton
+          type="button"
+          variant="outline"
+          className="h-11 w-full"
+          onClick={() => beginGoogleSignIn()}
+        >
+          Sign in with Google
+        </PrimitiveButton>
+
+        <PrimitiveText as="p" variant="bodySm" tone="muted" className="text-center">
+          New here?{" "}
+          <PrimitiveButton
+            type="button"
+            variant="link"
+            className="h-auto px-0 py-0"
+            onClick={() => navigateTo("/sign-up")}
+          >
+            Create an account
+          </PrimitiveButton>
+        </PrimitiveText>
+      </div>
+    </AuthPageLayout>
+  );
+}

--- a/front-end/src/app/components/auth/SignUpPage.tsx
+++ b/front-end/src/app/components/auth/SignUpPage.tsx
@@ -1,0 +1,194 @@
+import { FormEvent, useState } from "react";
+import { beginGoogleSignIn, registerUser, type User } from "../../lib/closet";
+import { MAX_EMAIL, MAX_PREFERRED_STYLE, MAX_USERNAME } from "../../lib/inputLengthPolicy";
+import { navigateTo } from "../../lib/routes";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
+import { PrimitiveText } from "../primitives/PrimitiveText";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { AuthPageLayout } from "./AuthPageLayout";
+
+interface SignUpPageProps {
+  onRegistered: (user: User) => void;
+}
+
+export function SignUpPage({ onRegistered }: SignUpPageProps) {
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [preferredStyle, setPreferredStyle] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setErrorMessage("");
+
+    if (!acceptedTerms) {
+      setErrorMessage("Please accept the terms and privacy policy before creating an account.");
+      return;
+    }
+
+    if (password !== passwordConfirmation) {
+      setErrorMessage("Password confirmation does not match.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const user = await registerUser({
+        username: username.trim(),
+        email: email.trim(),
+        preferredStyle: preferredStyle.trim(),
+        password,
+        passwordConfirmation,
+        acceptedTerms,
+      });
+      onRegistered(user);
+      navigateTo("/closet");
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Unable to create your account right now.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthPageLayout title="Create account" description="Register with email or continue with Google.">
+      <form className="space-y-4" onSubmit={(event) => void handleSubmit(event)} noValidate>
+        <div className="space-y-2">
+          <Label htmlFor="sign-up-username">Username</Label>
+          <Input
+            id="sign-up-username"
+            autoComplete="username"
+            required
+            maxLength={MAX_USERNAME}
+            value={username}
+            onChange={(event) => setUsername(event.target.value)}
+            className="h-11"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="sign-up-email">Email</Label>
+          <Input
+            id="sign-up-email"
+            type="email"
+            autoComplete="email"
+            required
+            maxLength={MAX_EMAIL}
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            className="h-11"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="sign-up-style">Preferred style (optional)</Label>
+          <Input
+            id="sign-up-style"
+            maxLength={MAX_PREFERRED_STYLE}
+            value={preferredStyle}
+            onChange={(event) => setPreferredStyle(event.target.value)}
+            placeholder="e.g. minimal, polished"
+            className="h-11"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="sign-up-password">Password</Label>
+          <Input
+            id="sign-up-password"
+            type="password"
+            autoComplete="new-password"
+            required
+            minLength={8}
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            className="h-11"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="sign-up-password-confirmation">Confirm password</Label>
+          <Input
+            id="sign-up-password-confirmation"
+            type="password"
+            autoComplete="new-password"
+            required
+            minLength={8}
+            value={passwordConfirmation}
+            onChange={(event) => setPasswordConfirmation(event.target.value)}
+            className="h-11"
+          />
+        </div>
+
+        <label className="flex items-start gap-3 text-sm leading-relaxed">
+          <input
+            type="checkbox"
+            checked={acceptedTerms}
+            onChange={(event) => setAcceptedTerms(event.target.checked)}
+            className="mt-1 size-4 border border-input"
+          />
+          <span>
+            I agree to the{" "}
+            <PrimitiveButton
+              type="button"
+              variant="link"
+              className="h-auto px-0 py-0"
+              onClick={() => navigateTo("/terms")}
+            >
+              terms
+            </PrimitiveButton>{" "}
+            and{" "}
+            <PrimitiveButton
+              type="button"
+              variant="link"
+              className="h-auto px-0 py-0"
+              onClick={() => navigateTo("/privacy")}
+            >
+              privacy policy
+            </PrimitiveButton>
+            .
+          </span>
+        </label>
+
+        {errorMessage ? (
+          <PrimitiveText as="p" variant="bodySm" className="text-destructive" role="alert">
+            {errorMessage}
+          </PrimitiveText>
+        ) : null}
+
+        <PrimitiveButton type="submit" disabled={isSubmitting} className="h-11 w-full">
+          {isSubmitting ? "Creating account..." : "Create account"}
+        </PrimitiveButton>
+      </form>
+
+      <div className="space-y-3">
+        <PrimitiveButton
+          type="button"
+          variant="outline"
+          className="h-11 w-full"
+          onClick={() => beginGoogleSignIn()}
+        >
+          Sign up with Google
+        </PrimitiveButton>
+
+        <PrimitiveText as="p" variant="bodySm" tone="muted" className="text-center">
+          Already have an account?{" "}
+          <PrimitiveButton
+            type="button"
+            variant="link"
+            className="h-auto px-0 py-0"
+            onClick={() => navigateTo("/sign-in")}
+          >
+            Sign in
+          </PrimitiveButton>
+        </PrimitiveText>
+      </div>
+    </AuthPageLayout>
+  );
+}

--- a/front-end/src/app/components/info/PrivacyPage.tsx
+++ b/front-end/src/app/components/info/PrivacyPage.tsx
@@ -48,8 +48,9 @@ export function PrivacyPage() {
       <InfoSection heading="How to request deletion">
         <PrimitiveText as="p" tone="muted">
           You may delete individual clothing items and outfits in the app. To remove your entire
-          account and associated data, {DELETION_CONTACT} Include the email address tied to your
-          Google sign-in so we can locate your account.
+          account and associated data, open Account settings after signing in and use Delete account.
+          Email/password accounts must confirm with their current password. If you cannot access the
+          app, {DELETION_CONTACT} Include the email address tied to your account.
         </PrimitiveText>
         <PrimitiveText as="p" tone="muted">
           Repository for requests:{" "}

--- a/front-end/src/app/components/shared/HomeLanding.tsx
+++ b/front-end/src/app/components/shared/HomeLanding.tsx
@@ -1,6 +1,7 @@
 import { motion } from "motion/react";
 import { ArrowRight } from "lucide-react";
 import { beginGoogleSignIn } from "../../lib/closet";
+import { navigateTo } from "../../lib/routes";
 import { PrimitiveButton } from "../primitives/PrimitiveButton";
 import { PrimitiveText } from "../primitives/PrimitiveText";
 
@@ -43,13 +44,29 @@ export function HomeLanding({ homeMessage }: HomeLandingProps) {
         >
           Find your fit, faster.
         </PrimitiveText>
+        <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+          <PrimitiveButton
+            onClick={() => navigateTo("/sign-in")}
+            className="h-auto px-6 py-3"
+          >
+            Sign in
+            <ArrowRight className="h-4 w-4" />
+          </PrimitiveButton>
+          <PrimitiveButton
+            onClick={() => navigateTo("/sign-up")}
+            variant="outline"
+            className="h-auto px-6 py-3"
+          >
+            Create account
+          </PrimitiveButton>
+        </div>
+
         <PrimitiveButton
           onClick={() => beginGoogleSignIn()}
-          variant="outline"
-          className="h-auto px-6 py-3"
+          variant="ghost"
+          className="mt-4 h-auto px-0 py-0 text-muted-foreground"
         >
-          Sign in with Google
-          <ArrowRight className="h-4 w-4" />
+          Continue with Google
         </PrimitiveButton>
 
         {homeMessage ? (

--- a/front-end/src/app/components/shared/SiteHeader.tsx
+++ b/front-end/src/app/components/shared/SiteHeader.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, Users } from "lucide-react";
+import { ArrowRight, UserRound, Users } from "lucide-react";
 import type { AppRoute } from "../../lib/routes";
 import { isClosetRoute, isOutfitRoute, isUsersRoute, navigateTo } from "../../lib/routes";
 import type { User } from "../../lib/closet";
@@ -69,6 +69,18 @@ export function SiteHeader({ route, user, onSignOut }: SiteHeaderProps) {
                   Users
                 </PrimitiveButton>
               ) : null}
+              <PrimitiveButton
+                onClick={() => navigateTo("/account")}
+                variant="outline"
+                className={
+                  route.kind === "account"
+                    ? "border-foreground bg-foreground text-background"
+                    : "border-border text-foreground hover:border-foreground"
+                }
+              >
+                <UserRound className="h-4 w-4" />
+                Account
+              </PrimitiveButton>
             </nav>
           ) : null}
           {globalAction}

--- a/front-end/src/app/lib/closet.ts
+++ b/front-end/src/app/lib/closet.ts
@@ -62,6 +62,10 @@ export interface ClothingItem {
 }
 
 export interface User extends UserSummary {
+  email?: string | null;
+  avatar_url?: string | null;
+  auth_provider?: string;
+  password_login_enabled?: boolean;
   clothing_items: ClothingItem[];
   clothing_items_count: number;
 }
@@ -417,6 +421,111 @@ export function beginGoogleSignIn() {
 export async function logoutSession() {
   await requestVoid(`${API_BASE_URL}/session`, {
     method: "DELETE",
+  });
+}
+
+export interface RegisterUserInput {
+  username: string;
+  email: string;
+  password: string;
+  passwordConfirmation: string;
+  preferredStyle?: string;
+  acceptedTerms: boolean;
+}
+
+export async function signInWithEmail(email: string, password: string) {
+  const user = await requestJson<User>(`${API_BASE_URL}/session`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ session: { email, password } }),
+  });
+
+  return normalizeUserPayload(user);
+}
+
+export async function registerUser(input: RegisterUserInput) {
+  const user = await requestJson<User>(`${API_BASE_URL}/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      user: {
+        username: input.username,
+        email: input.email,
+        password: input.password,
+        password_confirmation: input.passwordConfirmation,
+        preferred_style: input.preferredStyle ?? "",
+        accepted_terms: input.acceptedTerms,
+      },
+    }),
+  });
+
+  return normalizeUserPayload(user);
+}
+
+export async function requestPasswordReset(email: string) {
+  return requestJson<{ message: string; development_reset_url?: string }>(
+    `${API_BASE_URL}/password_reset`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password_reset: { email } }),
+    },
+  );
+}
+
+export async function resetPassword(input: {
+  token: string;
+  password: string;
+  passwordConfirmation: string;
+}) {
+  return requestJson<{ message: string }>(`${API_BASE_URL}/password_reset`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      password_reset: {
+        token: input.token,
+        password: input.password,
+        password_confirmation: input.passwordConfirmation,
+      },
+    }),
+  });
+}
+
+export interface UpdateCurrentUserInput {
+  username?: string;
+  preferredStyle?: string;
+  currentPassword?: string;
+  password?: string;
+  passwordConfirmation?: string;
+}
+
+export async function updateCurrentUser(userId: number, input: UpdateCurrentUserInput) {
+  const user = await requestJson<User>(`${API_BASE_URL}/users/${userId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      user: {
+        username: input.username,
+        preferred_style: input.preferredStyle,
+        current_password: input.currentPassword,
+        password: input.password,
+        password_confirmation: input.passwordConfirmation,
+      },
+    }),
+  });
+
+  return normalizeUserPayload(user);
+}
+
+export async function deleteCurrentUser(userId: number, password?: string) {
+  await requestVoid(`${API_BASE_URL}/users/${userId}`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      user: {
+        password: password ?? "",
+      },
+    }),
   });
 }
 

--- a/front-end/src/app/lib/routes.ts
+++ b/front-end/src/app/lib/routes.ts
@@ -4,6 +4,27 @@ interface HomeRouteState {
   kind: "home";
 }
 
+interface SignInRouteState {
+  kind: "sign-in";
+}
+
+interface SignUpRouteState {
+  kind: "sign-up";
+}
+
+interface ForgotPasswordRouteState {
+  kind: "forgot-password";
+}
+
+interface ResetPasswordRouteState {
+  kind: "reset-password";
+  token: string | null;
+}
+
+interface AccountRouteState {
+  kind: "account";
+}
+
 interface ClosetRouteState {
   kind: "closet";
 }
@@ -50,6 +71,11 @@ interface TermsRouteState {
 
 export type AppRoute =
   | HomeRouteState
+  | SignInRouteState
+  | SignUpRouteState
+  | ForgotPasswordRouteState
+  | ResetPasswordRouteState
+  | AccountRouteState
   | ClosetRouteState
   | ItemRouteState
   | UsersRouteState
@@ -65,6 +91,15 @@ export function isPublicInfoRoute(route: AppRoute) {
   return route.kind === "about" || route.kind === "privacy" || route.kind === "terms";
 }
 
+export function isAuthRoute(route: AppRoute) {
+  return (
+    route.kind === "sign-in" ||
+    route.kind === "sign-up" ||
+    route.kind === "forgot-password" ||
+    route.kind === "reset-password"
+  );
+}
+
 export function isClosetRoute(route: AppRoute) {
   return route.kind === "closet" || route.kind === "item" || route.kind === "new-item";
 }
@@ -78,7 +113,7 @@ export function isUsersRoute(route: AppRoute) {
 }
 
 export function isProtectedRoute(route: AppRoute) {
-  return route.kind !== "home" && route.kind !== "not-found" && !isPublicInfoRoute(route);
+  return route.kind !== "home" && route.kind !== "not-found" && !isPublicInfoRoute(route) && !isAuthRoute(route);
 }
 
 export function authErrorMessage(code: string | null) {
@@ -127,6 +162,26 @@ export function getRouteFromLocation(
 
   if (normalizedPath === "/outfits") {
     return { kind: "outfits" };
+  }
+
+  if (normalizedPath === "/account") {
+    return { kind: "account" };
+  }
+
+  if (normalizedPath === "/sign-in") {
+    return { kind: "sign-in" };
+  }
+
+  if (normalizedPath === "/sign-up") {
+    return { kind: "sign-up" };
+  }
+
+  if (normalizedPath === "/forgot-password") {
+    return { kind: "forgot-password" };
+  }
+
+  if (normalizedPath === "/reset-password") {
+    return { kind: "reset-password", token: query.get("token") };
   }
 
   if (userMatch) {


### PR DESCRIPTION
## Summary
- Adds email/password registration, sign-in, forgot/reset password, and an Account settings page (profile edit, change password, delete account) while keeping Google OAuth.
- Requires terms acceptance on signup, redirects logged-out users from protected routes to `/sign-in`, and includes backend integration tests for the new auth flows.

## Test plan
- [ ] Run `bin/rails db:migrate` in `back-end`
- [ ] Start backend (`bin/rails server`) and frontend (`npm run dev`) together
- [ ] Create account at `/sign-up` with terms checked → lands on `/closet`
- [ ] Sign out → sign in at `/sign-in` with email/password
- [ ] Request password reset at `/forgot-password` and use dev reset link
- [ ] Update profile and change password at `/account`
- [ ] Confirm Google sign-in still works from `/sign-in`
- [ ] Confirm visiting `/closet` while logged out redirects to `/sign-in`
- [ ] Run `bin/rails test test/integration/auth_flow_test.rb`


Made with [Cursor](https://cursor.com)