### PR TITLE
feat: password reset via email for local accounts

### DIFF
--- a/back-end/app/controllers/password_resets_controller.rb
+++ b/back-end/app/controllers/password_resets_controller.rb
@@ -1,0 +1,30 @@
+class PasswordResetsController < ApplicationController
+  def create
+    email = params[:email].to_s.strip.downcase
+    user = User.find_local_by_email(email)
+    if user
+      token = user.generate_token_for(:password_reset)
+      UserMailer.password_reset(user, token).deliver_now
+    end
+    render json: { message: "If that email is registered, you'll receive a reset link shortly." }
+  end
+
+  def update
+    user = User.find_by_token_for(:password_reset, params[:token].to_s)
+    unless user
+      return render json: { errors: [ "Reset link is invalid or has expired." ] },
+                    status: :unprocessable_entity
+    end
+
+    if params[:password].blank?
+      return render json: { errors: [ "New password can't be blank." ] },
+                    status: :unprocessable_entity
+    end
+
+    if user.update(password: params[:password], password_confirmation: params[:password_confirmation])
+      render json: { message: "Password reset successfully. You can now sign in." }
+    else
+      render_validation_errors(user)
+    end
+  end
+end

--- a/back-end/app/mailers/user_mailer.rb
+++ b/back-end/app/mailers/user_mailer.rb
@@ -1,0 +1,9 @@
+class UserMailer < ApplicationMailer
+  default from: "noreply@curatedcloset.app"
+
+  def password_reset(user, token)
+    @user = user
+    @reset_url = "#{ENV.fetch("FRONTEND_BASE_URL", "http://localhost:5173")}/reset-password?token=#{token}"
+    mail(to: user.email, subject: "Reset your Curated Closet password")
+  end
+end

--- a/back-end/app/models/user.rb
+++ b/back-end/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
   has_secure_password
 
+  generates_token_for :password_reset, expires_in: 2.hours do
+    password_salt&.last(10)
+  end
+
   has_many :clothing_items, dependent: :destroy
   has_many :outfits, dependent: :destroy
   has_many :outfit_uploads, dependent: :destroy
@@ -27,6 +31,10 @@ class User < ApplicationRecord
   def self.authenticate_local(username:, password:)
     user = find_by(provider: "local", uid: username.to_s.strip)
     user&.authenticate(password) ? user : nil
+  end
+
+  def self.find_local_by_email(email)
+    find_by(provider: "local", email: email.to_s.strip.downcase)
   end
 
   def self.from_google_auth(auth_hash)

--- a/back-end/app/views/user_mailer/password_reset.html.erb
+++ b/back-end/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,12 @@
+<p>Hi <%= @user.username %>,</p>
+
+<p>Someone requested a password reset for your Curated Closet account.</p>
+
+<p>
+  <a href="<%= @reset_url %>">Reset your password</a>
+  (link expires in 2&nbsp;hours)
+</p>
+
+<p>If you did not request this, you can safely ignore this email — your password will not change.</p>
+
+<p>— The Curated Closet team</p>

--- a/back-end/app/views/user_mailer/password_reset.text.erb
+++ b/back-end/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,11 @@
+Hi <%= @user.username %>,
+
+Someone requested a password reset for your Curated Closet account.
+
+Reset your password within the next 2 hours by clicking the link below:
+
+<%= @reset_url %>
+
+If you did not request this, you can safely ignore this email — your password will not change.
+
+— The Curated Closet team

--- a/back-end/config/routes.rb
+++ b/back-end/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
     get "me", to: "sessions#me"
     post "session", to: "sessions#login"
     delete "session", to: "sessions#destroy"
+    post "password_resets", to: "password_resets#create"
+    patch "password_resets", to: "password_resets#update"
 
     resources :users, except: %i[new edit]
     resources :clothing_items, except: %i[new edit] do

