### PR TITLE
feat: change password flow for local accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@
 
 # macOS filesystem metadata
 .DS_Store
+
+# Local personal notes (not for sharing)
+MILESTONE4_PLAN.md

--- a/back-end/app/controllers/users_controller.rb
+++ b/back-end/app/controllers/users_controller.rb
@@ -44,6 +44,27 @@ class UsersController < ApplicationController
     end
   end
 
+  def change_password
+    unless current_user.provider == "local"
+      return render json: { errors: [ "Password change is only available for username/password accounts." ] },
+                    status: :unprocessable_content
+    end
+
+    unless current_user.authenticate(params[:current_password].to_s)
+      return render_unauthorized("Current password is incorrect.")
+    end
+
+    if params[:password].blank?
+      return render json: { errors: [ "New password can't be blank." ] }, status: :unprocessable_content
+    end
+
+    if current_user.update(password: params[:password], password_confirmation: params[:password_confirmation])
+      render json: { message: "Password updated successfully." }
+    else
+      render_validation_errors(current_user)
+    end
+  end
+
   def destroy
     @user.destroy
     head :no_content

--- a/back-end/config/routes.rb
+++ b/back-end/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     get "me", to: "sessions#me"
     post "session", to: "sessions#login"
     delete "session", to: "sessions#destroy"
+    patch "change_password", to: "users#change_password"
 
     resources :users, except: %i[new edit]
     resources :clothing_items, except: %i[new edit] do

--- a/back-end/test/integration/change_password_flow_test.rb
+++ b/back-end/test/integration/change_password_flow_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class ChangePasswordFlowTest < ActionDispatch::IntegrationTest
+  setup do
+    @local_user = users(:local_one)
+    @google_user = users(:one)
+  end
+
+  test "local user can change password with correct current password" do
+    patch change_password_path,
+      params: { current_password: "localpass99", password: "newpass1234", password_confirmation: "newpass1234" },
+      headers: auth_headers(@local_user),
+      as: :json
+
+    assert_response :success
+    assert @local_user.reload.authenticate("newpass1234")
+  end
+
+  test "returns 401 when current password is wrong" do
+    patch change_password_path,
+      params: { current_password: "wrongpassword", password: "newpass1234", password_confirmation: "newpass1234" },
+      headers: auth_headers(@local_user),
+      as: :json
+
+    assert_response :unauthorized
+  end
+
+  test "returns 422 when new password confirmation does not match" do
+    patch change_password_path,
+      params: { current_password: "localpass99", password: "newpass1234", password_confirmation: "different" },
+      headers: auth_headers(@local_user),
+      as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "returns 422 when new password is blank" do
+    patch change_password_path,
+      params: { current_password: "localpass99", password: "", password_confirmation: "" },
+      headers: auth_headers(@local_user),
+      as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "returns 422 when google user tries to change password" do
+    patch change_password_path,
+      params: { current_password: "anything", password: "newpass1234", password_confirmation: "newpass1234" },
+      headers: auth_headers(@google_user),
+      as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "returns 401 when not logged in" do
+    patch change_password_path,
+      params: { current_password: "localpass99", password: "newpass1234", password_confirmation: "newpass1234" },
+      as: :json
+
+    assert_response :unauthorized
+  end
+end

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -9,6 +9,7 @@ import { ItemDetailPage } from "./components/ItemDetailPage";
 import { MyOutfitsPage } from "./components/MyOutfitsPage";
 import { OutfitCartSheet } from "./components/OutfitCartSheet";
 import { OutfitCreatedDialog } from "./components/OutfitCreatedDialog";
