### PR TITLE
Add profanity filter to clothing item and outfit text fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,6 +285,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0, >= 2.0.5)
       version_gem (~> 1.1, >= 1.1.11)
+    obscenity (1.0.2)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
       logger
@@ -521,6 +522,7 @@ DEPENDENCIES
   kamal
   kaminari
   net-imap (>= 0.6.4)
+  obscenity
   omniauth
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/back-end/Gemfile
+++ b/back-end/Gemfile
@@ -22,6 +22,7 @@ gem "bcrypt", "~> 3.1.7"
 gem "aws-sdk-s3", require: false
 gem "kaminari"
 gem "rack-attack"
+gem "obscenity"
 gem "omniauth"
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"

--- a/back-end/Gemfile.lock
+++ b/back-end/Gemfile.lock
@@ -285,6 +285,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0, >= 2.0.5)
       version_gem (~> 1.1, >= 1.1.11)
+    obscenity (1.0.2)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
       logger
@@ -521,6 +522,7 @@ DEPENDENCIES
   kamal
   kaminari
   net-imap (>= 0.6.4)
+  obscenity
   omniauth
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/back-end/app/models/clothing_item.rb
+++ b/back-end/app/models/clothing_item.rb
@@ -24,8 +24,8 @@ class ClothingItem < ApplicationRecord
     failed: 3
   }, prefix: true
 
-  validates :name, presence: true, length: { maximum: InputLengthPolicy::MAX_CLOTHING_ITEM_NAME }
-  validates :brand, length: { maximum: InputLengthPolicy::MAX_CLOTHING_ITEM_BRAND }, allow_blank: true
+  validates :name, presence: true, length: { maximum: InputLengthPolicy::MAX_CLOTHING_ITEM_NAME }, obscenity: true
+  validates :brand, length: { maximum: InputLengthPolicy::MAX_CLOTHING_ITEM_BRAND }, allow_blank: true, obscenity: true
   validates :category, length: { maximum: InputLengthPolicy::MAX_CLOTHING_ITEM_CATEGORY }, allow_blank: true
   validates :size, presence: true
   validate :tags_meet_length_policy

--- a/back-end/app/models/outfit.rb
+++ b/back-end/app/models/outfit.rb
@@ -3,8 +3,8 @@ class Outfit < ApplicationRecord
   has_many :outfit_items, -> { order(:layer_order, :id) }, dependent: :destroy, autosave: true
   has_many :clothing_items, through: :outfit_items
 
-  validates :name, presence: true, length: { maximum: InputLengthPolicy::MAX_OUTFIT_NAME }
-  validates :notes, length: { maximum: InputLengthPolicy::MAX_OUTFIT_NOTES }, allow_blank: true
+  validates :name, presence: true, length: { maximum: InputLengthPolicy::MAX_OUTFIT_NAME }, obscenity: true
+  validates :notes, length: { maximum: InputLengthPolicy::MAX_OUTFIT_NOTES }, allow_blank: true, obscenity: true
   validate :tags_must_be_an_array
   validate :tags_meet_length_policy
 

--- a/back-end/config/initializers/obscenity.rb
+++ b/back-end/config/initializers/obscenity.rb
@@ -1,0 +1,1 @@
+require "obscenity/active_model"

--- a/back-end/test/models/profanity_filter_test.rb
+++ b/back-end/test/models/profanity_filter_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class ProfanityFilterTest < ActiveSupport::TestCase
+  # --- ClothingItem ---
+
+  test "clothing item with clean name is valid" do
+    item = ClothingItem.new(
+      name: "Blue Denim Jacket",
+      size: "medium",
+      user: users(:one)
+    )
+    assert item.valid?
+  end
+
+  test "clothing item name with profanity is invalid" do
+    item = ClothingItem.new(
+      name: "shit jacket",
+      size: "medium",
+      user: users(:one)
+    )
+    assert item.invalid?
+    assert item.errors[:name].any?
+  end
+
+  test "clothing item brand with profanity is invalid" do
+    item = ClothingItem.new(
+      name: "Nice Jacket",
+      brand: "damn brand",
+      size: "medium",
+      user: users(:one)
+    )
+    assert item.invalid?
+    assert item.errors[:brand].any?
+  end
+
+  test "clothing item brand can be blank" do
+    item = ClothingItem.new(
+      name: "Nice Jacket",
+      brand: "",
+      size: "medium",
+      user: users(:one)
+    )
+    assert item.valid?
+  end
+
+  # --- Outfit ---
+
+  test "outfit with clean name is valid" do
+    outfit = Outfit.new(
+      name: "Weekend Capsule",
+      user: users(:one)
+    )
+    assert outfit.valid?
+  end
+
+  test "outfit name with profanity is invalid" do
+    outfit = Outfit.new(
+      name: "my shit outfit",
+      user: users(:one)
+    )
+    assert outfit.invalid?
+    assert outfit.errors[:name].any?
+  end
+
+  test "outfit notes with profanity is invalid" do
+    outfit = Outfit.new(
+      name: "Weekend Look",
+      notes: "this is fucking great",
+      user: users(:one)
+    )
+    assert outfit.invalid?
+    assert outfit.errors[:notes].any?
+  end
+
+  test "outfit notes can be blank" do
+    outfit = Outfit.new(
+      name: "Weekend Look",
+      notes: "",
+      user: users(:one)
+    )
+    assert outfit.valid?
+  end
+end

--- a/back-end/test/models/profanity_filter_test.rb
+++ b/back-end/test/models/profanity_filter_test.rb
@@ -25,7 +25,7 @@ class ProfanityFilterTest < ActiveSupport::TestCase
   test "clothing item brand with profanity is invalid" do
     item = ClothingItem.new(
       name: "Nice Jacket",
-      brand: "damn brand",
+      brand: "shit brand",
       size: "medium",
       user: users(:one)
     )


### PR DESCRIPTION
Closes #178

## Summary
- Adds `obscenity` gem with ActiveModel integration
- Clothing item `name` and `brand` fields reject profane input
- Outfit `name` and `notes` fields reject profane input
- Blank `brand` and `notes` fields still allowed (allow_blank: true)
- Blocked saves return a model validation error on the relevant field

## Trust & Safety
This is an optional 4th trust & safety feature, giving comfortable margin above the rubric minimum of 3:
1. ✅ Terms/privacy pages
2. ✅ Accept-terms-on-signup (PR #171)
3. ✅ Rate limiting with rack-attack (PR #177)
4. ✅ Profanity filter (this PR)

## Test plan
- [ ] 8 Minitest model tests (Red → Green): happy path (clean input valid) + sad path (profane input invalid) for ClothingItem and Outfit
- [ ] All profanity filter tests pass: `bin/rails test test/models/profanity_filter_test.rb`
- [ ] Full test suite shows no regressions vs main