--- a/back-end/db/migrate/20260610120000_add_password_reset_columns_to_users.rb
+++ b/back-end/db/migrate/20260610120000_add_password_reset_columns_to_users.rb
@@ -1,0 +1,7 @@
+class AddPasswordResetColumnsToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :password_reset_token, :string
+    add_column :users, :password_reset_sent_at, :datetime
+    add_index :users, :password_reset_token, unique: true
+  end
+end

--- a/back-end/db/migrate/20260610120100_remove_password_reset_columns_from_users.rb
+++ b/back-end/db/migrate/20260610120100_remove_password_reset_columns_from_users.rb
@@ -1,0 +1,7 @@
+class RemovePasswordResetColumnsFromUsers < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :users, :password_reset_token, if_exists: true
+    remove_column :users, :password_reset_token, :string
+    remove_column :users, :password_reset_sent_at, :datetime
+  end
+end

--- a/back-end/db/schema.rb
+++ b/back-end/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_21_165312) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_10_120100) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false

--- a/back-end/test/integration/password_reset_flow_test.rb
+++ b/back-end/test/integration/password_reset_flow_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class PasswordResetFlowTest < ActionDispatch::IntegrationTest
+  include ActiveSupport::Testing::TimeHelpers
+
+  setup do
+    @local_user = users(:local_one)
+    @google_user = users(:one)
+    ActionMailer::Base.deliveries.clear
+  end
+
+  # --- POST /password_resets (request reset) ---
+
+  test "returns 200 and sends email for known local-account email" do
+    post password_resets_url,
+      params: { email: @local_user.email },
+      as: :json
+
+    assert_response :success
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_equal [ @local_user.email ], ActionMailer::Base.deliveries.first.to
+  end
+
+  test "returns 200 but sends no email for unknown email (user enumeration protection)" do
+    post password_resets_url,
+      params: { email: "nobody@example.com" },
+      as: :json
+
+    assert_response :success
+    assert_empty ActionMailer::Base.deliveries
+  end
+
+  test "returns 200 but sends no email for google-account email" do
+    post password_resets_url,
+      params: { email: @google_user.email },
+      as: :json
+
+    assert_response :success
+    assert_empty ActionMailer::Base.deliveries
+  end
+
+  # --- PATCH /password_resets (apply reset) ---
+
+  test "resets password with valid token" do
+    token = @local_user.generate_token_for(:password_reset)
+    patch password_resets_url,
+      params: { token: token, password: "brandnew99", password_confirmation: "brandnew99" },
+      as: :json
+
+    assert_response :success
+    assert @local_user.reload.authenticate("brandnew99")
+  end
+
+  test "returns 422 for invalid token" do
+    patch password_resets_url,
+      params: { token: "badtoken", password: "brandnew99", password_confirmation: "brandnew99" },
+      as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "returns 422 for expired token" do
+    token = @local_user.generate_token_for(:password_reset)
+    travel 3.hours do
+      patch password_resets_url,
+        params: { token: token, password: "brandnew99", password_confirmation: "brandnew99" },
+        as: :json
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "returns 422 when new password is blank" do
+    token = @local_user.generate_token_for(:password_reset)
+    patch password_resets_url,
+      params: { token: token, password: "", password_confirmation: "" },
+      as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "returns 422 when password confirmation does not match" do
+    token = @local_user.generate_token_for(:password_reset)
+    patch password_resets_url,
+      params: { token: token, password: "brandnew99", password_confirmation: "different" },
+      as: :json
+
+    assert_response :unprocessable_entity
+  end
+end

--- a/front-end/src/app/App.tsx
+++ b/front-end/src/app/App.tsx
@@ -37,8 +37,10 @@ import { PrivacyPage } from "./components/info/PrivacyPage";
 import { TermsPage } from "./components/info/TermsPage";
 import { AccessRestrictedState } from "./components/shared/AccessRestrictedState";
 import { ClosetEmptyState } from "./components/shared/ClosetEmptyState";
+import { ForgotPasswordPage } from "./components/shared/ForgotPasswordPage";
 import { HomeLanding } from "./components/shared/HomeLanding";
 import { NotFoundPage } from "./components/shared/NotFoundPage";