+import { SettingsPage } from "./components/SettingsPage";
 import { UserDetailPage } from "./components/UserDetailPage";
 import { UsersDirectoryPage } from "./components/UsersDirectoryPage";
 import {
@@ -586,6 +587,8 @@ export default function App() {
         user={user}
       />
     ) : null;
+  } else if (route.kind === "settings") {
+    pageContent = user ? <SettingsPage user={user} /> : null;
   } else {
     pageContent = (
       <div className="max-w-7xl mx-auto px-6 py-12">

--- a/front-end/src/app/components/SettingsPage.tsx
+++ b/front-end/src/app/components/SettingsPage.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import { changePassword } from "../lib/closet";
+import type { User } from "../lib/closet";
+import { PrimitiveButton } from "./primitives/PrimitiveButton";
+import { PrimitiveText } from "./primitives/PrimitiveText";
+
+interface SettingsPageProps {
+  user: User;
+}
+
+export function SettingsPage({ user }: SettingsPageProps) {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formError, setFormError] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
+
+  const isLocalUser = user.provider === "local";
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFormError("");
+    setSuccessMessage("");
+    setIsSubmitting(true);
+
+    try {
+      await changePassword(currentPassword, newPassword, confirmPassword);
+      setSuccessMessage("Password updated successfully.");
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Something went wrong. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl px-6 py-12">
+      <PrimitiveText
+        as="h1"
+        variant="display"
+        font="serif"
+        className="mb-8"
+        style={{ fontSize: "clamp(2rem, 4vw, 3rem)", lineHeight: "1" }}
+      >
+        Account Settings
+      </PrimitiveText>
+
+      <section aria-labelledby="change-password-heading">
+        <PrimitiveText as="h2" variant="title" id="change-password-heading" className="mb-4">
+          Change Password
+        </PrimitiveText>
+
+        {!isLocalUser ? (
+          <div className="border border-border bg-card px-4 py-3">
+            <PrimitiveText as="p" tone="muted">
+              Password changes are only available for username/password accounts. Your account uses
+              Google sign-in.
+            </PrimitiveText>
+          </div>
+        ) : (
+          <form onSubmit={(e) => void handleSubmit(e)} noValidate className="flex flex-col gap-4">
+            <div>
+              <label htmlFor="current-password" className="mb-1 block text-sm font-medium text-foreground">
+                Current password
+              </label>
+              <input
+                id="current-password"
+                type="password"
+                autoComplete="current-password"
+                required
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                className="w-full border border-border bg-input-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                placeholder="••••••••"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="new-password" className="mb-1 block text-sm font-medium text-foreground">
+                New password
+              </label>
+              <input
+                id="new-password"
+                type="password"
+                autoComplete="new-password"
+                required
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                className="w-full border border-border bg-input-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                placeholder="••••••••"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="confirm-password" className="mb-1 block text-sm font-medium text-foreground">
+                Confirm new password
+              </label>
+              <input
+                id="confirm-password"
+                type="password"
+                autoComplete="new-password"
+                required
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="w-full border border-border bg-input-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                placeholder="••••••••"
+              />
+            </div>
+
+            {formError ? (
+              <p role="alert" className="text-sm text-destructive">
+                {formError}
+              </p>
+            ) : null}
+
+            {successMessage ? (
+              <p role="status" className="text-sm text-emerald-700">
+                {successMessage}
+              </p>
+            ) : null}
+
+            <PrimitiveButton
+              type="submit"
+              disabled={isSubmitting}
+              className="mt-1 h-auto w-full px-6 py-3"
+            >
+              {isSubmitting ? "Updating…" : "Update password"}
+            </PrimitiveButton>
+          </form>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/front-end/src/app/components/shared/SiteHeader.tsx
+++ b/front-end/src/app/components/shared/SiteHeader.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, Users } from "lucide-react";
+import { ArrowRight, Settings, Users } from "lucide-react";
 import type { AppRoute } from "../../lib/routes";
 import { isClosetRoute, isOutfitRoute, isUsersRoute, navigateTo } from "../../lib/routes";
 import type { User } from "../../lib/closet";
@@ -13,10 +13,25 @@ interface SiteHeaderProps {
 
 export function SiteHeader({ route, user, onSignOut }: SiteHeaderProps) {
   const globalAction = user ? (
-    <PrimitiveButton onClick={onSignOut} variant="outline">
-      <Users className="h-4 w-4" />
-      Sign Out
-    </PrimitiveButton>
+    <div className="flex items-center gap-2">
+      <PrimitiveButton
+        onClick={() => navigateTo("/settings")}
+        variant="outline"
+        aria-label="Account settings"
+        className={
+          route.kind === "settings"
+            ? "border-foreground bg-foreground text-background"
+            : "border-border text-foreground hover:border-foreground"
+        }
+      >
+        <Settings className="h-4 w-4" />
+        <span className="hidden sm:inline">Settings</span>
+      </PrimitiveButton>
+      <PrimitiveButton onClick={onSignOut} variant="outline">
+        <Users className="h-4 w-4" />
+        Sign Out
+      </PrimitiveButton>
+    </div>
   ) : (
     <PrimitiveButton onClick={() => beginGoogleSignIn()} variant="outline">
       Sign In

--- a/front-end/src/app/lib/closet.ts
+++ b/front-end/src/app/lib/closet.ts
@@ -64,6 +64,7 @@ export interface ClothingItem {
 export interface User extends UserSummary {
   clothing_items: ClothingItem[];
   clothing_items_count: number;
+  provider?: string | null;
 }
 
 export interface PaginationMeta {
@@ -441,6 +442,18 @@ export async function registerLocal(
     body: JSON.stringify({ user: { username, password, password_confirmation: passwordConfirmation, email } }),
   });
   return normalizeUserPayload(raw);
+}
+
+export async function changePassword(
+  currentPassword: string,
+  password: string,
+  passwordConfirmation: string,
+) {
+  await requestJson<{ message: string }>(`${API_BASE_URL}/change_password`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ current_password: currentPassword, password, password_confirmation: passwordConfirmation }),
+  });
 }
 
 export interface FetchUsersParams {

--- a/front-end/src/app/lib/routes.ts
+++ b/front-end/src/app/lib/routes.ts
@@ -36,6 +36,10 @@ interface NotFoundRouteState {
   kind: "not-found";
 }
 
+interface SettingsRouteState {
+  kind: "settings";
+}
+
 interface AboutRouteState {
   kind: "about";
 }
@@ -59,6 +63,7 @@ export type AppRoute =
   | AboutRouteState
   | PrivacyRouteState
   | TermsRouteState
+  | SettingsRouteState
   | NotFoundRouteState;
 
 export function isPublicInfoRoute(route: AppRoute) {
@@ -147,6 +152,10 @@ export function getRouteFromLocation(
 
   if (normalizedPath === "/terms") {
     return { kind: "terms" };
+  }
+
+  if (normalizedPath === "/settings") {
+    return { kind: "settings" };
   }
 
   if (normalizedPath === "/") {


### PR DESCRIPTION
Closes #172

## Summary
- `PATCH /change_password` endpoint validates current password, rejects blank/mismatched new passwords, and restricts to `provider: "local"` accounts
- `/settings` page with a change-password form, linked from the header for all signed-in users
- Google-auth users see an informational message instead of the form
- 6 integration tests covering the happy path, wrong current password, mismatched confirmation, blank password, Google-user rejection, and unauthenticated request

## Test plan
- [ ] Local user can change password and log in with the new one
- [ ] Wrong current password returns 401
- [ ] Mismatched or blank new password returns 422
- [ ] Google-auth user sees "password change not available" message on /settings
- [ ] CI passes (rubocop, brakeman, rails tests)