### PR TITLE
Fix: move vite-plugin-pwa to dependencies for Heroku build

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -59,9 +59,7 @@
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
     "vaul": "^1.1.2",
-    "vite": "^8.0.13"
-  },
-  "devDependencies": {
+    "vite": "^8.0.13",
     "vite-plugin-pwa": "^1.3.0"
   }
 }


### PR DESCRIPTION
## Problem
Heroku build was failing with:
```
Cannot find package 'vite-plugin-pwa'
```
Heroku runs `npm install` with `NPM_CONFIG_PRODUCTION=true`, which skips `devDependencies`. Since `vite-plugin-pwa` was added as a devDependency, it wasn't installed during the Heroku postbuild step and the Vite build failed.

## Fix
Move `vite-plugin-pwa` from `devDependencies` to `dependencies` in `front-end/package.json`. All other build tools (vite, react, tailwind, etc.) are already in `dependencies` for this same reason.

## Test plan
- [ ] Heroku build succeeds after merge
- [ ] PWA manifest and service worker present in production build