### PR TITLE
Require terms acceptance on local registration

### DIFF
--- a/back-end/app/controllers/users_controller.rb
+++ b/back-end/app/controllers/users_controller.rb
@@ -26,6 +26,11 @@ class UsersController < ApplicationController
   end
 
   def create
+    unless params.dig(:user, :terms_accepted).in?([ true, "true", "1", 1 ])
+      return render json: { errors: [ "You must accept the Terms of Service to create an account." ] },
+                    status: :unprocessable_content
+    end
+
     user = User.from_local_registration(registration_params)
     if user.save
       reset_session

--- a/back-end/test/integration/local_auth_flow_test.rb
+++ b/back-end/test/integration/local_auth_flow_test.rb
@@ -5,7 +5,8 @@ class LocalAuthFlowTest < ActionDispatch::IntegrationTest
 
   test "registers a new local user with valid params" do
     post users_url, params: {
-      user: { username: "newuser", password: "hunter2hunter2", password_confirmation: "hunter2hunter2" }
+      user: { username: "newuser", password: "hunter2hunter2", password_confirmation: "hunter2hunter2",
+              terms_accepted: true }
     }, as: :json
 
     assert_response :created

--- a/back-end/test/integration/local_auth_flow_test.rb
+++ b/back-end/test/integration/local_auth_flow_test.rb
@@ -71,4 +71,32 @@ class LocalAuthFlowTest < ActionDispatch::IntegrationTest
 
     assert_response :unauthorized
   end
+
+  # --- Terms acceptance ---
+
+  test "registration returns 422 when terms are not accepted" do
+    post users_url, params: {
+      user: { username: "termstester", password: "hunter2hunter2", password_confirmation: "hunter2hunter2",
+              terms_accepted: false }
+    }, as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "registration returns 422 when terms param is absent" do
+    post users_url, params: {
+      user: { username: "termstester2", password: "hunter2hunter2", password_confirmation: "hunter2hunter2" }
+    }, as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "registration succeeds when terms are accepted" do
+    post users_url, params: {
+      user: { username: "termstester3", password: "hunter2hunter2", password_confirmation: "hunter2hunter2",
+              terms_accepted: true }
+    }, as: :json
+
+    assert_response :created
+  end
 end

--- a/back-end/test/integration/users_flow_test.rb
+++ b/back-end/test/integration/users_flow_test.rb
@@ -67,7 +67,8 @@ class UsersFlowTest < ActionDispatch::IntegrationTest
         user: {
           username: "brandnewuser",
           password: "hunter2hunter2",
-          password_confirmation: "hunter2hunter2"
+          password_confirmation: "hunter2hunter2",
+          terms_accepted: true
         }
       }, as: :json
     end

--- a/front-end/src/app/components/shared/HomeLanding.tsx
+++ b/front-end/src/app/components/shared/HomeLanding.tsx
@@ -19,12 +19,19 @@ export function HomeLanding({ homeMessage, onAuthSuccess }: HomeLandingProps) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [termsAccepted, setTermsAccepted] = useState(false);
   const [formError, setFormError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   async function handleLocalSubmit(e: React.FormEvent) {
     e.preventDefault();
     setFormError("");
+
+    if (mode === "register" && !termsAccepted) {
+      setFormError("You must accept the Terms of Service to create an account.");
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
@@ -47,6 +54,7 @@ export function HomeLanding({ homeMessage, onAuthSuccess }: HomeLandingProps) {
     setFormError("");
     setPassword("");
     setPasswordConfirmation("");
+    setTermsAccepted(false);
   }
 
   return (
@@ -194,6 +202,24 @@ export function HomeLanding({ homeMessage, onAuthSuccess }: HomeLandingProps) {
             </div>
           )}
 
+          {mode === "register" && (
+            <label className="flex items-start gap-2 text-sm text-foreground">
+              <input
+                id="local-terms"
+                type="checkbox"
+                checked={termsAccepted}
+                onChange={(e) => setTermsAccepted(e.target.checked)}
+                className="mt-0.5 shrink-0 accent-foreground"
+              />
+              <span>
+                I agree to the{" "}
+                <a href="/terms" className="underline hover:text-muted-foreground">
+                  Terms of Service
+                </a>
+              </span>
+            </label>
+          )}
+
           {formError ? (
             <p role="alert" className="text-sm text-destructive">
               {formError}
@@ -202,7 +228,7 @@ export function HomeLanding({ homeMessage, onAuthSuccess }: HomeLandingProps) {
 
           <PrimitiveButton
             type="submit"
-            disabled={isSubmitting}
+            disabled={isSubmitting || (mode === "register" && !termsAccepted)}
             className="mt-1 h-auto w-full px-6 py-3"
           >
             {isSubmitting

--- a/front-end/src/app/lib/closet.ts
+++ b/front-end/src/app/lib/closet.ts
@@ -438,7 +438,15 @@ export async function registerLocal(
   const raw = await requestJson<User>(`${API_BASE_URL}/users`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ user: { username, password, password_confirmation: passwordConfirmation, email } }),
+    body: JSON.stringify({
+      user: {
+        username,
+        password,
+        password_confirmation: passwordConfirmation,
+        email,
+        terms_accepted: true,
+      },
+    }),
   });
   return normalizeUserPayload(raw);
 }


### PR DESCRIPTION
Closes #170

## What changed
- Backend: `POST /users` returns 422 with a clear error if `terms_accepted` is not `true`
- Frontend: Terms of Service checkbox added to the Create Account form; submit button is disabled until checked
- `registerLocal()` in `closet.ts` always sends `terms_accepted: true` (checkbox is the gate)

## Trust & safety
Counts as 1 of the 3 required trust & safety features.

## Tests
3 new integration tests (terms absent → 422, terms false → 422, terms true → 201). All 22 auth tests pass.