### PR TITLE
Add rate limiting to protect login, registration, and password reset

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,6 +330,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -525,6 +527,7 @@ DEPENDENCIES
   pg
   propshaft
   puma (>= 5.0)
+  rack-attack
   rails (~> 8.1.3)
   rubocop-rails-omakase
   selenium-webdriver

--- a/back-end/Gemfile
+++ b/back-end/Gemfile
@@ -21,6 +21,7 @@ gem "jbuilder"
 gem "bcrypt", "~> 3.1.7"
 gem "aws-sdk-s3", require: false
 gem "kaminari"
+gem "rack-attack"
 gem "omniauth"
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"

--- a/back-end/Gemfile.lock
+++ b/back-end/Gemfile.lock
@@ -330,6 +330,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -525,6 +527,7 @@ DEPENDENCIES
   pg
   propshaft
   puma (>= 5.0)
+  rack-attack
   rails (~> 8.1.3)
   rubocop-rails-omakase
   selenium-webdriver

--- a/back-end/config/application.rb
+++ b/back-end/config/application.rb
@@ -16,6 +16,8 @@ module ProjectClosetOrganizer
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.middleware.use Rack::Attack
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/back-end/config/initializers/rack_attack.rb
+++ b/back-end/config/initializers/rack_attack.rb
@@ -1,0 +1,28 @@
+class Rack::Attack
+  # Use Rails cache so throttle counters survive across requests
+  Rack::Attack.cache.store = Rails.cache
+
+  # Throttle login attempts: 5 per IP per minute
+  throttle("logins/ip", limit: 5, period: 1.minute) do |req|
+    req.ip if req.path == "/session" && req.post?
+  end
+
+  # Throttle registration: 3 per IP per minute
+  throttle("signups/ip", limit: 3, period: 1.minute) do |req|
+    req.ip if req.path == "/users" && req.post?
+  end
+
+  # Throttle password reset requests: 5 per IP per 10 minutes
+  throttle("password_resets/ip", limit: 5, period: 10.minutes) do |req|
+    req.ip if req.path == "/password_resets" && req.post?
+  end
+
+  # Return JSON 429 instead of the default plain-text response
+  self.throttled_responder = lambda do |_env|
+    [
+      429,
+      { "Content-Type" => "application/json" },
+      [ { error: "Too many requests. Please try again later." }.to_json ]
+    ]
+  end
+end

--- a/back-end/test/integration/rate_limiting_test.rb
+++ b/back-end/test/integration/rate_limiting_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+class RateLimitingTest < ActionDispatch::IntegrationTest
+  setup do
+    # Clear rack-attack cache between tests
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.reset!
+  end
+
+  # --- Login throttling ---
+
+  test "allows login attempts below the throttle threshold" do
+    4.times do
+      post session_url,
+        params: { username: "nobody", password: "wrong" },
+        headers: { "REMOTE_ADDR" => "1.2.3.4" },
+        as: :json
+      assert_not_equal 429, response.status
+    end
+  end
+
+  test "blocks login after 5 failed attempts from the same IP" do
+    5.times do
+      post session_url,
+        params: { username: "nobody", password: "wrong" },
+        headers: { "REMOTE_ADDR" => "1.2.3.5" },
+        as: :json
+    end
+
+    post session_url,
+      params: { username: "nobody", password: "wrong" },
+      headers: { "REMOTE_ADDR" => "1.2.3.5" },
+      as: :json
+
+    assert_response :too_many_requests
+  end
+
+  test "blocked login response includes JSON error message" do
+    5.times do
+      post session_url,
+        params: { username: "nobody", password: "wrong" },
+        headers: { "REMOTE_ADDR" => "1.2.3.6" },
+        as: :json
+    end
+
+    post session_url,
+      params: { username: "nobody", password: "wrong" },
+      headers: { "REMOTE_ADDR" => "1.2.3.6" },
+      as: :json
+
+    body = JSON.parse(response.body)
+    assert_includes body["error"].downcase, "too many"
+  end
+
+  # --- Registration throttling ---
+
+  test "allows registration attempts below the throttle threshold" do
+    2.times do
+      post users_url,
+        params: { username: "u#{rand(9999)}", password: "pass", email: "x@x.com", terms_accepted: "1" },
+        headers: { "REMOTE_ADDR" => "2.2.3.4" },
+        as: :json
+      assert_not_equal 429, response.status
+    end
+  end
+
+  test "blocks registration after 3 attempts from the same IP" do
+    3.times do
+      post users_url,
+        params: { username: "u#{rand(9999)}", password: "pass", email: "x@x.com", terms_accepted: "1" },
+        headers: { "REMOTE_ADDR" => "2.2.3.5" },
+        as: :json
+    end
+
+    post users_url,
+      params: { username: "new_user", password: "pass", email: "new@x.com", terms_accepted: "1" },
+      headers: { "REMOTE_ADDR" => "2.2.3.5" },
+      as: :json
+
+    assert_response :too_many_requests
+  end
+
+  # --- Password reset throttling ---
+
+  test "blocks password reset requests after 5 attempts from the same IP" do
+    5.times do
+      post password_resets_url,
+        params: { email: "nobody@example.com" },
+        headers: { "REMOTE_ADDR" => "3.2.3.5" },
+        as: :json
+    end
+
+    post password_resets_url,
+      params: { email: "nobody@example.com" },
+      headers: { "REMOTE_ADDR" => "3.2.3.5" },
+      as: :json
+
+    assert_response :too_many_requests
+  end
+end


### PR DESCRIPTION
Closes #176

## Summary
- Adds `rack-attack` gem to throttle brute-force and spam attacks
- Login: max 5 attempts/IP/minute
- Registration: max 3 attempts/IP/minute
- Password reset: max 5 attempts/IP/10 minutes
- Blocked requests return `429 Too Many Requests` with a JSON `{ "error": "..." }` body

## Trust & Safety
This is the third trust & safety feature (the rubric requires ceil(5/2) = 3):
1. ✅ Terms/privacy pages
2. ✅ Accept-terms-on-signup (PR #171)
3. ✅ Rate limiting (this PR)

## Test plan
- [ ] 6 new Minitest integration tests (Red → Green)
- [ ] All rate limiting tests pass: `bin/rails test test/integration/rate_limiting_test.rb`
- [ ] Full test suite shows no regressions vs main