+import { ResetPasswordPage } from "./components/shared/ResetPasswordPage";
 import { SiteFooter } from "./components/shared/SiteFooter";
 import { SiteHeader } from "./components/shared/SiteHeader";
 import { ClosetSearchField } from "./components/ClosetSearchField";
@@ -66,6 +68,7 @@ import {
   AppRoute,
   authErrorMessage,
   getRouteFromLocation,
+  isAuthRoute,
   isClosetRoute,
   isOutfitRoute,
   isProtectedRoute,
@@ -470,7 +473,8 @@ export default function App() {
     navigateTo("/");
   }
 
-  const shouldRenderStandaloneAuthPage = !user && (route.kind === "home" || isLoggedOutProtectedRoute);
+  const shouldRenderStandaloneAuthPage =
+    isAuthRoute(route) || (!user && (route.kind === "home" || isLoggedOutProtectedRoute));
 
   let pageContent;
 
@@ -478,7 +482,11 @@ export default function App() {
     return <div className="min-h-screen bg-background" />;
   }
 
-  if ((!user && route.kind === "home") || (isLoggedOutProtectedRoute && !isLoading)) {
+  if (route.kind === "forgot-password") {
+    pageContent = <ForgotPasswordPage />;
+  } else if (route.kind === "reset-password") {
+    pageContent = <ResetPasswordPage token={route.token} />;
+  } else if ((!user && route.kind === "home") || (isLoggedOutProtectedRoute && !isLoading)) {
     pageContent = (
       <HomeLanding
         homeMessage={homeMessage}

--- a/front-end/src/app/components/shared/ForgotPasswordPage.tsx
+++ b/front-end/src/app/components/shared/ForgotPasswordPage.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { requestPasswordReset } from "../../lib/closet";
+import { navigateTo } from "../../lib/routes";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
+import { PrimitiveText } from "../primitives/PrimitiveText";
+
+export function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [formError, setFormError] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFormError("");
+    setIsSubmitting(true);
+
+    try {
+      await requestPasswordReset(email.trim());
+      setSubmitted(true);
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Something went wrong. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="flex flex-1 items-center justify-center px-6 py-16">
+      <div className="w-full max-w-sm">
+        <PrimitiveText
+          as="h1"
+          variant="display"
+          font="serif"
+          className="mb-2"
+          style={{ fontSize: "clamp(2rem, 5vw, 3rem)", lineHeight: "1" }}
+        >
+          Forgot password
+        </PrimitiveText>
+        <PrimitiveText as="p" tone="muted" className="mb-8">
+          Enter the email address for your account and we'll send you a reset link.
+        </PrimitiveText>
+
+        {submitted ? (
+          <div className="border border-emerald-300/40 bg-emerald-50 px-4 py-3">
+            <PrimitiveText as="p" variant="bodySm" className="text-emerald-900">
+              If that email is registered, you'll receive a reset link shortly. Check your inbox.
+            </PrimitiveText>
+          </div>
+        ) : (
+          <form onSubmit={(e) => void handleSubmit(e)} noValidate className="flex flex-col gap-4">
+            <div>
+              <label htmlFor="reset-email" className="mb-1 block text-sm font-medium text-foreground">
+                Email address
+              </label>
+              <input
+                id="reset-email"
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full border border-border bg-input-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                placeholder="you@example.com"
+              />
+            </div>
+
+            {formError ? (
+              <p role="alert" className="text-sm text-destructive">
+                {formError}
+              </p>
+            ) : null}
+
+            <PrimitiveButton
+              type="submit"
+              disabled={isSubmitting}
+              className="h-auto w-full px-6 py-3"
+            >
+              {isSubmitting ? "Sending…" : "Send reset link"}
+            </PrimitiveButton>
+          </form>
+        )}
+
+        <button
+          type="button"
+          onClick={() => navigateTo("/")}
+          className="mt-6 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          Back to sign in
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/front-end/src/app/components/shared/HomeLanding.tsx
+++ b/front-end/src/app/components/shared/HomeLanding.tsx
@@ -3,6 +3,7 @@ import { motion } from "motion/react";
 import { ArrowRight } from "lucide-react";
 import { beginGoogleSignIn, loginLocal, registerLocal } from "../../lib/closet";
 import type { User } from "../../lib/closet";
+import { navigateTo } from "../../lib/routes";
 import { PrimitiveButton } from "../primitives/PrimitiveButton";
 import { PrimitiveText } from "../primitives/PrimitiveText";
 
@@ -175,6 +176,18 @@ export function HomeLanding({ homeMessage, onAuthSuccess }: HomeLandingProps) {
               placeholder="••••••••"
             />
           </div>
+
+          {mode === "sign-in" ? (
+            <div className="text-right">
+              <button
+                type="button"
+                onClick={() => navigateTo("/forgot-password")}
+                className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+              >
+                Forgot password?
+              </button>
+            </div>
+          ) : null}
 
           {mode === "register" && (
             <div>

--- a/front-end/src/app/components/shared/ResetPasswordPage.tsx
+++ b/front-end/src/app/components/shared/ResetPasswordPage.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import { resetPassword } from "../../lib/closet";
+import { navigateTo } from "../../lib/routes";
+import { PrimitiveButton } from "../primitives/PrimitiveButton";
+import { PrimitiveText } from "../primitives/PrimitiveText";
+
+interface ResetPasswordPageProps {
+  token: string;
+}
+
+export function ResetPasswordPage({ token }: ResetPasswordPageProps) {
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formError, setFormError] = useState("");
+  const [succeeded, setSucceeded] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFormError("");
+    setIsSubmitting(true);
+
+    try {
+      await resetPassword(token, password, passwordConfirmation);
+      setSucceeded(true);
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Something went wrong. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (!token) {
+    return (
+      <section className="flex flex-1 items-center justify-center px-6 py-16">
+        <div className="w-full max-w-sm text-center">
+          <PrimitiveText as="p" tone="muted" className="mb-6">
+            This reset link is missing a token. Please request a new one.
+          </PrimitiveText>
+          <PrimitiveButton onClick={() => navigateTo("/forgot-password")} className="h-auto px-6 py-3">
+            Request new link
+          </PrimitiveButton>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex flex-1 items-center justify-center px-6 py-16">
+      <div className="w-full max-w-sm">
+        <PrimitiveText
+          as="h1"
+          variant="display"
+          font="serif"
+          className="mb-2"
+          style={{ fontSize: "clamp(2rem, 5vw, 3rem)", lineHeight: "1" }}
+        >
+          Reset password
+        </PrimitiveText>
+        <PrimitiveText as="p" tone="muted" className="mb-8">
+          Choose a new password for your account.
+        </PrimitiveText>
+
+        {succeeded ? (
+          <div className="border border-emerald-300/40 bg-emerald-50 px-4 py-3">
+            <PrimitiveText as="p" variant="bodySm" className="mb-4 text-emerald-900">
+              Your password has been reset. You can now sign in with your new password.
+            </PrimitiveText>
+            <PrimitiveButton
+              onClick={() => navigateTo("/")}
+              className="h-auto px-6 py-3"
+            >
+              Sign in
+            </PrimitiveButton>
+          </div>
+        ) : (
+          <form onSubmit={(e) => void handleSubmit(e)} noValidate className="flex flex-col gap-4">
+            <div>
+              <label htmlFor="new-password" className="mb-1 block text-sm font-medium text-foreground">
+                New password
+              </label>
+              <input
+                id="new-password"
+                type="password"
+                autoComplete="new-password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full border border-border bg-input-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                placeholder="••••••••"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="confirm-password" className="mb-1 block text-sm font-medium text-foreground">
+                Confirm new password
+              </label>
+              <input
+                id="confirm-password"
+                type="password"
+                autoComplete="new-password"
+                required
+                value={passwordConfirmation}
+                onChange={(e) => setPasswordConfirmation(e.target.value)}
+                className="w-full border border-border bg-input-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                placeholder="••••••••"
+              />
+            </div>
+
+            {formError ? (
+              <p role="alert" className="text-sm text-destructive">
+                {formError}
+              </p>
+            ) : null}
+
+            <PrimitiveButton
+              type="submit"
+              disabled={isSubmitting}
+              className="h-auto w-full px-6 py-3"
+            >
+              {isSubmitting ? "Resetting…" : "Reset password"}
+            </PrimitiveButton>
+          </form>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/front-end/src/app/lib/closet.ts
+++ b/front-end/src/app/lib/closet.ts
@@ -443,6 +443,22 @@ export async function registerLocal(
   return normalizeUserPayload(raw);
 }
 
+export async function requestPasswordReset(email: string) {
+  await requestJson<{ message: string }>(`${API_BASE_URL}/password_resets`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
+  });
+}
+
+export async function resetPassword(token: string, password: string, passwordConfirmation: string) {
+  await requestJson<{ message: string }>(`${API_BASE_URL}/password_resets`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token, password, password_confirmation: passwordConfirmation }),
+  });
+}
+
 export interface FetchUsersParams {
   page?: number;
   perPage?: number;

--- a/front-end/src/app/lib/routes.ts
+++ b/front-end/src/app/lib/routes.ts
@@ -48,6 +48,15 @@ interface TermsRouteState {
   kind: "terms";
 }
 
+interface ForgotPasswordRouteState {
+  kind: "forgot-password";
+}
+
+interface ResetPasswordRouteState {
+  kind: "reset-password";
+  token: string;
+}
+
 export type AppRoute =
   | HomeRouteState
   | ClosetRouteState
@@ -59,6 +68,8 @@ export type AppRoute =
   | AboutRouteState
   | PrivacyRouteState
   | TermsRouteState
+  | ForgotPasswordRouteState
+  | ResetPasswordRouteState
   | NotFoundRouteState;
 
 export function isPublicInfoRoute(route: AppRoute) {
@@ -77,8 +88,17 @@ export function isUsersRoute(route: AppRoute) {
   return route.kind === "users" || route.kind === "user";
 }
 
+export function isAuthRoute(route: AppRoute) {
+  return route.kind === "forgot-password" || route.kind === "reset-password";
+}
+
 export function isProtectedRoute(route: AppRoute) {
-  return route.kind !== "home" && route.kind !== "not-found" && !isPublicInfoRoute(route);
+  return (
+    route.kind !== "home" &&
+    route.kind !== "not-found" &&
+    !isPublicInfoRoute(route) &&
+    !isAuthRoute(route)
+  );
 }
 
 export function authErrorMessage(code: string | null) {
@@ -147,6 +167,14 @@ export function getRouteFromLocation(
 
   if (normalizedPath === "/terms") {
     return { kind: "terms" };
+  }
+
+  if (normalizedPath === "/forgot-password") {
+    return { kind: "forgot-password" };
+  }
+
+  if (normalizedPath === "/reset-password") {
+    return { kind: "reset-password", token: query.get("token") ?? "" };
   }
 
   if (normalizedPath === "/") {


### PR DESCRIPTION
Closes #174

## Summary
- `POST /password_resets` accepts an email, sends a reset link if a local account with that email exists, and always returns 200 (no user enumeration)
- `PATCH /password_resets` validates the token (invalid/expired → 422), checks for blank/mismatched password, updates the password
- Token uses Rails 8's built-in `generates_token_for :password_reset` with 2-hour expiry — automatically invalidated when the password changes
- `UserMailer#password_reset` sends a text + HTML email with a link to `FRONTEND_BASE_URL/reset-password?token=…`
- Frontend: `/forgot-password` page (email form), `/reset-password?token=…` page (new password form), "Forgot password?" link on sign-in form

## Test plan
- [ ] Request reset with known local-account email → email received with reset link
- [ ] Request reset with unknown email or Google-auth email → 200 with no email sent
- [ ] Valid token → password updated, can sign in with new password
- [ ] Expired token (3h later) → 422
- [ ] Invalid token → 422
- [ ] Mismatched/blank new password → 422
- [ ] CI passes (rubocop, brakeman, rails tests)